### PR TITLE
Phases 1 and 2: kernel proof and nurb check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,9 @@ CLI, the viewer's sliders, the tests, and any future configurator. Never add a
 parallel `PARAMS` dict; the two would drift.
 
 `draft` is optional and injected by the runtime, never passed by callers. When true,
-skip the polish pass. This matters more than it looks: chamfers are most of the build
-cost, so draft mode is the difference between a live loop and a batch job.
+skip the polish pass. Worth 20% on a real part, not the 18x a cube suggested: chamfers
+are 23% of the gridfinity shelf's build. Tessellation, at 620ms against a 470ms build,
+is where the loop latency actually lives.
 
 ## Commands
 
@@ -75,12 +76,21 @@ table in RESEARCH.md for the full list of what vanishes and what survives.
 What does survive is physics: the print doctrine, sliver thresholds, chamfer sizing
 limits, and chamfer ordering effects.
 
-### Prefer `Select.LAST` over geometric selectors for chamfers
+### Prefer `new_edges` over geometric selectors for chamfers
 
 Each chamfer changes topology, so selectors resolved against pristine geometry drift
-once an earlier chamfer runs. `part.edges() - last` targets exactly what an operation
-just created and sidesteps the problem. Reach for it before falling back on strict
-operation ordering.
+once an earlier chamfer runs. `new_edges(before, combined=after)` returns exactly the
+edges an operation created and sidesteps the problem. It is the algebra-mode
+equivalent of a builder's `Select.LAST`, and algebra mode is what a part file uses, so
+`part.edges() - last` is not available to you. Reach for it before falling back on
+strict operation ordering.
+
+### Two chamfered edges need room between them
+
+More than `2 * chamfer_size` of face, or OCCT fails with `BRep_API: command not done`.
+This is the analogue of Fusion's `ASM_BL_NO_MATE` and it is the single most common way
+a part stops building. The trap: every edge chamfers fine on its own and only the batch
+fails, so testing them one at a time reports that nothing is wrong. Bisect the set.
 
 ### Systems are extracted, never scaffolded
 
@@ -145,7 +155,10 @@ as though every file will be read by a stranger.
 
 ## Current state
 
-The runtime works but has only ever built `Box() - chamfer()`. Every timing number
-and every claim about OCCT robustness comes from that. Phase 1 in
-`docs/core/IMPLEMENTATION.md` exists to fix exactly this, by porting the hardest
-Notch part. **Do not build on top of unproven kernel assumptions.**
+Phase 1 is done. Two real Notch parts live in `examples/notch/`, build to one solid
+each, match their Fusion originals dimension for dimension, and reproduce their sliver
+baselines exactly. The kernel question is settled and the timing numbers now come from
+real geometry rather than a cube. Phase 2 (`nurb check`) is next.
+
+`docs/core/PROGRESS.md` has the findings, including two claims from RESEARCH.md that a
+real part disproved.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,11 @@ is where the loop latency actually lives.
 nurb new <name>      create parts/<name>.py and its card
 nurb dev             watch, rebuild, serve the viewer on :7373
 nurb build [part]    build once, report size and timing
+nurb check [part]    run the printability rules, --strict for CI
 nurb export [part]   write STL/STEP/GLB into build/
 ```
+
+`uv run pytest` runs the suite, which includes the parts in `examples/`.
 
 A project is any directory containing `parts/`. There is no init step, and there
 never should be.
@@ -50,9 +53,12 @@ never should be.
 ```
 src/nurb/registry.py   @part, signature introspection
 src/nurb/builder.py    load, build, tessellate, GLB
+src/nurb/checks.py     printability rules, convexity, Finding/Context
 src/nurb/server.py     watcher, rebuild, HTTP + websocket on one port
 src/nurb/viewer.html   three.js viewer, Z-up, camera persistence
 src/nurb/cli.py        command surface
+examples/notch/        the real parts, which are also the calibration set
+tests/                 rules and examples, both cases per rule
 docs/core/             research, plan, progress
 ```
 
@@ -155,10 +161,18 @@ as though every file will be read by a stranger.
 
 ## Current state
 
-Phase 1 is done. Two real Notch parts live in `examples/notch/`, build to one solid
-each, match their Fusion originals dimension for dimension, and reproduce their sliver
-baselines exactly. The kernel question is settled and the timing numbers now come from
-real geometry rather than a cube. Phase 2 (`nurb check`) is next.
+Phases 1 and 2 are done. Two real Notch parts and a calibration coupon live in
+`examples/notch/`; they build to one solid each, match their Fusion originals dimension
+for dimension, and reproduce the sliver baselines their catalog cards recorded. The
+kernel question is settled and the timing numbers come from real geometry.
 
-`docs/core/PROGRESS.md` has the findings, including two claims from RESEARCH.md that a
-real part disproved.
+`nurb check` runs eight printability rules against the solid and reports nothing on any
+of the three, which is the bar: a warning fired at a part that prints fine is a bug in
+the rule. It has already caught one real defect in what Phase 1 shipped, four cosmetic
+chamfers laid into concave junctions.
+
+Phase 3 (agent interface: `nurb rules`, card generation, headless render) is next.
+
+`docs/core/PROGRESS.md` has the findings, including three claims from RESEARCH.md and
+one from Phase 1 that a real part or a real print disproved. Read them before trusting
+anything in this file that sounds like a measurement.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ nearer 20%.
 nurb new <name>     create parts/<name>.py and its card
 nurb dev            watch, rebuild, serve the viewer
 nurb build [part]   build once and report size
+nurb check [part]   run the printability rules
 nurb export [part]  write STL/STEP/GLB into build/
 ```
 
@@ -49,9 +50,13 @@ A project is any directory with a `parts/` folder. There's no init step.
 
 ## Why a long-lived process
 
-Importing build123d costs 45s cold and 2.3s warm. Everything after that is fast:
-build, boolean, chamfer, tessellate, and export together run in about 80ms. So the
-dev server pays the import once and every rebuild afterwards feels instant.
+Importing build123d costs 45s cold and 2.3s warm, and that is the whole argument: the
+dev server pays it once instead of on every save.
+
+What a rebuild costs after that depends on the part. A simple one is 46ms to build and
+120ms to tessellate. The heaviest part in `examples/` is 470ms and 620ms. Tessellation
+being the larger half is worth knowing before optimising the wrong thing, and draft
+mode is not the lever it looks like: chamfers are 23% of that build, not most of it.
 
 ## Layout
 
@@ -65,11 +70,49 @@ build/              generated, gitignored
 Cards are colocated with parts and share a basename. That's the whole link; a
 rename is `git mv` on two files.
 
+## Checks
+
+`nurb check` runs the printability rules against the solid rather than an exported
+mesh, so it sees real faces with exact areas and normals instead of triangles.
+
+```
+overhang          downward faces past 45 degrees, bridges told from cantilevers
+min_wall          thinnest section, by ray cast
+sliver            faces too small to print as anything but a smear
+concave_cosmetic  polish laid into an inside corner
+bed_bevel         polish laid on the edges that meet the build plate
+stability         center of mass outside the footprint
+projection_ratio  reach over height, for a part cantilevered off a wall
+build_volume      does it fit the printer at all
+```
+
+Every part carries what it has already justified on its card, so a known finding is
+silent and a new one is a regression:
+
+```toml
+[part]
+min_wall = 1.0
+
+[accepted]
+sliver = 6
+```
+
+It reports by default and takes `--strict` for CI, on the grounds that a warning which
+blocks work gets switched off. Findings also show up in `nurb dev`, with a pin on the
+geometry at each one.
+
+## Tests
+
+```
+uv run pytest
+```
+
+The parts in `examples/` are part of the suite, asserted against the dimensions and
+baselines their catalog cards recorded in Fusion.
+
 ## Not built yet
 
-- `nurb check` — printability rules as assertions (overhangs, wall thickness,
-  slivers, stability, build volume), with an accepted-warnings baseline per part
-- `nurb extract` — pull shared geometry out of sibling parts into `system.py`
+- `nurb extract`, pull shared geometry out of sibling parts into `system.py`
   once duplication actually shows up, rather than scaffolding it up front
 - Headless PNG render so an agent can see its own work
 - Parameter sliders in the viewer, driven by the same keyword defaults

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ def dispenser(width=40, depth=30, height=20, wall=2, draft=False):
 ```
 
 `draft` is optional and passed by the runtime, not the caller. When it's true the
-part should skip its polish pass. `nurb dev` builds in draft by default because
-chamfers dominate build time: on this trivial part it's 18ms polished vs 1ms draft.
+part should skip its polish pass. `nurb dev` builds in draft by default: on this
+trivial part it's 18ms polished vs 1ms draft, and on a real one the saving is
+nearer 20%.
 
 ## Commands
 
@@ -57,6 +58,7 @@ dev server pays the import once and every rebuild afterwards feels instant.
 ```
 parts/<name>.py     the part
 parts/<name>.md     its card: what it is, why, what not to retry
+system.py           optional: shared constants and geometry, importable from a part
 build/              generated, gitignored
 ```
 

--- a/docs/core/PROGRESS.md
+++ b/docs/core/PROGRESS.md
@@ -139,6 +139,7 @@ Printability rules on the in-memory B-rep, calibrated to zero false positives.
 - [x] Accepted baselines, declared in each part's card
 - [x] `nurb check` CLI, with `--strict` for CI
 - [x] Rule `projection_ratio`
+- [x] Rules `concave_cosmetic` and `bed_bevel`
 - [x] Findings in the viewer: a panel plus a pin at each reported point
 - [x] **Zero false positives on all three parts**, which is the credibility bar
 
@@ -185,6 +186,22 @@ recorded. Checks run in 7ms on the hook and 277ms on the shelf.
   makes an unsupported ledge droop is how far it protrudes, not its area or its
   length, so a ledge under `overhang_reach` is silent. Same physics as the bridge
   limit, applied to the cantilever case.
+- **The rules found a real defect in Phase 1's output.** `concave_cosmetic` flagged
+  four 1mm chamfers at the shelf's gusset roots, which are inside corners, and both
+  the convexity test and independent ring sampling confirm it. Phase 1 had reasoned
+  that the only concave edges were the ones the structural pass made; that was
+  untrue, and nothing in the build, the export or the print said so. This is the
+  argument for the whole phase in one finding: it is invisible in code, the selector
+  reads as an ordinary exposed-edge query, and the part looked fine by every other
+  measure. Bounding box, solid count and the sliver baseline are unchanged by the fix.
+- **`is_convex` and `concave_edges` are public API now.** A polish pass cannot be
+  written correctly without them, which the above demonstrates, so they belong in the
+  vocabulary a part file gets rather than inside the checker.
+- **Neither chamfer rule identifies chamfers.** `bed_bevel` looks for a face touching
+  the plate that is neither flat on it nor square to it, which a bevel is and nothing
+  else is. `concave_cosmetic` looks for a strip about as wide as the polish pass
+  makes, whose long edges are concave and which leans against what it joins. Trying to
+  recognise a chamfer as such was the fragile version; describing the defect is not.
 - **`projection_ratio` reproduces the card's own number.** grid_y 3 gives 3.24 against
   a card that says "a ratio of 3.2 at item_height 42", and 55mm clears it exactly as
   the card claims. That is the third rule to land on a figure recorded by hand in
@@ -215,10 +232,11 @@ recorded. Checks run in 7ms on the hook and 277ms on the shelf.
 - `polish_edges()` in `examples/notch/system.py` is a first draft of the
   `back_bottom_chamfer` and `mating_chamfer` rules, written as a selector instead of
   a check. Phase 2 should be able to reuse the predicate.
-- The concave-edge exclusion is still done structurally (subtract `new_edges` from
-  the polish set) rather than by testing convexity. That works because the only
-  concave edges in these two parts are the ones the structural pass just made. It
-  will not generalize, so the convexity test is still owed.
+- ~~The concave-edge exclusion is done structurally rather than by testing convexity,
+  which works because the only concave edges in these parts are the ones the
+  structural pass just made.~~ **Wrong, and Phase 2 proved it.** The shelf's gusset
+  roots are concave too, and all four were carrying a 1mm cosmetic chamfer in the
+  shipped part. `polish_edges` now vetoes concave edges outright.
 
 #### Blockers
 - (none)

--- a/docs/core/PROGRESS.md
+++ b/docs/core/PROGRESS.md
@@ -138,11 +138,13 @@ Printability rules on the in-memory B-rep, calibrated to zero false positives.
 - [x] Rule `stability`
 - [x] Accepted baselines, declared in each part's card
 - [x] `nurb check` CLI, with `--strict` for CI
+- [x] Rule `projection_ratio`
 - [x] Findings in the viewer: a panel plus a pin at each reported point
 - [x] **Zero false positives on all three parts**, which is the credibility bar
 
-27 tests, every rule with both cases against shapes whose answers were worked out by
-hand. Checks run in 7ms on the hook and 277ms on the shelf.
+42 tests. Every rule has both cases against shapes whose answers were worked out by
+hand, and the example parts are asserted against the numbers their Fusion cards
+recorded. Checks run in 7ms on the hook and 277ms on the shelf.
 
 #### Decisions made
 
@@ -183,6 +185,14 @@ hand. Checks run in 7ms on the hook and 277ms on the shelf.
   makes an unsupported ledge droop is how far it protrudes, not its area or its
   length, so a ledge under `overhang_reach` is silent. Same physics as the bridge
   limit, applied to the cantilever case.
+- **`projection_ratio` reproduces the card's own number.** grid_y 3 gives 3.24 against
+  a card that says "a ratio of 3.2 at item_height 42", and 55mm clears it exactly as
+  the card claims. That is the third rule to land on a figure recorded by hand in
+  another kernel, after the two sliver baselines, and it is the strongest evidence
+  available that these rules measure what they claim to.
+- **A part opts in to `projection_ratio` by naming which way it reaches.** The rule is
+  meaningless for anything not cantilevered off a wall, and a default guess would
+  either fire on everything or nothing. Cards carry it as `[part] forward`.
 - **Checks are broadcast after the geometry, not with it.** Checking the shelf costs
   about as much again as building it, so running them inline would push the live loop
   past 1.5s. The model swaps at the speed it always did and the panel fills in a beat

--- a/docs/core/PROGRESS.md
+++ b/docs/core/PROGRESS.md
@@ -138,6 +138,7 @@ Printability rules on the in-memory B-rep, calibrated to zero false positives.
 - [x] Rule `stability`
 - [x] Accepted baselines, declared in each part's card
 - [x] `nurb check` CLI, with `--strict` for CI
+- [x] Findings in the viewer: a panel plus a pin at each reported point
 - [x] **Zero false positives on all three parts**, which is the credibility bar
 
 27 tests, every rule with both cases against shapes whose answers were worked out by
@@ -182,6 +183,13 @@ hand. Checks run in 7ms on the hook and 277ms on the shelf.
   makes an unsupported ledge droop is how far it protrudes, not its area or its
   length, so a ledge under `overhang_reach` is silent. Same physics as the bridge
   limit, applied to the cantilever case.
+- **Checks are broadcast after the geometry, not with it.** Checking the shelf costs
+  about as much again as building it, so running them inline would push the live loop
+  past 1.5s. The model swaps at the speed it always did and the panel fills in a beat
+  later.
+- **Cards are watched too.** A card carries what the part has justified, so editing
+  one changes the answer even though no geometry moved. Without this, editing a
+  baseline did nothing until the next code change.
 - **The sliver baseline is a count, not a set of faces.** Which face is which shifts
   as soon as anything upstream of the polish pass moves; the count is the stable
   assertion. Hook 6, shelf 18, both silent when declared and both reported exactly

--- a/docs/core/PROGRESS.md
+++ b/docs/core/PROGRESS.md
@@ -125,15 +125,42 @@ generalizes to `4 * grid_x * grid_y + 2`, confirmed at four grid sizes.
 ---
 
 ### Phase 2: `nurb check`
-**Status:** Not Started
+**Status:** In progress
 
 Printability rules on the in-memory B-rep, calibrated to zero false positives.
 
 #### Tasks completed
-- (none yet)
+- [x] `checks.py`: `Finding`, `Context`, a rule registry, `run()`
+- [x] Convexity test, with both cases unit-tested
+- [x] Rule `sliver`, silent at a declared baseline
+- [x] Rule `build_volume`
 
 #### Decisions made
-- (none yet)
+
+- **Convexity is `n1 . u2`**: does the second face extend in the direction the first
+  face's outward normal points. If it does, the solid folds back on itself and the
+  edge is concave. No winding convention, no orientation assumption.
+- **Which way a face extends is settled by probing the face**, not by aiming at its
+  centroid. The centroid version passed a box and both unit tests and was still
+  wrong: a face with the rest of the part merged into it puts its centroid somewhere
+  unrelated to this edge, which showed up as convex slab edges reported concave. It
+  took an independent method to catch, which is the whole reason RESEARCH said to
+  verify this one empirically rather than reason about it.
+- **Verified two ways.** Four unit tests with hand-counted answers covering both
+  cases, plus every edge of both real parts cross-checked against a completely
+  separate method (sample a ring around the edge, ask the solid how much of it is
+  inside). 115/115 on the hook and 369/512 on the shelf agree with zero
+  disagreements; the other 143 are edges the sampling method cannot resolve at any
+  radius, which is a limit of the cross-check and not a verdict on the classifier.
+- **The build direction is not the model's z**, so `Context.up` carries it. A part is
+  modelled on whatever datums make it readable and printed on whatever face keeps it
+  off supports, and for Notch those differ by 90 degrees: parts hang from a slab top
+  at z=0 and print on their backs. An overhang rule that assumes model z would report
+  confident nonsense about every part in this library.
+- **The sliver baseline is a count, not a set of faces.** Which face is which shifts
+  as soon as anything upstream of the polish pass moves; the count is the stable
+  assertion. Hook 6, shelf 18, both silent when declared and both reported exactly
+  when not.
 
 #### Carried in from Phase 1
 - Two calibration parts exist with **known-exact** baselines: hook 6 slivers at

--- a/docs/core/PROGRESS.md
+++ b/docs/core/PROGRESS.md
@@ -1,6 +1,6 @@
 # nurb core progress
 
-## Status: Phase 1 complete. Phase 2 nearly there.
+## Status: Phases 1 and 2 complete. Phase 3 next.
 
 **The kernel question is answered: OCCT builds both parts and both match the Fusion
 originals dimension for dimension.** The architecture stands. `nurb check` now runs
@@ -127,7 +127,7 @@ generalizes to `4 * grid_x * grid_y + 2`, confirmed at four grid sizes.
 ---
 
 ### Phase 2: `nurb check`
-**Status:** In progress
+**Status:** Complete (2026-07-26)
 
 Printability rules on the in-memory B-rep, calibrated to zero false positives.
 
@@ -236,6 +236,35 @@ recorded. Checks run in 7ms on the hook and 277ms on the shelf.
   as soon as anything upstream of the polish pass moves; the count is the stable
   assertion. Hook 6, shelf 18, both silent when declared and both reported exactly
   when not.
+
+#### Results against the success criteria
+
+| Criterion | Result |
+|---|---|
+| Rules run on the in-memory B-rep | Yes, eight of them |
+| Zero false positives on the calibration set | Yes, all three parts report clean |
+| Convexity test verified empirically | Two independent methods, both cases, 484 real edges |
+| Baselines per part, so a new finding is a regression | On the card, next to the reason |
+| `nurb check` exists and is usable | Reports by default, `--strict` for CI |
+| Findings visible in the loop | Panel and 3D pins in the viewer |
+
+It also caught a real defect in Phase 1's output: four 1mm chamfers on concave gusset
+roots, invisible in code and in every other measure.
+
+#### Deferred, deliberately
+
+- **`chamfer_clearance` is not a `nurb check` rule.** Phase 1 earned the underlying
+  rule (two chamfered convex edges need more than `2 * chamfer_size` between them), but
+  it is a question about geometry that does not exist yet. By the time `nurb check`
+  runs, a violation has already failed the build with an OCCT error. It belongs at
+  build time, wrapping the chamfer call with a better message, which is a different
+  piece of work from a rule.
+- **`nurb check` does not gate `nurb export`.** The open question from RESEARCH,
+  answered the way it leaned: report only. A part with a justified warning still has to
+  be exportable, and a check that blocks work gets switched off. `--strict` is there
+  for CI, which is where blocking belongs.
+- **`min_wall` is approximate and says so.** The inscribed-sphere method is the real
+  answer if wall thickness ever matters more than it does now.
 
 #### Carried in from Phase 1
 - Two calibration parts exist with **known-exact** baselines: hook 6 slivers at

--- a/docs/core/PROGRESS.md
+++ b/docs/core/PROGRESS.md
@@ -1,9 +1,11 @@
 # nurb core progress
 
-## Status: Phase 1 complete. Phase 2 next.
+## Status: Phase 1 complete. Phase 2 nearly there.
 
 **The kernel question is answered: OCCT builds both parts and both match the Fusion
-originals dimension for dimension.** The architecture stands. Two assumptions carried
+originals dimension for dimension.** The architecture stands. `nurb check` now runs
+seven rules against them, clean, and has already caught one real defect in what
+Phase 1 shipped. Two assumptions carried
 in from research did not survive contact with a real part, and they change what Phase 2
 and Phase 4 should prioritize. See Findings below.
 
@@ -140,6 +142,7 @@ Printability rules on the in-memory B-rep, calibrated to zero false positives.
 - [x] `nurb check` CLI, with `--strict` for CI
 - [x] Rule `projection_ratio`
 - [x] Rules `concave_cosmetic` and `bed_bevel`
+- [x] Rule `min_wall`, by ray cast, with its limits documented rather than hidden
 - [x] Findings in the viewer: a panel plus a pin at each reported point
 - [x] **Zero false positives on all three parts**, which is the credibility bar
 
@@ -186,6 +189,18 @@ recorded. Checks run in 7ms on the hook and 277ms on the shelf.
   makes an unsupported ledge droop is how far it protrudes, not its area or its
   length, so a ledge under `overhang_reach` is silent. Same physics as the bridge
   limit, applied to the cantilever case.
+- **`min_wall` is the weakest rule here and the docstring says so.** A ray cast is
+  exact on flat parallel walls and wrong in two directions everywhere else, and both
+  showed up on the first run: it read the shelf's knife-edge mouth rim as a 0.76mm
+  wall, and the coupon's 0.5mm raised label as a 0.5mm wall. Neither is a defect and
+  all three parts print. It also misses what an inscribed sphere would catch, a thin
+  spot in an inside corner. So a clean result means "no thin walls found", not "no
+  thin walls", and the parts declare their own floor next to the reason on the card.
+
+  The one real filter it needed: only count a surface the ray leaves *through*, whose
+  outward normal points along the ray. A hit facing back means the ray had already
+  left the material, which is how a chamfer two corners away read as a 0.89mm wall on
+  a 6mm slab.
 - **The rules found a real defect in Phase 1's output.** `concave_cosmetic` flagged
   four 1mm chamfers at the shelf's gusset roots, which are inside corners, and both
   the convexity test and independent ring sampling confirm it. Phase 1 had reasoned

--- a/docs/core/PROGRESS.md
+++ b/docs/core/PROGRESS.md
@@ -1,8 +1,11 @@
 # nurb core progress
 
-## Status: Phase 1 - Not Started
+## Status: Phase 1 complete. Phase 2 next.
 
-Prerequisites outstanding. See below.
+**The kernel question is answered: OCCT builds both parts and both match the Fusion
+originals dimension for dimension.** The architecture stands. Two assumptions carried
+in from research did not survive contact with a real part, and they change what Phase 2
+and Phase 4 should prioritize. See Findings below.
 
 ## Quick reference
 
@@ -11,27 +14,110 @@ Prerequisites outstanding. See below.
 
 ## Prerequisites
 
-- [ ] Commit the current tree. **No restore point exists.** Everything below the
-      phase list was built uncommitted.
-- [ ] Decide where the Notch port lives. Recommendation: `examples/notch/` in this
-      repo, its own project directory with `parts/` and `system.py`, doubling as
-      test corpus and worked example.
+- [x] Commit the current tree. Done: `957a6fc`, the runtime and docs.
+- [x] Decide where the Notch port lives. **`examples/notch/`**, its own project
+      directory with `parts/` and `system.py`. It doubles as test corpus and worked
+      example, and `examples/` is already where the suite will look.
 
 ---
 
 ## Phase progress
 
 ### Phase 1: Kernel proof
-**Status:** Not Started
+**Status:** Complete (2026-07-25)
 
-Port `Hook - Scissors - 1x` and `Shelf - Gridfinity 2x2 - 4x` to prove OCCT handles
-real Notch geometry.
+Both parts build, match the Fusion originals, and run in the live loop.
 
 #### Tasks completed
-- (none yet)
+- [x] Notch port lives in `examples/notch/`
+- [x] `system.py`: constants, `channels()`, `detent_dimples()`, `polish_edges()`
+- [x] Ported `Hook - Scissors - 1x`
+- [x] Ported `Shelf - Gridfinity 2x2 - 4x`
+- [x] Fit verified by coordinate on both parts
+- [x] `bracket_count` flexed both directions
+- [x] Sliver counts compared against the known baselines
+- [x] Rebuild latency measured, draft and polished, per stage
+- [x] STL exported and checked
+
+#### Results against the success criteria
+
+| Criterion | Result |
+|---|---|
+| Both parts build without OCCT errors | Yes, one solid each |
+| Gridfinity sliver count is 18 | **Exactly 18**: 16 x 0.632mm² + 2 x 0.866mm² |
+| Fit coordinates match Fusion exactly | Floors at x=-4.2, y-centers on exact pitch, full 21.56mm spans |
+| `bracket_count` flexes both directions | Hook 1 -> 2 -> 3 -> 1, shelf 4 -> 6 -> 4, baselines unchanged |
+| Polished rebuild under ~500ms | Build yes (470ms). **Whole loop no (~1.09s)**, see Findings |
+| An exported STL is genuinely printable | Watertight, 1 body, euler 2, no degenerate faces; BambuStudio reports `manifold = yes` |
+
+The hook's bounding box is 34 x 25.16 x 30mm and the shelf's is 94 x 100.64 x 42mm.
+Both match their catalog cards to the digit.
+
+The sliver counts are the strongest evidence in the phase. Neither was tuned for:
+the polish exclusion rule was derived from the doctrine, and the counts came out at
+the recorded baselines on the first build that completed. The shelf's baseline also
+generalizes to `4 * grid_x * grid_y + 2`, confirmed at four grid sizes.
 
 #### Decisions made
-- (none yet)
+
+- **Notch lives at `examples/notch/`.** Test corpus and worked example in one place.
+- **`system.py` carries `polish_edges()` as well as the constants.** Both parts need
+  the same three vetoes (back face, bottom face, channel interior), and it was clear
+  they were shared because both parts were in front of me. Extraction, not scaffolding.
+- **No `gusset_count` on the shelf.** The Fusion part carries one because the shelf
+  family shares a template; here the gussets are the side cheeks and a third lands in
+  the middle of a cell. A parameter that breaks the part when changed is worse than
+  no parameter.
+- **`gusset_drop` raised 2 -> 3mm.** The 2mm in Fusion was a kernel workaround, not
+  design intent. Restated as a rule (clear twice the chamfer) it is correct for both.
+- **Structural chamfers use `new_edges`, not geometric selectors.** This is the
+  algebra-mode answer to `Select.LAST`, and it is why the parts survive a flex.
+- **Grid is the build plate.** The viewer now drops a part onto z=0 rather than
+  drawing it where its modeling origin says. Notch hangs everything below z=0, so
+  every part rendered underneath the plate.
+- **Channel clearance is per-channel, not per-system.** The first printed
+  `hook_scissors` came out loose side to side. A calibration ladder (`fit_coupon` at
+  0.20 / 0.30 / 0.40 / 0.50) put the right single-bracket fit at **0.30mm per side**,
+  against a shipped 0.5. The looseness is specific to 1x parts: one channel constrains
+  yaw over its own 21.56mm, four constrain it over 75mm, which is why the shelves
+  never felt loose at the same number. **One clearance now, every channel, every
+  part.** Printed coupons at 2, 4 and 6 brackets all slid on at the same fit, so a
+  real wall's pitch needs no compensating for and a longer run costs nothing.
+
+  Three wrong versions preceded that, all variations on giving later channels more
+  room, and the sequence is the lesson:
+
+  1. Relief accumulating per channel, unbounded. Printed at 0.66 on the far channel of
+     a 4x, looser than the flat 0.5 the library shipped for years, so it exceeded the
+     only fit ever shown to work.
+  2. Relief capped, but still per-channel: channel 0 tight, the rest relieved. Nothing
+     makes channel 0 the datum except being `k=0` in the loop, and putting the one
+     tight channel at the *end* of a run is the worst place for it, since residual yaw
+     then pivots there and swings the far end the maximum amount.
+  3. Uniform within a part, scaled by run length. Coherent, and still wrong, because
+     it was compensating for scatter the wall does not have.
+
+  Each version was a smaller amount of code than the one before, and the correct
+  answer was the least of all: no scaling at all. `PITCH_SLOP` survives in the
+  constants table as measured hardware data with nothing spending it.
+
+  The general lesson is worth more than the number. Every version was reasoned from a
+  plausible physical story about pitch scatter, and the story was never checked
+  against a wall. Three rounds of increasingly careful modelling of a phenomenon that
+  had to be measured before it was worth modelling at all.
+
+  **The number is 0.25**, from 0.20 printing too tight to seat and 0.30 sliding on
+  loosely. The window is therefore only about 0.1mm wide, which is the same order as
+  FDM extrusion variation, so 0.25 is chosen as the middle of the band rather than as
+  a preference: it is where a print that drifts either way still fits. It also sets
+  where calibration stops being worth it, since the printer moves further between
+  prints than a finer increment would.
+- **Parts check `item_depth` against `MIN_ITEM_DEPTH`.** Found in review: a slab
+  thinner than 5.2mm leaves no material at `MERGE_X`, so the forward feature never
+  touches it. That built, reported a normal bounding box, and exported an STL in two
+  loose pieces. Nothing in the pipeline reports solid count, which is what made it
+  silent, and `item_depth=5` is a plausible edit given the channel is only 4.2 deep.
+  The two guards duplicate; `nurb extract` in Phase 5 is where that gets lifted.
 
 #### Blockers
 - (none)
@@ -49,8 +135,23 @@ Printability rules on the in-memory B-rep, calibrated to zero false positives.
 #### Decisions made
 - (none yet)
 
+#### Carried in from Phase 1
+- Two calibration parts exist with **known-exact** baselines: hook 6 slivers at
+  0.866mm², shelf 18 (`4 * grid_x * grid_y + 2`). A nineteenth is a regression.
+- A new rule falls out of the port: **`chamfer_clearance`**. Two chamfered convex
+  edges need more than `2 * chamfer_size` of face between them or the kernel cannot
+  build the corner. It is cheap to check, it is exact, and it caught two real bugs
+  in this phase before either was understood. Worth adding to the rule list.
+- `polish_edges()` in `examples/notch/system.py` is a first draft of the
+  `back_bottom_chamfer` and `mating_chamfer` rules, written as a selector instead of
+  a check. Phase 2 should be able to reuse the predicate.
+- The concave-edge exclusion is still done structurally (subtract `new_edges` from
+  the polish set) rather than by testing convexity. That works because the only
+  concave edges in these two parts are the ones the structural pass just made. It
+  will not generalize, so the convexity test is still owed.
+
 #### Blockers
-- Depends on Phase 1 producing parts to calibrate against
+- (none)
 
 ---
 
@@ -123,9 +224,102 @@ above, and the entire reason Phase 1 comes first.
 
 ---
 
+## Findings from Phase 1
+
+Three of these change what later phases should do. Recorded here rather than buried
+in a card, because they contradict things written in RESEARCH.md before any real part
+existed.
+
+### 1. The kernel rule that explains every failure in this phase
+
+**Two chamfered convex edges need more than `2 * chamfer_size` of face between them.**
+Closer than that and OCCT raises `Standard_Failure: BRep_API: command not done`, which
+build123d surfaces as `ValueError: Failed creating a chamfer, try a smaller length
+value(s)`. This is the OCCT analogue of `ASM_BL_NO_MATE`.
+
+Measured, not reasoned: at `chamfer_size` 1mm the shelf fails with 1.66mm between the
+edges and builds with 2.16mm; at 0.5mm it builds with 1.16mm. The threshold tracks the
+chamfer exactly.
+
+Both shelf failures were this one rule:
+
+- The gusset peak 2mm below the slab top. Fusion needed exactly that 2mm to escape
+  `ASM_BL_NO_MATE`; OCCT needs more than 2mm. Same spot, same cause, different
+  threshold.
+- A platform wider than `slab - 4 * chamfer_size`. This is where the card's grid-to-
+  bracket pairings (1 -> 3, 2 -> 4, 3 -> 6) actually come from.
+
+Notably, **every individual edge chamfered fine**; only the batch failed. Debugging by
+"try a smaller length" would never have found it. Bisecting the edge set pairwise did.
+
+### 2. Draft mode is not the latency lever research claimed
+
+RESEARCH.md says chamfers are essentially the entire build cost and that draft mode
+scales with polish. That came from `Box() - chamfer()` and **it is false on a real
+part.** Stage breakdown for the shelf:
+
+```
+socket lofts          156ms   34%
+socket cut             68ms   15%
+cosmetic chamfer       66ms   14%
+structural chamfer     43ms    9%
+gussets                42ms    9%
+fuse to slab           39ms    8%
+select polish edges    26ms    6%
+channels + detent      21ms    5%
+--------------------------------
+build                 460ms
+```
+
+Stage timings come from one instrumented run, so they total 460ms against the 470ms
+measured elsewhere in this document. Run-to-run noise, not a discrepancy.
+
+Chamfers are 23% of the build, not all of it. Draft mode saves 20%, not 18x.
+
+### 3. Tessellation, not the build, is the loop
+
+```
+                     build    tessellate + GLB    loop
+hook, polished        46ms          120ms        ~166ms
+hook, draft           26ms           66ms         ~92ms
+shelf, polished      470ms          620ms       ~1090ms
+shelf, draft         380ms          520ms        ~900ms
+```
+
+Tessellation costs more than the entire build on the shelf, and draft mode barely
+touches it. **The phase's ~500ms target is met by the build and missed by the loop.**
+The lever is tessellation tolerance, geometry caching, or pushing tessellation off the
+rebuild path, none of which is draft mode. This should inform Phase 4 rather than
+being discovered there.
+
+### 4. `new_edges` is the algebra-mode `Select.LAST`
+
+`new_edges(before, combined=after)` returns exactly the edges an operation created.
+Used for the structural chamfers and to exclude them from the cosmetic pass. This is
+what makes the parts survive a `bracket_count` flex, and it is a genuine improvement
+over the strict-ordering rule Fusion needed. CLAUDE.md's preference for it is correct
+and now has evidence.
+
+---
+
 ## Session log
 
-### 2026-07-25
+### 2026-07-25 (later): Phase 1
+
+Ported both parts. Read the exact channel cross-section off the live Fusion model
+rather than deriving it from the constants table, which was the right call: the table
+documents the bracket pocket, and the channel is the pocket plus clearance that is
+0.2mm in depth but 0.5mm per side in width. Guessing would have produced a channel
+1mm too tight.
+
+Order of work: system module, hook, shelf. The hook earned its place in the plan.
+Its cosmetic pass failed first, on the detent dimple, which was a plain bug in my
+exclusion envelope rather than anything kernel-related, and finding that on simple
+geometry made the shelf's two real failures easy to recognize as different.
+
+Both parts verified in the live loop with a screenshot, both sitting on the grid.
+
+### 2026-07-25: runtime skeleton
 
 Built the runtime skeleton, then wrote RESEARCH.md and IMPLEMENTATION.md.
 
@@ -160,6 +354,22 @@ README.md
 docs/core/*.md
 ```
 
+Phase 1:
+
+```
+examples/notch/system.py                     new  constants, channels, detent, polish_edges
+examples/notch/parts/hook_scissors.py        new
+examples/notch/parts/hook_scissors.md        new
+examples/notch/parts/shelf_gridfinity.py     new
+examples/notch/parts/shelf_gridfinity.md     new
+src/nurb/builder.py       load() puts the project root on sys.path so a part can
+                          `from system import ...`, and forgets the project's own
+                          modules afterwards so editing a shared one is picked up
+src/nurb/server.py        watch the project root too; a change outside parts/ is
+                          treated as a shared module and rebuilds every part
+src/nurb/viewer.html      parts sit on the grid instead of hanging under it
+```
+
 ---
 
 ## Architectural decisions
@@ -178,6 +388,9 @@ Carried from research and the questions answered during planning.
 | Persistent process is mandatory | 2.28s warm import per rebuild would make the loop unusable |
 | Do not port Fusion's scaffolding | `ChannelTool`, the 16-lobe comb, `CombWeb`, `JoinComb` exist only because combine tool lists never grow. Use a `for` loop. |
 | Name: nurb, command `nurb` | Clean on PyPI, npm, nurb.dev. NURBS is the geometry primitive, so the search overlap is on-topic rather than misleading. |
+| A project's own modules are importable and reloadable | `system.py` is the whole point of a parts library. A part says `from system import ...`; the loader puts the root on `sys.path` and forgets project modules after each build so an edit lands on the next rebuild. |
+| The grid is the build plate | Where a part's origin falls is a modeling datum. Notch hangs everything below z=0, which put every part under the plate. The viewer drops the part onto z=0 instead. |
+| Chamfer selection uses `new_edges`, never frozen geometry | It is what survives a `bracket_count` flex, and it is the algebra-mode `Select.LAST` CLAUDE.md asks for. |
 
 ---
 
@@ -206,3 +419,25 @@ Carried from research and the questions answered during planning.
   covering the HUD when painting was fine. Screenshots were the real evidence.
 - Redirect stdout early. The first hot-reload debugging session was blind because
   Python buffers stdout when it is not a tty and none of the prints had `flush=True`.
+
+**From Phase 1:**
+
+- **Read the real model, do not derive it from the notes.** The Notch constants table
+  documents the bracket pocket; the channel is the pocket plus clearance, and that
+  clearance is 0.2mm in depth but 0.5mm per side in width. Nothing said so. Dumping
+  the actual faces off the live Fusion part took one script and settled it, and the
+  trapezoid area matching to 72.912mm² proved the port before any part was written.
+- **A batch chamfer failure is not a bad edge.** Every edge in the shelf's polish set
+  chamfered fine on its own; only the set failed. Testing edges individually says
+  "everything is fine" and is worthless. Bisecting pairwise found the real rule in
+  one pass.
+- **Predict the baseline before looking.** Working out that the hook should have
+  exactly 6 corner triangles, from the polish exclusions alone, turned the sliver
+  count into a test of the rule instead of a number to write down. It came out 6.
+  The shelf then came out 18 without tuning. Two independent confirmations that the
+  port matches, for free.
+- **Fusion's workarounds are sometimes real constraints wearing a disguise.** The
+  gusset's 2mm drop looked like pure kernel scaffolding. It is a kernel workaround,
+  but the underlying constraint (a chamfer needs room to land) is physics-adjacent
+  and applies to OCCT too, at a different number. Deleting it would have been wrong;
+  restating it as a rule was right.

--- a/docs/core/PROGRESS.md
+++ b/docs/core/PROGRESS.md
@@ -136,9 +136,11 @@ Printability rules on the in-memory B-rep, calibrated to zero false positives.
 - [x] Rule `build_volume`
 - [x] Rule `overhang`, with curved faces sampled and bridges told from cantilevers
 - [x] Rule `stability`
-- [x] **Zero false positives on both parts**, which is the credibility bar
+- [x] Accepted baselines, declared in each part's card
+- [x] `nurb check` CLI, with `--strict` for CI
+- [x] **Zero false positives on all three parts**, which is the credibility bar
 
-20 tests, every rule with both cases against shapes whose answers were worked out by
+27 tests, every rule with both cases against shapes whose answers were worked out by
 hand. Checks run in 7ms on the hook and 277ms on the shelf.
 
 #### Decisions made
@@ -170,6 +172,16 @@ hand. Checks run in 7ms on the hook and 277ms on the shelf.
   face. Under `bridge_limit` a bridge is silent, over it a warning, and a cantilever
   past 45 degrees is a failure. Without this both parts fire two findings per
   channel, on geometry that has printed fine for months.
+- **The baseline lives in the card, next to the sentence that justifies it.** A count
+  on its own is a magic number; the reason it is allowed is the part that matters, and
+  a card is where a part already explains itself. It is a TOML fence, so `tomllib`
+  reads it and no dependency is added. A card can also carry printer settings, and a
+  typo in a setting name is an error rather than a silently ignored line.
+- **A shallow ledge is not an overhang.** The raised label on the calibration coupon
+  produced a hundred 90-degree findings at a third of a square millimetre each. What
+  makes an unsupported ledge droop is how far it protrudes, not its area or its
+  length, so a ledge under `overhang_reach` is silent. Same physics as the bridge
+  limit, applied to the cantilever case.
 - **The sliver baseline is a count, not a set of faces.** Which face is which shifts
   as soon as anything upstream of the polish pass moves; the count is the stable
   assertion. Hook 6, shelf 18, both silent when declared and both reported exactly

--- a/docs/core/PROGRESS.md
+++ b/docs/core/PROGRESS.md
@@ -134,6 +134,12 @@ Printability rules on the in-memory B-rep, calibrated to zero false positives.
 - [x] Convexity test, with both cases unit-tested
 - [x] Rule `sliver`, silent at a declared baseline
 - [x] Rule `build_volume`
+- [x] Rule `overhang`, with curved faces sampled and bridges told from cantilevers
+- [x] Rule `stability`
+- [x] **Zero false positives on both parts**, which is the credibility bar
+
+20 tests, every rule with both cases against shapes whose answers were worked out by
+hand. Checks run in 7ms on the hook and 277ms on the shelf.
 
 #### Decisions made
 
@@ -152,11 +158,18 @@ Printability rules on the in-memory B-rep, calibrated to zero false positives.
   inside). 115/115 on the hook and 369/512 on the shelf agree with zero
   disagreements; the other 143 are edges the sampling method cannot resolve at any
   radius, which is a limit of the cross-check and not a verdict on the classifier.
-- **The build direction is not the model's z**, so `Context.up` carries it. A part is
-  modelled on whatever datums make it readable and printed on whatever face keeps it
-  off supports, and for Notch those differ by 90 degrees: parts hang from a slab top
-  at z=0 and print on their backs. An overhang rule that assumes model z would report
-  confident nonsense about every part in this library.
+- **The build direction is a setting, not an assumption**, so `Context.up` carries it.
+  Notch parts print exactly as modelled, top up, so +z is right for them and the
+  default holds. That was worth asking rather than deriving: the same hook reports 3,
+  1 or 4 findings depending on which face goes down, and every one of those answers
+  looks equally confident. Nothing generalises the Notch case to other projects.
+- **A bridge is not an overhang.** Both are 90 degrees to the build direction and the
+  normal cannot tell them apart, which is why an angle-only rule reports a channel
+  roof and a cantilevered shelf as the same problem. What separates them is whether
+  material sits on both sides, so the rule probes just outside and just below the
+  face. Under `bridge_limit` a bridge is silent, over it a warning, and a cantilever
+  past 45 degrees is a failure. Without this both parts fire two findings per
+  channel, on geometry that has printed fine for months.
 - **The sliver baseline is a count, not a set of faces.** Which face is which shifts
   as soon as anything upstream of the polish pass moves; the count is the stable
   assertion. Hook 6, shelf 18, both silent when declared and both reported exactly

--- a/docs/core/RESEARCH.md
+++ b/docs/core/RESEARCH.md
@@ -2,8 +2,11 @@
 
 The central reference for nurb. Everything else pulls from here.
 
-Status as of 2026-07-25: runtime skeleton built and verified on trivial geometry.
-744 lines across six files. Not committed. Never tested on a real part.
+Status as of 2026-07-25: Phase 1 complete. Two real Notch parts build, match their
+Fusion originals dimension for dimension, and run in the live loop. The kernel
+question is settled. See `PROGRESS.md` for the findings, two of which correct claims
+made in this document before any real part existed; those corrections are folded in
+below and marked.
 
 ## Overview
 
@@ -108,10 +111,29 @@ Two consequences, both load-bearing:
 
 1. **The persistent process is mandatory, not an optimization.** A 2.3s import per
    rebuild would make the loop unusable. `nurb dev` pays it once.
-2. **Draft mode is worth more than expected.** On a trivial part, 18ms polished vs
-   **1ms** draft. Chamfers are essentially the entire build cost. Skipping the polish
-   pass during iteration is the highest-leverage latency lever available, and it
-   scales: the more polished the part, the bigger the win.
+2. ~~**Draft mode is worth more than expected.** On a trivial part, 18ms polished vs
+   **1ms** draft. Chamfers are essentially the entire build cost.~~ **Wrong, corrected
+   by Phase 1.** That held only for `Box() - chamfer()`. On the gridfinity shelf,
+   chamfers are 23% of the build and draft mode saves 20%, not 18x.
+
+### Corrected by Phase 1, on real parts
+
+```
+                     build    tessellate + GLB    loop
+hook, polished        46ms          120ms        ~166ms
+hook, draft           26ms           66ms         ~92ms
+shelf, polished      470ms          620ms       ~1090ms
+shelf, draft         380ms          520ms        ~900ms
+```
+
+Shelf build, by stage: socket lofts 156ms (34%), socket cut 68ms, cosmetic chamfer
+66ms, structural chamfer 43ms, gussets 42ms, fuse 39ms, edge selection 26ms, channels
+and detent 21ms.
+
+**Tessellation costs more than the entire build, and draft mode barely touches it.**
+The latency lever is tessellation tolerance, caching, or moving tessellation off the
+rebuild path. It is not the polish pass. Anything that plans around draft mode as the
+primary lever is planning around a measurement taken on a cube.
 
 ## Architecture
 
@@ -353,6 +375,15 @@ pitch_slop          0.12 mm   per-interval scatter allowance
 bracket height     25 mm      physical, drives min item_height = 28
 ```
 
+**Those are the bracket pocket, not the channel.** Phase 1 read the shipped
+`ChannelTool` off the live Fusion model and the channel is the pocket plus clearance
+that differs by axis: **0.2mm in depth, 0.5mm per side in width.** Nothing in the
+notes said so, and deriving the channel from the table alone produces one a
+millimeter too tight. The channel that ships is a trapezoid, floor at `x=-4.2`
+spanning `y` +/-10.78, mouth at `x=0` spanning +/-6.58, ceiling at `z=-3`. Its walls
+are therefore at exactly 45 degrees, which is what lets the dovetail print without
+support. `examples/notch/system.py` holds it.
+
 Coordinate convention: slab top at `z=0` (part extends down), back face at `x=0`
 (part extends forward in `-x`), first channel centered at `y=0`, channels marching
 `+y` at `block_width` spacing. Landing those three datums makes the hanging
@@ -411,26 +442,33 @@ Fit assertions for the test suite: channel floors at `x=-4.2`, y-centers exactly
 
 ## Risks
 
-**Ranked by how much they threaten the thesis.**
+**Ranked by how much they threaten the thesis.** Ranks 1, 2 and 5 were resolved by
+Phase 1 and are kept here with their outcomes, since the outcomes are the useful part.
 
-1. **OCCT chamfer robustness on real geometry. Untested.** Every timing number and
-   every claim of viability comes from `Box() - chamfer()`. The gridfinity 2x2 shelf
-   is the proof case: four loft-cut socket features, a pattern, gussets, two chamfer
-   passes, and a known 18-face sliver baseline. It already fights Fusion's kernel
-   (the gusset peak lands exactly on the slab-top chamfer boundary and fails
-   `ASM_BL_NO_MATE` if positioned naively). If OCCT cannot chamfer it cleanly, the
-   architecture needs rethinking. **This should be resolved before building anything
-   on top.**
-2. **Rebuild latency on real parts.** 1ms on a cube says nothing. If a real part
-   takes multiple seconds, draft mode and caching stop being optimizations and
-   become the critical path.
-3. **False positives in the rules.** Kills adoption faster than missing checks.
+1. ~~**OCCT chamfer robustness on real geometry. Untested.**~~ **Resolved. OCCT
+   handles it.** Both parts build, the shelf reproduces its 18-face sliver baseline
+   exactly, and the geometry matches the Fusion originals dimension for dimension.
+   One rule accounts for every failure encountered: **two chamfered convex edges need
+   more than `2 * chamfer_size` of face between them**, or OCCT raises
+   `BRep_API: command not done`. That is the `ASM_BL_NO_MATE` analogue. Fusion's
+   gusset-peak workaround was the same constraint at a smaller threshold.
+
+   The trap: **every edge chamfers fine individually; only the batch fails.** Checking
+   edges one at a time reports that nothing is wrong. Bisect the set pairwise.
+2. ~~**Rebuild latency on real parts.**~~ **Resolved, and the answer is not the one
+   assumed.** Build is 470ms on the shelf, but tessellation is another 620ms, so the
+   loop is ~1.1s. Tessellation is the critical path and draft mode does not address
+   it. See the measured facts above.
+3. **False positives in the rules.** Kills adoption faster than missing checks. Two
+   calibration parts now exist with exact baselines.
 4. **Concave edge detection.** Required by the polish rules, known to have a subtle
-   failure mode, must be verified empirically rather than reasoned about.
-5. **Chamfer selector drift.** Each chamfer changes topology, so selectors resolved
-   before an earlier chamfer runs may not match after. Fusion's answer was strict
-   ordering (cosmetic on pristine geometry first, then structural). OCCT's behavior
-   is unknown and may differ.
+   failure mode, must be verified empirically rather than reasoned about. Phase 1
+   sidestepped it by subtracting `new_edges` from the polish set, which works only
+   because those parts' sole concave edges are the ones the structural pass made.
+5. ~~**Chamfer selector drift.**~~ **Resolved.** `new_edges(before, combined=after)`
+   returns exactly what an operation created, and is the algebra-mode `Select.LAST`.
+   Both parts flex `bracket_count` in both directions with baselines unchanged. This
+   is genuinely better than Fusion's strict-ordering rule, not just parity.
 6. **three.js CDN dependency.** Offline breaks the viewer.
 
 ## Open questions

--- a/examples/notch/calibrate.py
+++ b/examples/notch/calibrate.py
@@ -1,0 +1,85 @@
+"""Build one plate carrying every fit variant worth trying, instead of iterating.
+
+    uv run --project ../.. python calibrate.py
+
+Edit SWEEP and SPANS, re-run, reprint. Each coupon carries its own settings raised on
+its face, so the plate is still readable once it is a pile of parts on the bench.
+
+Two different questions, which is why there are two groups:
+
+  SWEEP  one bracket, varying clearance. A judgement about feel. Empty by default:
+         0.30 is settled, and steps finer than about 0.1 are below what an FDM
+         printer resolves anyway, so a fine sweep measures extrusion noise rather
+         than fit. Put values back here only if the base number is in question again.
+  SPANS  a full-length run at one clearance. Pass or fail, not a feel: either the
+         part slides onto real brackets or it binds. The answer you want is the
+         longest run that still goes on at the tightest clearance.
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+from build123d import Pos, Part, export_stl  # noqa: E402
+
+sys.path.insert(0, str(pathlib.Path(__file__).parents[2] / "src"))
+from nurb import builder  # noqa: E402
+
+from system import BLOCK_WIDTH  # noqa: E402
+
+SWEEP = [0.25]
+SPANS = [(2, 0.25), (3, 0.25), (4, 0.25), (5, 0.25), (6, 0.25)]
+
+BED = 250.0  # usable width, minus a margin
+GAP = 6.0
+ROW_PITCH = 40.0  # coupons are 30mm tall, and height is what separates rows
+
+HERE = pathlib.Path(__file__).parent
+COUPON = HERE / "parts" / "fit_coupon.py"
+
+
+def rows(items):
+    """Pack widest-first into rows that fit the bed."""
+    row, used = [], 0.0
+    for width, shape in sorted(items, key=lambda i: -i[0]):
+        if row and used + width + GAP > BED:
+            yield row
+            row, used = [], 0.0
+        row.append((width, shape))
+        used += width + GAP
+    if row:
+        yield row
+
+
+def main():
+    built = []
+    for count, clearance in [(1, c) for c in SWEEP] + SPANS:
+        shape, _, ms = builder.build(
+            COUPON, overrides={"bracket_count": count, "side_clearance": clearance}
+        )
+        width = count * BLOCK_WIDTH
+        built.append((width, shape))
+        print(f"  {count}x  {clearance:.2f}   {width:6.1f}mm wide   {ms:5.0f}ms")
+
+    plate = Part()
+    for r, row in enumerate(rows(built)):
+        y = 0.0
+        for width, shape in row:
+            plate += Pos(0, y, -r * ROW_PITCH) * shape
+            y += width + GAP
+
+    out = HERE / "build"
+    out.mkdir(exist_ok=True)
+    target = out / "calibration_plate.stl"
+    export_stl(plate, str(target))
+    bb = plate.bounding_box()
+    print(
+        f"\n  {target.name}: {len(built)} coupons, "
+        f"{bb.size.Y:.0f} x {bb.size.Z:.0f}mm footprint, {plate.volume / 1000:.1f}cm3"
+    )
+    print("  Slice it the way you slice a part, so the fits are comparable.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/notch/parts/fit_coupon.md
+++ b/examples/notch/parts/fit_coupon.md
@@ -25,6 +25,19 @@ keep the one that feels right, then set the constant in `system.py`. Each is abo
 - 30mm slab matches the light-part default, so the coupon engages a bracket the same
   way a hook does.
 
+## Accepted
+
+The raised label is lettering, and lettering is made of small faces. All 65 are in
+the glyphs; the coupon itself has no chamfers and so no corner triangles. The number
+tracks whatever the label says, so a coupon built at a different clearance or bracket
+count will not match it. That is tolerable here in a way it would not be on a real
+part: this is a gauge, and the only surface that has to come out right is the channel.
+
+```toml
+[accepted]
+sliver = 65
+```
+
 ## Don't
 
 - **Don't orient these differently from the part you are comparing against.** Print

--- a/examples/notch/parts/fit_coupon.md
+++ b/examples/notch/parts/fit_coupon.md
@@ -33,7 +33,14 @@ tracks whatever the label says, so a coupon built at a different clearance or br
 count will not match it. That is tolerable here in a way it would not be on a real
 part: this is a gauge, and the only surface that has to come out right is the channel.
 
+The thinnest section is 0.5mm, which is the raised label standing off the front
+face. A ray cast cannot tell a relief from a wall. The channel web, which is the
+part that matters, is 1.8mm.
+
 ```toml
+[part]
+min_wall = 0.5
+
 [accepted]
 sliver = 65
 ```

--- a/examples/notch/parts/fit_coupon.md
+++ b/examples/notch/parts/fit_coupon.md
@@ -1,0 +1,58 @@
+# fit_coupon
+
+## What it is
+
+The hanging interface with nothing attached to it: one channel, one detent dimple, a
+30mm slab. A tool for dialing `SIDE_CLEARANCE` against a real bracket, not a part
+anyone hangs anything on.
+
+Print a ladder of them at different clearances, slide them all onto the same bracket,
+keep the one that feels right, then set the constant in `system.py`. Each is about
+2.6cm³, so a four-rung ladder is one short print rather than four hooks.
+
+## Design notes
+
+- `side_clearance` is a real parameter here rather than the system constant, which is
+  the whole point. `channels()` takes it so the coupon can build a fit the library
+  does not ship.
+- Widening it moves both dovetail walls by the same amount, so they stay at exactly 45
+  degrees whatever you pass. The depth clearance is not like this: `CHANNEL_WIDTH -
+  CHANNEL_NECK == 2 * CHANNEL_DEPTH` only holds at `CLEARANCE` 0.2, and the 45 degrees
+  is what lets the dovetail print without support. Side clearance is the free knob.
+- The value is raised on the front face, not cut into it. The web in front of the
+  channel is only 1.8mm and debossing would take a third of it. It is also the reason
+  the coupons are worth labelling at all: four of these come off the plate identical.
+- 30mm slab matches the light-part default, so the coupon engages a bracket the same
+  way a hook does.
+
+## Don't
+
+- **Don't orient these differently from the part you are comparing against.** Print
+  orientation changes the effective size of the slot, so a coupon laid down one way
+  and a hook laid another are not measuring the same thing. Slice them the way you
+  sliced the hook.
+- **Don't use this to dial multi-bracket parts.** One channel constrains yaw over its
+  own 21.56mm; four constrain it over 75mm. The same clearance that wobbles on a 1x
+  hook is fine on a 4x shelf, which is the whole reason this got noticed on the hook
+  first.
+- **Don't tighten `CLEARANCE` (depth) to fix a loose fit.** It breaks the 45 degree
+  walls. See Design notes.
+
+## Changelog
+
+- 2026-07-26: **0.25 settled.** 0.20 printed too tight to seat, 0.30 slid on loosely,
+  so the usable window is about 0.1mm wide and 0.25 is the middle of it. That width is
+  the same order as FDM extrusion variation, which is the real reason to stop here:
+  the printer moves further between prints than a finer increment would.
+- 2026-07-26: 2x, 4x and 6x all printed at 0.30 and all slid on, the 6x easily. Run
+  length needs no allowance at all, so the scaling is gone and every channel on every
+  part is one number. Three versions of that scaling were built and all three were
+  compensating for scatter the wall does not have. Base clearance now going below 0.30
+  since even a 6x feels a touch easy.
+- 2026-07-26: ladder printed. **0.30 is the number**, and `SIDE_CLEARANCE` moved 0.5
+  -> 0.3. Clearance is now per-channel rather than per-system, so the coupon takes
+  `bracket_count`.
+- 2026-07-26: created, after a printed `hook_scissors` came out loose side to side.
+  The shipped `SIDE_CLEARANCE` was 0.5mm per side, which is generous for FDM and
+  disagrees with the Notch constants table's stated 0.2. Ladder exported at 0.20 /
+  0.30 / 0.40 / 0.50.

--- a/examples/notch/parts/fit_coupon.py
+++ b/examples/notch/parts/fit_coupon.py
@@ -1,0 +1,43 @@
+"""Fit coupon: the hanging interface on its own, for dialing channel clearance."""
+
+from nurb import *
+
+from system import BLOCK_WIDTH, SIDE_CLEARANCE, channels, detent_dimples
+
+
+@part
+def fit_coupon(
+    side_clearance=SIDE_CLEARANCE,
+    bracket_count=1,
+    item_height=30,
+    item_depth=6,
+    label_size=6,
+    label_relief=0.5,
+    draft=False,
+):
+    y0, y1 = -BLOCK_WIDTH / 2, (bracket_count - 0.5) * BLOCK_WIDTH
+    slab = Pos(-item_depth / 2, (y0 + y1) / 2, -item_height / 2) * Box(
+        item_depth, y1 - y0, item_height
+    )
+    body = (
+        slab
+        - channels(bracket_count, item_height, side_clearance=side_clearance)
+        - detent_dimples(bracket_count)
+    )
+    if draft:
+        return body
+
+    # What it is, raised on the front face. A plate of these comes out looking
+    # identical, and a coupon you cannot identify afterwards is no use. Raised rather
+    # than cut: the web in front of the channel is only 1.8mm and debossing would take
+    # a third of it.
+    caption = f"{side_clearance:.2f}" if bracket_count == 1 else (
+        f"{bracket_count}x {side_clearance:.2f}"
+    )
+    front = Plane(
+        origin=(-item_depth, (y0 + y1) / 2, -item_height / 2),
+        x_dir=(0, -1, 0),
+        z_dir=(-1, 0, 0),
+    )
+    label = front * Text(caption, label_size)
+    return body + extrude(label, label_relief)

--- a/examples/notch/parts/hook_scissors.md
+++ b/examples/notch/parts/hook_scissors.md
@@ -32,6 +32,17 @@ kernel problem and not unfamiliarity with the API.
   three 1mm chamfers meet. That is the same count the Fusion part carried, and it
   is what confirms the polish exclusions match.
 
+## Accepted
+
+Six faces under 1mm2, and all six are the corner triangles where three 1mm chamfers
+meet at a convex corner. That is the only tiny face the doctrine allows. A seventh
+means the polish pass has started cutting something it should not.
+
+```toml
+[accepted]
+sliver = 6
+```
+
 ## Don't
 
 - **Don't chamfer the channel mouths.** The 1.5mm lead-in was retired on 2026-07-22

--- a/examples/notch/parts/hook_scissors.md
+++ b/examples/notch/parts/hook_scissors.md
@@ -38,12 +38,17 @@ Six faces under 1mm2, and all six are the corner triangles where three 1mm chamf
 meet at a convex corner. That is the only tiny face the doctrine allows. A seventh
 means the polish pass has started cutting something it should not.
 
+The thinnest section is 1.0mm, behind the detent dimple: 6mm slab less the 4.2mm
+channel less the 0.8mm dimple. It is a consequence of the fit geometry rather than
+a choice, and it prints.
+
 ```toml
+[part]
+min_wall = 1.0
+forward = [-1, 0, 0]
+
 [accepted]
 sliver = 6
-
-[part]
-forward = [-1, 0, 0]
 ```
 
 ## Don't

--- a/examples/notch/parts/hook_scissors.md
+++ b/examples/notch/parts/hook_scissors.md
@@ -1,0 +1,54 @@
+# hook_scissors
+
+Ported from Fusion `Hook - Scissors - 1x` v4.
+
+## What it is
+
+Single-channel J-hook for hanging scissors by their finger holes. A 6mm arm projects
+28mm forward at the bottom of the slab with a 15mm upstand at the far end; the
+scissors drop into the cradle the two of them make.
+
+It is also the simple case in this library. The gridfinity shelf is the part that
+tests the kernel; this one exists so that a failure over there is unambiguously a
+kernel problem and not unfamiliarity with the API.
+
+## Design notes
+
+- Bottom-weighted: the arm and upstand sit on the floor of the slab, so the load
+  hangs under the channel stop rather than levering against it.
+- 30mm slab is the light-part default: 28mm for full bracket engagement plus 2mm
+  spare. The 0.93:1 projection-to-height ratio is inside the no-gusset band.
+- The J is drawn once as a section on `Plane.XZ` and swept. The Fusion original built
+  it as two extrusions plus a chamfer feature; one polygon says the same thing and
+  keeps the arm and upstand in one solid, so their junction is an interior edge.
+- Structural chamfers are 3mm at the two concave junctions the load runs through.
+  The arm-to-slab pair comes from `new_edges`, which reports exactly what the fuse
+  created, so it stays correct when `bracket_count` moves.
+- The cosmetic pass is 1mm on everything `polish_edges` allows, minus the edges the
+  structural pass just made.
+- Verified: channel floor at x=-4.2, y-center exactly 0, floor span the full 21.56mm.
+  Flexes 1 -> 2 -> 3 -> 1 with the floors landing on exact pitch every time.
+- Sliver baseline is 6 faces at 0.866mm², all of them the corner triangles where
+  three 1mm chamfers meet. That is the same count the Fusion part carried, and it
+  is what confirms the polish exclusions match.
+
+## Don't
+
+- **Don't chamfer the channel mouths.** The 1.5mm lead-in was retired on 2026-07-22
+  because it made tiny compound facets that print badly on other people's machines.
+  `polish_edges` already excludes them; do not add them back.
+- **Don't run a feature's back face behind x=-4.2.** It fills the dovetail and the
+  part will not go on the wall. `MERGE_X` is the constant to use.
+- **Don't chamfer the detent dimple.** Its walls are 0.8mm, so a 1mm chamfer fails
+  outright, and it is fit geometry regardless.
+- **Don't lengthen the slab to fix a projection ratio without checking it first.**
+  v1 was 45mm and got cut to 30mm for looking wrong on a small hook.
+
+## Changelog
+
+- 2026-07-26: channel clearance 0.5 -> 0.3mm per side, from a printed calibration
+  ladder. The first nurb print of this hook was loose side to side, and being a 1x it
+  has only one channel constraining yaw. Geometry is otherwise untouched: same
+  bounding box, same 6 slivers.
+- 2026-07-25: ported to nurb. Geometry matches the Fusion v4 bounding box exactly
+  (34 x 25.16 x 30mm) and the sliver baseline is unchanged at 6.

--- a/examples/notch/parts/hook_scissors.md
+++ b/examples/notch/parts/hook_scissors.md
@@ -41,6 +41,9 @@ means the polish pass has started cutting something it should not.
 ```toml
 [accepted]
 sliver = 6
+
+[part]
+forward = [-1, 0, 0]
 ```
 
 ## Don't

--- a/examples/notch/parts/hook_scissors.py
+++ b/examples/notch/parts/hook_scissors.py
@@ -1,0 +1,78 @@
+"""Hook - Scissors - 1x. Read hook_scissors.md before changing anything."""
+
+from nurb import *
+
+from system import (
+    BLOCK_WIDTH,
+    EPS,
+    MERGE_X,
+    MIN_ITEM_DEPTH,
+    channels,
+    detent_dimples,
+    polish_edges,
+    span,
+)
+
+
+@part
+def hook_scissors(
+    bracket_count=1,
+    item_height=30,
+    item_depth=6,
+    hook_projection=28,
+    hook_width=15,
+    arm_thickness=6,
+    upstand_height=15,
+    upstand_thickness=6,
+    chamfer_size=1,
+    structural_chamfer=3,
+    draft=False,
+):
+    if item_depth <= MIN_ITEM_DEPTH:
+        raise ValueError(
+            f"item_depth {item_depth} leaves no material behind the channel floor, so the "
+            f"arm would not reach the slab. Raise it above {MIN_ITEM_DEPTH}."
+        )
+
+    y0, y1 = -BLOCK_WIDTH / 2, (bracket_count - 0.5) * BLOCK_WIDTH
+    slab = Pos(-item_depth / 2, (y0 + y1) / 2, -item_height / 2) * Box(
+        item_depth, y1 - y0, item_height
+    )
+    back = slab - channels(bracket_count, item_height) - detent_dimples(bracket_count)
+
+    # The J, drawn once in section and swept across. Bottom-weighted: the arm and
+    # its upstand sit on the floor of the slab, so the load hangs under the stop.
+    floor = -item_height
+    arm_top = floor + arm_thickness
+    tip = -(item_depth + hook_projection)
+    inner = tip + upstand_thickness
+    crest = arm_top + upstand_height
+    section = Plane.XZ * Polygon(
+        (MERGE_X, floor),
+        (tip, floor),
+        (tip, crest),
+        (inner, crest),
+        (inner, arm_top),
+        (MERGE_X, arm_top),
+        align=None,
+    )
+    arm = Pos(0, span(bracket_count), 0) * extrude(section, hook_width / 2, both=True)
+
+    body = arm + back
+    pristine = body
+
+    # Structural, 3mm: the two concave junctions the load runs through. `new_edges`
+    # gives the arm-to-slab weld exactly, which no geometric selector does once a
+    # chamfer has already moved the topology around.
+    junction = [e for e in new_edges(back, arm, combined=body) if e.center().Z > floor + EPS]
+    corner = body.edges().filter_by(Axis.Y).filter_by(
+        lambda e: abs(e.center().X - inner) < EPS and abs(e.center().Z - arm_top) < EPS
+    )
+    body = chamfer(junction + list(corner), structural_chamfer)
+    if draft:
+        return body
+
+    # Cosmetic, 1mm: everything exposed except the structural chamfers we just made
+    # and the faces they landed on, which are concave and would sliver.
+    polish = polish_edges(body, item_height) - new_edges(pristine, combined=body)
+    return chamfer(polish, chamfer_size)

--- a/examples/notch/parts/shelf_gridfinity.md
+++ b/examples/notch/parts/shelf_gridfinity.md
@@ -39,6 +39,18 @@ sockets, a grid array, two gussets, two chamfer passes, and a known sliver basel
 - Verified: channel floors at x=-4.2 with y-centers exactly 0, 25.16, 50.32, 75.48,
   every floor the full 21.56mm span. Flexes 4 -> 6 -> 4 with the baseline unchanged.
 
+## Accepted
+
+Eighteen faces under 1mm2 at the default 2x2: sixteen recess corners at 0.632mm2,
+which are gridfinity spec geometry and come four to a cell, plus two three-chamfer
+corner triangles at 0.866mm2. It generalizes as `4 * grid_x * grid_y + 2`, so a
+different grid wants a different number here. A nineteenth at 2x2 is a regression.
+
+```toml
+[accepted]
+sliver = 18
+```
+
 ## Don't
 
 - **Don't set `gusset_drop` to 2mm.** Fusion needed exactly 2mm to keep the gusset peak

--- a/examples/notch/parts/shelf_gridfinity.md
+++ b/examples/notch/parts/shelf_gridfinity.md
@@ -1,0 +1,76 @@
+# shelf_gridfinity
+
+Ported from Fusion `Shelf - Gridfinity 2x2 - 4x` v4.
+
+## What it is
+
+A bracket-mount shelf whose platform is a spec-true gridfinity baseplate, `grid_x` by
+`grid_y` sockets, 2x2 by default. Any standard gridfinity bin drops in and is located
+by the spec's z-profile. The anti-lift detent is what keeps the shelf on the wall when
+a bin is pulled straight up.
+
+This is the hardest part in the library and the reason Phase 1 exists: four lofted
+sockets, a grid array, two gussets, two chamfer passes, and a known sliver baseline.
+
+## Design notes
+
+- **Socket geometry is the gridfinity spec.** Per cell, cut down from the platform
+  top: mouth 42.0 r4 -> 45 degree band 2.15 -> vertical 1.8 at 37.7 r1.85 -> 45 degree
+  band 0.7 -> floor 36.3 r1.15 -> 0.35 clearance recess, 5.0mm total. Bins seat on the
+  two bands with 0.25mm/side clearance and must never bottom out, so the recess is
+  required rather than optional. Verified against gridfinity-rebuilt-openscad.
+- Built as a single 5-section `loft(ruled=True)` rather than Fusion's four features.
+  The widths and radii fall out of the two chamfer depths, so the 45 degree bands are
+  exact by construction instead of by dimension.
+- `GridLocations` replaces `SocketArray` outright. No pattern feature, no instance
+  counting, no seed-inclusion trap.
+- `shelf_thickness` 7mm = 5mm pocket + 2mm floor. That is the floor of the parameter:
+  below it the pocket floor goes under 2mm and gets drummy under load.
+- `back_gap` 4mm stands the grid off the slab. It is bin insertion clearance and it is
+  the land the 3mm structural chamfer needs, whose forward leg takes 3 of those 4mm.
+- Gussets double as side cheeks, so `platform_width = grid + 2 x gusset_thickness`.
+  Their inner faces are flush with the outer cells' mouths.
+- **Front and outer mouth rims are sharp 45 degree knife edges** flush with the
+  platform edge, exactly like a real baseplate. They are left out of the cosmetic pass
+  on purpose, not by oversight.
+- Sliver baseline is 18 faces: 16 recess-corner segments at 0.632mm² (spec geometry,
+  four per cell) plus 2 three-chamfer corner triangles at 0.866mm². It generalizes as
+  `4 * grid_x * grid_y + 2`, confirmed at 1x2, 2x2, 2x3 and 3x2.
+- Verified: channel floors at x=-4.2 with y-centers exactly 0, 25.16, 50.32, 75.48,
+  every floor the full 21.56mm span. Flexes 4 -> 6 -> 4 with the baseline unchanged.
+
+## Don't
+
+- **Don't set `gusset_drop` to 2mm.** Fusion needed exactly 2mm to keep the gusset peak
+  off the slab-top chamfer boundary, and OCCT needs more: the peak and the slab top
+  both get a 1mm chamfer, and if the two bands meet the kernel cannot build the corner
+  and raises "BRep_API: command not done". The rule is that `gusset_drop` must clear
+  twice `chamfer_size`. 3mm leaves a millimeter of clean face.
+- **Don't run a grid wider than the slab.** Two polished edges need more than twice
+  the chamfer between them, which is where the pairings come from: grid_x 1 needs 3
+  brackets, 2 needs 4, 3 needs 6. The part raises a `ValueError` saying so rather than
+  failing in the chamfer.
+- **Don't read that one guard as general cover.** It checks the grid against the slab
+  and nothing else, and there are four more places on this part where the same
+  clearance rule bites, each one notch from a default: `chamfer_size` 1.5 (collides
+  with both `gusset_drop` and `gusset_thickness`), `back_gap` 3 or less and
+  `structural_chamfer` 4 or more (the structural band runs into the first socket
+  mouth at x=-10), and `gusset_thickness` 2. All four fail with the bare OCCT message.
+  They are not guarded on purpose, since four more checks would cost more than they
+  return, but do the arithmetic before you move any of them.
+- **Don't chamfer anything in the socket band or along the gusset-platform junction.**
+  The rims are meant to be sharp and the junctions are concave.
+- **Don't add a `gusset_count`.** The Fusion part carries one because the shelf family
+  shares a template, but here the gussets are the side cheeks. A third one lands in
+  the middle of a cell and blocks a bin.
+- **Don't raise `grid_y` past 2 without raising `item_height`.** At grid_y 3 the
+  projection is 136mm, a ratio of 3.2 at item_height 42. About 55mm brings it back
+  under 2.5.
+- **Don't add magnet holes** unless a print asks for it. Bins sit in the sockets and
+  the detent handles anti-lift.
+
+## Changelog
+
+- 2026-07-25: ported to nurb. Bounding box matches the Fusion v4 exactly
+  (94 x 100.64 x 42mm) and the 18-face sliver baseline reproduces. `gusset_drop`
+  raised 2 -> 3mm for OCCT; see Don't.

--- a/examples/notch/parts/shelf_gridfinity.md
+++ b/examples/notch/parts/shelf_gridfinity.md
@@ -46,12 +46,18 @@ which are gridfinity spec geometry and come four to a cell, plus two three-chamf
 corner triangles at 0.866mm2. It generalizes as `4 * grid_x * grid_y + 2`, so a
 different grid wants a different number here. A nineteenth at 2x2 is a regression.
 
+The thinnest section the ray cast finds is 0.76mm, at the front mouth rim. That
+is a knife edge flush with the platform edge, which is gridfinity spec and
+deliberate, and any straight line across the tip of a wedge is short. The real
+wall behind the detent is 1.0mm.
+
 ```toml
+[part]
+min_wall = 0.7
+forward = [-1, 0, 0]
+
 [accepted]
 sliver = 18
-
-[part]
-forward = [-1, 0, 0]
 ```
 
 ## Don't

--- a/examples/notch/parts/shelf_gridfinity.md
+++ b/examples/notch/parts/shelf_gridfinity.md
@@ -75,6 +75,12 @@ forward = [-1, 0, 0]
   return, but do the arithmetic before you move any of them.
 - **Don't chamfer anything in the socket band or along the gusset-platform junction.**
   The rims are meant to be sharp and the junctions are concave.
+- **Don't polish a concave edge anywhere.** The gusset roots, where each fin meets the
+  slab face, are inside corners, and the first version of this part put a 1mm chamfer
+  on all four. `polish_edges` vetoes concave edges now and `nurb check` has a rule for
+  it, but the reason it survived a review is worth knowing: it is invisible in code.
+  The selector read as an ordinary exposed-edge query and the part built, exported and
+  printed without complaint.
 - **Don't add a `gusset_count`.** The Fusion part carries one because the shelf family
   shares a template, but here the gussets are the side cheeks. A third one lands in
   the middle of a cell and blocks a bin.
@@ -86,6 +92,10 @@ forward = [-1, 0, 0]
 
 ## Changelog
 
+- 2026-07-26: four 1mm chamfers removed from the gusset roots. They were concave
+  junctions, which the doctrine forbids polishing, and `nurb check`'s new
+  `concave_cosmetic` rule found them in the shipped part. Bounding box, solid count
+  and the 18-face sliver baseline are all unchanged.
 - 2026-07-25: ported to nurb. Bounding box matches the Fusion v4 exactly
   (94 x 100.64 x 42mm) and the 18-face sliver baseline reproduces. `gusset_drop`
   raised 2 -> 3mm for OCCT; see Don't.

--- a/examples/notch/parts/shelf_gridfinity.md
+++ b/examples/notch/parts/shelf_gridfinity.md
@@ -49,6 +49,9 @@ different grid wants a different number here. A nineteenth at 2x2 is a regressio
 ```toml
 [accepted]
 sliver = 18
+
+[part]
+forward = [-1, 0, 0]
 ```
 
 ## Don't

--- a/examples/notch/parts/shelf_gridfinity.py
+++ b/examples/notch/parts/shelf_gridfinity.py
@@ -1,0 +1,146 @@
+"""Shelf - Gridfinity 2x2 - 4x. Read shelf_gridfinity.md before changing anything."""
+
+from math import floor
+
+from nurb import *
+
+from system import (
+    BLOCK_WIDTH,
+    EPS,
+    MERGE_X,
+    MIN_ITEM_DEPTH,
+    channels,
+    detent_dimples,
+    polish_edges,
+    span,
+)
+
+# The gridfinity baseplate socket, cut down from the platform top. Verified against
+# gridfinity-rebuilt-openscad and gridfinity.xyz. Do not tweak these: a bin seats on
+# the two 45 degree bands, and the recess at the bottom is what stops it bottoming
+# out on the floor before the bands take it.
+MOUTH_CHAMFER = 2.15
+WALL = 1.80
+THROAT_CHAMFER = 0.70
+RECESS = 0.35
+MOUTH_RADIUS = 4.00
+SOCKET_DEPTH = MOUTH_CHAMFER + WALL + THROAT_CHAMFER + RECESS  # 5.0
+
+
+def socket(cell):
+    """One gridfinity pocket, mouth at z=0, opening downward."""
+    rings = [
+        (0.0, cell, MOUTH_RADIUS),
+        (MOUTH_CHAMFER, cell - 2 * MOUTH_CHAMFER, MOUTH_RADIUS - MOUTH_CHAMFER),
+        (MOUTH_CHAMFER + WALL, cell - 2 * MOUTH_CHAMFER, MOUTH_RADIUS - MOUTH_CHAMFER),
+        (SOCKET_DEPTH - RECESS, cell - 2 * (MOUTH_CHAMFER + THROAT_CHAMFER),
+         MOUTH_RADIUS - MOUTH_CHAMFER - THROAT_CHAMFER),
+        (SOCKET_DEPTH, cell - 2 * (MOUTH_CHAMFER + THROAT_CHAMFER),
+         MOUTH_RADIUS - MOUTH_CHAMFER - THROAT_CHAMFER),
+    ]
+    return loft(
+        [Pos(0, 0, -down) * RectangleRounded(w, w, r) for down, w, r in rings],
+        ruled=True,
+    )
+
+
+@part
+def shelf_gridfinity(
+    bracket_count=4,
+    item_height=42,
+    item_depth=6,
+    grid_x=2,
+    grid_y=2,
+    cell=42,
+    shelf_thickness=7,
+    back_gap=4,
+    gusset_thickness=3,
+    gusset_tip=6,
+    gusset_drop=3,
+    chamfer_size=1,
+    structural_chamfer=3,
+    draft=False,
+):
+    if item_depth <= MIN_ITEM_DEPTH:
+        raise ValueError(
+            f"item_depth {item_depth} leaves no material behind the channel floor, so the "
+            f"platform would not reach the slab. Raise it above {MIN_ITEM_DEPTH}."
+        )
+
+    # The slab has to stand wider than the platform, with room to spare: two polished
+    # edges closer together than twice the chamfer leave the kernel no corner to
+    # build. Same arithmetic as `gusset_drop`, and the reason the grid sizes pair with
+    # bracket counts the way they do (1 -> 3, 2 -> 4, 3 -> 6).
+    #
+    # floor + 1 rather than ceil: the rule needs strictly more room than the chamfers
+    # take, so a width that divides exactly still needs the next bracket.
+    width = grid_x * cell + 2 * gusset_thickness
+    need = floor((width + 4 * chamfer_size) / BLOCK_WIDTH) + 1
+    if bracket_count < need:
+        raise ValueError(
+            f"a {grid_x}-wide grid is {width:.0f}mm across, so it needs {need} brackets, "
+            f"not {bracket_count}. Raise bracket_count to {need}, or drop grid_x."
+        )
+
+    y0, y1 = -BLOCK_WIDTH / 2, (bracket_count - 0.5) * BLOCK_WIDTH
+    slab = Pos(-item_depth / 2, (y0 + y1) / 2, -item_height / 2) * Box(
+        item_depth, y1 - y0, item_height
+    )
+    back = slab - channels(bracket_count, item_height) - detent_dimples(bracket_count)
+
+    # Everything forward hangs off the bracket run's midpoint, not off y=0, so the
+    # load stays balanced between the brackets.
+    mid = span(bracket_count)
+    top = -item_height + shelf_thickness
+    front = -(item_depth + back_gap + grid_y * cell)
+
+    platform = Pos((MERGE_X + front) / 2, mid, top - shelf_thickness / 2) * Box(
+        MERGE_X - front, width, shelf_thickness
+    )
+    grid = Pos(-(item_depth + back_gap) - grid_y * cell / 2, mid, top)
+    platform -= Part() + [
+        grid * place * socket(cell) for place in GridLocations(cell, cell, grid_y, grid_x)
+    ]
+
+    # Gussets, which are also the side cheeks. Truncated at the tip rather than run
+    # out to a point: a knife edge there is a sliver, and the last few millimeters of
+    # a triangle carry no load anyway.
+    #
+    # `gusset_drop` has to clear twice `chamfer_size`. The peak and the slab top both
+    # get polished, and if their chamfer bands meet the kernel cannot build the
+    # corner. Fusion failed in the same place with ASM_BL_NO_MATE; OCCT raises
+    # "BRep_API: command not done" and needs a little more room than Fusion did.
+    section = Plane.XZ * Polygon(
+        (MERGE_X, top),
+        (-(item_depth + grid_y * cell / 2), top),
+        (-(item_depth + grid_y * cell / 2), top + gusset_tip),
+        (-item_depth, -gusset_drop),
+        (MERGE_X, -gusset_drop),
+        align=None,
+    )
+    cheek = extrude(section, gusset_thickness / 2, both=True)
+    reach = (width - gusset_thickness) / 2
+    shelf = platform + Part() + [Pos(0, mid + s * reach, 0) * cheek for s in (-1, 1)]
+
+    body = back + shelf
+    pristine = body
+
+    # Structural, 3mm: only where the platform lands on the slab. The gusset roots
+    # are concave too, but a gusset is 3mm thick, so a 3mm chamfer would eat it.
+    junction = [
+        e for e in new_edges(back, shelf, combined=body)
+        if abs(e.bounding_box().min.Z - top) < EPS and abs(e.bounding_box().max.Z - top) < EPS
+    ]
+    body = chamfer(junction, structural_chamfer)
+    if draft:
+        return body
+
+    # Cosmetic, 1mm. On top of the standing vetoes: nothing in the socket band. The
+    # mouth rims are spec geometry and read as a real baseplate precisely because
+    # they stay knife sharp, and the gusset roots live in that plane too.
+    def in_sockets(edge):
+        bb = edge.bounding_box()
+        return bb.max.Z < top + EPS and bb.min.Z > top - SOCKET_DEPTH - EPS
+
+    polish = polish_edges(body, item_height).filter_by(lambda e: not in_sockets(e))
+    return chamfer(polish - new_edges(pristine, combined=body), chamfer_size)

--- a/examples/notch/system.py
+++ b/examples/notch/system.py
@@ -1,0 +1,153 @@
+"""Notch: the constants and shared geometry every part in this library hangs on.
+
+Notch parts mount on Wall Control pegboard brackets. Every part carries the same
+dovetail channels in its back, so the channels live here and nowhere else. Sizing
+belongs to the parts.
+
+Datums. Land these three and the hanging interface is correct for free:
+
+    slab top face at z = 0, the part extends down
+    back face at x = 0, the part extends forward in -x
+    first channel centered on y = 0, the rest march +y on BLOCK_WIDTH pitch
+"""
+
+from build123d import Box, Part, Polygon, Pos, extrude
+
+# --- measured hardware -------------------------------------------------------
+
+BLOCK_WIDTH = 25.16    # bracket pitch on-center, measured off a real wall
+BRACKET_HEIGHT = 25.0  # physical bracket height, drives the minimum slab
+PITCH_SLOP = 0.12      # per-interval scatter allowance across a run of brackets
+
+POCKET_WIDTH = 20.56       # bracket plate width where it meets the part
+POCKET_NECK_WIDTH = 12.16  # dovetail opening at the back face
+POCKET_DEPTH = 4.0         # plate thickness
+
+# --- fit ---------------------------------------------------------------------
+
+TOP_MARGIN = 3.0  # solid material above the channel ceiling: this is the stop
+MIN_ITEM_HEIGHT = BRACKET_HEIGHT + TOP_MARGIN  # 28mm for full engagement
+
+CLEARANCE = 0.2        # slide fit, depth
+SIDE_CLEARANCE = 0.25  # slide fit, width
+
+# 0.25 is the middle of the window, not a preference. 0.20 printed too tight to seat
+# and 0.30 slid on loosely, so the whole usable band is about 0.1mm wide -- the same
+# order as FDM extrusion variation. Sitting in the middle is what leaves margin when a
+# print drifts either way, and it is why chasing a finer number is not worth a plate:
+# the printer moves further than the increment would.
+
+# One clearance, every channel, every part. Printed runs of 2, 4 and 6 brackets all
+# slid on at the same fit, so a real wall's pitch does not need compensating for and a
+# longer run costs nothing. PITCH_SLOP above is what an allowance would have been built
+# from; it stays in the table as measured hardware data, but nothing spends it.
+#
+# Getting here took three wrong versions, all of them variations on giving later
+# channels more room: relief accumulating per channel, then relief capped, then a
+# clearance that scaled with run length. The first printed looser at the far end of a
+# 4x than anything the library ever shipped. All three solved a problem the wall does
+# not have.
+
+# The channel is the pocket plus clearance. Its walls come out at exactly 45
+# degrees, which is what lets the dovetail print with no support:
+# CHANNEL_NECK == CHANNEL_WIDTH - 2 * CHANNEL_DEPTH. Side clearance drops out of that
+# identity, so widening it keeps the 45; depth clearance does not, so 0.2 is pinned.
+CHANNEL_DEPTH = POCKET_DEPTH + CLEARANCE               # 4.2, the floor plane
+CHANNEL_WIDTH = POCKET_WIDTH + 2 * SIDE_CLEARANCE      # 21.16 at channel 0's floor
+CHANNEL_NECK = POCKET_NECK_WIDTH + 2 * SIDE_CLEARANCE  # 12.76 at channel 0's mouth
+
+FLOOR_X = -CHANNEL_DEPTH  # -4.2, the coordinate every fit check is written against
+
+# Where a forward feature stops when it reaches back into the slab. It has to
+# overlap solid material to merge cleanly, and it has to stay clear of the channel
+# floor or it fills the dovetail and the part will not go on the wall.
+MERGE_X = FLOOR_X - 1.0
+
+# A slab thinner than this has no material at MERGE_X at all, so a forward feature
+# lands in front of it and never touches. That builds and exports without complaint,
+# in two loose pieces, so parts check it.
+MIN_ITEM_DEPTH = -MERGE_X
+
+# Anti-lift detent. Gravity-drop dovetails resist pulling a part off the wall but
+# nothing resists pulling it up, so the shared bracket plate carries a ramped nub
+# and every channel floor carries this dimple. Slide down and it clicks in; pull
+# up and the nub has to climb out.
+DETENT_Z = -10.0
+DETENT_WIDTH = 6.0
+DETENT_HEIGHT = 5.0
+DETENT_DEPTH = 0.8
+
+OVERSHOOT = 1.0  # cuts run past the bottom face; coincident faces make brittle booleans
+EPS = 1e-4       # slack for "is this coordinate on that plane"
+
+
+def pitch(count, step=1):
+    """Y centers of the channels, which is also where anything bracket-aligned goes."""
+    return [k * step * BLOCK_WIDTH for k in range(count)]
+
+
+def span(count, step=1):
+    """Y midpoint of the bracket run. Loads hang balanced when they center here."""
+    return (count - 1) * step * BLOCK_WIDTH / 2
+
+
+def channels(count, height, step=1, side_clearance=SIDE_CLEARANCE):
+    """The dovetail negative. Subtract it from a slab.
+
+    `height` is the slab height, so the cut can run out through the bottom face.
+    Fusion needed a fixed 16-lobe comb here because its combine tool lists never
+    pick up new pattern instances. In code it is a loop.
+
+    `side_clearance` is here so a part can be built at a fit other than the shipped
+    one, which is what the calibration coupon does. Widening moves both walls equally,
+    so they stay at 45 degrees whatever you pass.
+    """
+    width = POCKET_WIDTH + 2 * side_clearance
+    neck = POCKET_NECK_WIDTH + 2 * side_clearance
+    profile = Polygon(
+        (0, neck / 2),
+        (FLOOR_X, width / 2),
+        (FLOOR_X, -width / 2),
+        (0, -neck / 2),
+        align=None,
+    )
+    one = Pos(0, 0, -TOP_MARGIN) * extrude(profile, -(height - TOP_MARGIN + OVERSHOOT))
+    return Part() + [Pos(0, y, 0) * one for y in pitch(count, step)]
+
+
+def polish_edges(shape, height):
+    """Every edge the cosmetic pass is allowed to touch.
+
+    Three standing vetoes, all of them Notch rather than taste: the back face sits
+    flat against the wall, the bottom face is the first layer, and the channels are
+    the fit. What is excluded is an edge *lying in* one of those, not one that
+    merely ends there, so the vertical corners still get polished. Parts subtract
+    their own exclusions (structural chamfers, sockets) from what comes back.
+
+    The channel veto runs a detent deep, since the dimple is fit too. It is also
+    where a 1mm chamfer fails outright: the dimple walls are 0.8mm.
+    """
+    interface = FLOOR_X - DETENT_DEPTH
+
+    def allowed(edge):
+        bb = edge.bounding_box()
+        if bb.min.X > -EPS:  # in the back face
+            return False
+        if bb.max.Z < -height + EPS:  # in the bottom face
+            return False
+        if bb.min.X > interface - EPS and bb.max.Z < -TOP_MARGIN + EPS:  # in a channel
+            return False
+        return True
+
+    return shape.edges().filter_by(allowed)
+
+
+def detent_dimples(count, step=1):
+    """The mating half of the anti-lift detent, one per channel floor.
+
+    Separate from `channels` so a part that should lift off freely can leave it out.
+    """
+    one = Pos(FLOOR_X - DETENT_DEPTH / 2, 0, DETENT_Z) * Box(
+        DETENT_DEPTH, DETENT_WIDTH, DETENT_HEIGHT
+    )
+    return Part() + [Pos(0, y, 0) * one for y in pitch(count, step)]

--- a/examples/notch/system.py
+++ b/examples/notch/system.py
@@ -13,6 +13,8 @@ Datums. Land these three and the hanging interface is correct for free:
 
 from build123d import Box, Part, Polygon, Pos, extrude
 
+from nurb import concave_edges
+
 # --- measured hardware -------------------------------------------------------
 
 BLOCK_WIDTH = 25.16    # bracket pitch on-center, measured off a real wall
@@ -118,18 +120,27 @@ def channels(count, height, step=1, side_clearance=SIDE_CLEARANCE):
 def polish_edges(shape, height):
     """Every edge the cosmetic pass is allowed to touch.
 
-    Three standing vetoes, all of them Notch rather than taste: the back face sits
-    flat against the wall, the bottom face is the first layer, and the channels are
-    the fit. What is excluded is an edge *lying in* one of those, not one that
-    merely ends there, so the vertical corners still get polished. Parts subtract
-    their own exclusions (structural chamfers, sockets) from what comes back.
+    Four standing vetoes. Three are Notch rather than taste: the back face sits flat
+    against the wall, the bottom face is the first layer, and the channels are the fit.
+    What is excluded is an edge *lying in* one of those, not one that merely ends
+    there, so the vertical corners still get polished. Parts subtract their own
+    exclusions (structural chamfers, sockets) from what comes back.
+
+    The fourth is general, and it is the one that is invisible in code: a cosmetic
+    chamfer belongs on a convex edge. Run over a concave one it adds a feather wedge
+    into an inside corner rather than taking a sharp edge off. This veto was missing
+    until `nurb check` grew the rule and found four of them on the shelf, at the gusset
+    roots, in a part that had already shipped.
 
     The channel veto runs a detent deep, since the dimple is fit too. It is also
     where a 1mm chamfer fails outright: the dimple walls are 0.8mm.
     """
     interface = FLOOR_X - DETENT_DEPTH
+    inside = set(concave_edges(shape))
 
     def allowed(edge):
+        if edge in inside:  # concave, so polish would wedge into the corner
+            return False
         bb = edge.bounding_box()
         if bb.min.X > -EPS:  # in the back face
             return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
     "websockets>=16.1.1",
 ]
 
+[dependency-groups]
+dev = ["pytest>=8.0"]
+
 [project.scripts]
 nurb = "nurb.cli:main"
 

--- a/src/nurb/__init__.py
+++ b/src/nurb/__init__.py
@@ -12,8 +12,16 @@ A part file needs one import:
 import build123d as _b3d
 from build123d import *  # noqa: F401,F403  -- geometry vocabulary
 
+from .checks import concave_edges, is_convex  # noqa: E402
 from .registry import part  # noqa: E402  -- must win over any build123d name
 
-# `from nurb import *` hands a part file the whole build123d vocabulary plus @part.
-__all__ = [*getattr(_b3d, "__all__", [n for n in dir(_b3d) if not n.startswith("_")]), "part"]
+# `from nurb import *` hands a part file the whole build123d vocabulary, @part, and the
+# convexity test. That last one is here because a polish pass cannot be written without
+# it: chamfering an inside corner is the one polish mistake that looks fine in code.
+__all__ = [
+    *getattr(_b3d, "__all__", [n for n in dir(_b3d) if not n.startswith("_")]),
+    "part",
+    "is_convex",
+    "concave_edges",
+]
 __version__ = "0.1.0"

--- a/src/nurb/builder.py
+++ b/src/nurb/builder.py
@@ -13,9 +13,23 @@ class BuildError(Exception):
     pass
 
 
+def _in_project(module, root):
+    """A module the project owns, as opposed to one installed into its venv.
+
+    The venv usually sits inside the project, so location alone would call every
+    installed package a project module and re-import it on every rebuild.
+    """
+    file = getattr(module, "__file__", None)
+    if not file:
+        return False
+    path = pathlib.Path(file)
+    return path.is_relative_to(root) and "site-packages" not in path.parts
+
+
 def load(path):
     """Import a part file fresh and return its @part function."""
-    path = pathlib.Path(path)
+    path = pathlib.Path(path).resolve()
+    root = path.parent.parent if path.parent.name == "parts" else path.parent
     modname = f"_nurb_part_{path.stem}_{time.time_ns()}"
     spec = importlib.util.spec_from_file_location(modname, path)
     if spec is None or spec.loader is None:
@@ -24,10 +38,18 @@ def load(path):
     sys.modules[modname] = mod
     written = sys.dont_write_bytecode
     sys.dont_write_bytecode = True  # keep __pycache__ out of the user's parts/
+    sys.path.insert(0, str(root))  # so a part can `from system import ...`
+    known = set(sys.modules)
     try:
         spec.loader.exec_module(mod)
     finally:
         sys.dont_write_bytecode = written
+        sys.path.remove(str(root))
+        # Forget the project's own modules, so editing a shared one lands on the
+        # next rebuild instead of the next restart.
+        for name in set(sys.modules) - known:
+            if _in_project(sys.modules[name], root):
+                del sys.modules[name]
         sys.modules.pop(modname, None)
 
     for value in vars(mod).values():

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -11,7 +11,7 @@ import pathlib
 from dataclasses import dataclass, field
 from math import asin, degrees
 
-from build123d import CenterOf, GeomType, Vector
+from build123d import Axis, CenterOf, GeomType, Vector
 
 FAIL = "fail"  # this will not print, or will not work
 WARN = "warn"  # this needs attention, most often support
@@ -48,6 +48,7 @@ class Context:
     forward: tuple | None = None  # which way a wall-mounted part cantilevers, if it does
     projection_limit: float = 2.5  # reach over height, past which height is the fix
     cosmetic_chamfer: float = 1.0  # the size the polish pass uses
+    min_wall: float = 1.0  # what this printer lays down reliably; per part, per card
     sliver_area: float = 1.0
     accepted: dict = field(default_factory=dict)  # rule -> how many are already known
 
@@ -511,3 +512,86 @@ def concave_cosmetic(shape, ctx):
                 )
             )
     return found
+
+
+def _probes(face, grid=2):
+    """Points across a face with the outward normal at each."""
+    spots = [face.center()]
+    if face.geom_type != GeomType.PLANE or face.area > 25:
+        # Inset from the boundary on purpose. A probe sitting on a face's own edge
+        # measures the distance to whatever is around the corner, which is not a wall.
+        for i in range(grid):
+            for j in range(grid):
+                try:
+                    spots.append(
+                        face.position_at((i + 1) / (grid + 1), (j + 1) / (grid + 1))
+                    )
+                except Exception:
+                    continue
+    out = []
+    for spot in spots:
+        try:
+            out.append((spot, face.normal_at(spot)))
+        except Exception:
+            continue
+    return out
+
+
+@rule("min_wall")
+def min_wall(shape, ctx):
+    """The thinnest section in the solid, by shooting inward and seeing what it hits.
+
+    This is a ray cast, not an inscribed sphere, and it is the weakest rule here. It is
+    exact on the flat parallel walls that make up most of a printed part. It is wrong in
+    two directions everywhere else, and both showed up on the first run against this
+    library:
+
+    - It reads a taper as a wall. The shelf's mouth rims are knife edges by design, and
+      near the tip of a wedge any straight line across it is short. 0.76mm there is a
+      true measurement of something that is not a wall.
+    - It reads a relief as a wall. The calibration coupon's raised label is 0.5mm proud,
+      and that is what the ray finds.
+
+    Neither is a defect and all three parts print. So the number a part is allowed lives
+    on its card next to the reason, and the default is what the printer manages rather
+    than what a textbook says. It also misses the case an inscribed sphere would catch,
+    a thin spot in an inside corner, where the smallest sphere that fits is smaller than
+    any straight line across. Treat a clean result as "no thin walls found", not as
+    "no thin walls".
+    """
+    thinnest, spot = None, None
+    for face in shape.faces():
+        if face.area < ctx.sliver_area:
+            continue  # a face this small has no wall to speak of
+        for point, normal in _probes(face):
+            inward = -normal
+            hits = shape.find_intersection_points(Axis(point + inward * PROBE, inward))
+            # Only count a surface the ray leaves through: its outward normal points
+            # along the way the ray is going. A hit facing back at the ray means the
+            # ray had already left the material and struck something across a gap,
+            # which is how a chamfer two corners away reads as a thin wall.
+            reach = [
+                (hit - point).length
+                for hit, hit_normal in hits
+                if (hit - point).dot(inward) > ctx.min_wall * 0.01
+                and hit_normal.dot(inward) > 0.3
+            ]
+            if not reach:
+                continue
+            near = min(reach)
+            if thinnest is None or near < thinnest:
+                thinnest, spot = near, point
+    # Slack, because a card declaring the value it measured should not then fail on
+    # the last bit of a float.
+    if thinnest is None or thinnest >= ctx.min_wall - 1e-3:
+        return []
+    return [
+        Finding(
+            "min_wall",
+            WARN,
+            f"{thinnest:.2f}mm section, under the {ctx.min_wall:.2f}mm this printer "
+            f"lays down reliably (ray cast, so corners may be thinner still)",
+            value=round(thinnest, 3),
+            where=tuple(round(v, 2) for v in spot),
+        )
+    ]

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -7,6 +7,7 @@ A rule takes the shape and a Context and yields Findings. Rules compose: they ne
 see each other, and `run` gathers them.
 """
 
+import pathlib
 from dataclasses import dataclass, field
 from math import asin, degrees
 
@@ -43,6 +44,7 @@ class Context:
     up: tuple = (0.0, 0.0, 1.0)
     overhang_limit: float = 45.0  # degrees away from the build direction
     bridge_limit: float = 30.0  # how far this printer will span unsupported
+    overhang_reach: float = 1.0  # a ledge shorter than this cannot droop enough to matter
     sliver_area: float = 1.0
     accepted: dict = field(default_factory=dict)  # rule -> how many are already known
 
@@ -223,6 +225,21 @@ def _span(shape, up):
     return min(reach), max(reach)
 
 
+def _reach(face, up):
+    """How far a face protrudes, which is the smallest of its horizontal extents.
+
+    What makes an unsupported ledge droop is how far out it goes, not how much of it
+    there is. A 0.5mm ledge prints cleanly at any length, which is why raised lettering
+    is not a hundred overhang failures.
+    """
+    across = [
+        _span(face, axis)[1] - _span(face, axis)[0]
+        for axis in (Vector(1, 0, 0), Vector(0, 1, 0), Vector(0, 0, 1))
+        if abs(axis.dot(up)) < 0.9
+    ]
+    return min(across) if across else 0.0
+
+
 def _bridged(solid, face, up, ctx):
     """The shortest span this face is supported across, or None if it is cantilevered.
 
@@ -276,6 +293,8 @@ def overhang(shape, ctx):
         crossing = _bridged(solid, face, up, ctx) if solid else None
         if crossing is not None and crossing <= ctx.bridge_limit:
             continue  # a bridge this printer walks across
+        if crossing is None and _reach(face, up) <= ctx.overhang_reach:
+            continue  # a ledge too shallow to droop, whatever its angle or length
         if crossing is not None:
             found.append(
                 Finding(
@@ -324,3 +343,44 @@ def stability(shape, ctx):
                 )
             ]
     return []
+
+
+# --- per part settings -------------------------------------------------------
+
+CARD_SETTINGS = "toml"  # the fence a card uses to carry them
+
+
+def from_card(part_path, base=None):
+    """Read a part's check settings out of its card.
+
+    The card is where a part records what it has already justified, so a known
+    finding stays silent and a new one is a regression. It lives with the design
+    notes rather than in a file of its own, because the number is only meaningful
+    next to the sentence explaining why it is allowed.
+
+    A card with no settings block is normal and means no findings are excused.
+    """
+    import tomllib
+
+    ctx = base or Context()
+    card = pathlib.Path(part_path).with_suffix(".md")
+    if not card.is_file():
+        return ctx
+    text = card.read_text()
+    opening = f"```{CARD_SETTINGS}"
+    if opening not in text:
+        return ctx
+    block = text.split(opening, 1)[1].split("```", 1)[0]
+    try:
+        settings = tomllib.loads(block)
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"{card.name}: settings block is not valid TOML ({exc})") from exc
+    ctx.accepted = {**ctx.accepted, **settings.get("accepted", {})}
+    for field_name, value in settings.get("printer", {}).items():
+        if not hasattr(ctx, field_name):
+            raise ValueError(
+                f"{card.name}: no printer setting called {field_name!r}. "
+                f"have: {', '.join(sorted(vars(Context())))}"
+            )
+        setattr(ctx, field_name, tuple(value) if isinstance(value, list) else value)
+    return ctx

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -45,6 +45,8 @@ class Context:
     overhang_limit: float = 45.0  # degrees away from the build direction
     bridge_limit: float = 30.0  # how far this printer will span unsupported
     overhang_reach: float = 1.0  # a ledge shorter than this cannot droop enough to matter
+    forward: tuple | None = None  # which way a wall-mounted part cantilevers, if it does
+    projection_limit: float = 2.5  # reach over height, past which height is the fix
     sliver_area: float = 1.0
     accepted: dict = field(default_factory=dict)  # rule -> how many are already known
 
@@ -376,7 +378,8 @@ def from_card(part_path, base=None):
     except tomllib.TOMLDecodeError as exc:
         raise ValueError(f"{card.name}: settings block is not valid TOML ({exc})") from exc
     ctx.accepted = {**ctx.accepted, **settings.get("accepted", {})}
-    for field_name, value in settings.get("printer", {}).items():
+    tunables = {**settings.get("printer", {}), **settings.get("part", {})}
+    for field_name, value in tunables.items():
         if not hasattr(ctx, field_name):
             raise ValueError(
                 f"{card.name}: no printer setting called {field_name!r}. "
@@ -384,3 +387,36 @@ def from_card(part_path, base=None):
             )
         setattr(ctx, field_name, tuple(value) if isinstance(value, list) else value)
     return ctx
+
+
+@rule("projection_ratio")
+def projection_ratio(shape, ctx):
+    """How far a wall-mounted part reaches out against how much wall it hangs on.
+
+    Past a point the fix is a taller back, not a bigger gusset: the load is levering
+    against the mount and no amount of bracing under the shelf changes that. Only
+    meaningful for something cantilevered off a wall, so a part opts in by saying
+    which way it reaches.
+    """
+    if ctx.forward is None:
+        return []
+    out = Vector(*ctx.forward).normalized()
+    up = Vector(*ctx.up).normalized()
+    low, high = _span(shape, out)
+    reach = high - low
+    floor, ceiling = _span(shape, up)
+    height = ceiling - floor
+    if height <= 0:
+        return []
+    ratio = reach / height
+    if ratio <= ctx.projection_limit:
+        return []
+    return [
+        Finding(
+            "projection_ratio",
+            WARN,
+            f"reaches {reach:.0f}mm on a {height:.0f}mm back, ratio {ratio:.2f}. "
+            f"past {ctx.projection_limit:.1f} the fix is a taller back, not more gusset",
+            value=round(ratio, 2),
+        )
+    ]

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -8,6 +8,9 @@ see each other, and `run` gathers them.
 """
 
 from dataclasses import dataclass, field
+from math import asin, degrees
+
+from build123d import CenterOf, GeomType, Vector
 
 FAIL = "fail"  # this will not print, or will not work
 WARN = "warn"  # this needs attention, most often support
@@ -171,3 +174,106 @@ def build_volume(shape, ctx):
             value=round(max(got), 1),
         )
     ]
+
+
+def _sample_normals(face, grid=5):
+    """Outward normals across a face.
+
+    A planar face has one and it is exact. A curved face does not, and the sampling
+    has to reach the ends of its parameter range: sampling cell midpoints instead
+    walks a cylinder round at 45, 135, 225 and 315 degrees and never once looks
+    straight down, which is the only normal an overhang check cares about. Endpoints
+    included, the same grid hits 270 exactly.
+
+    Still an approximation on a curved face, bounded by the grid spacing. Planar
+    faces, which is nearly all of this library, are exact.
+    """
+    if face.geom_type == GeomType.PLANE:
+        return [face.normal_at(face.center())]
+    out = []
+    for i in range(grid):
+        for j in range(grid):
+            try:
+                spot = face.position_at(i / (grid - 1), j / (grid - 1))
+                out.append(face.normal_at(spot))
+            except Exception:
+                continue
+    return out or [face.normal_at(face.center())]
+
+
+def _span(shape, up):
+    """How far a shape reaches along the build direction, as (lowest, highest).
+
+    Off the bounding box, not off the vertices. A curved face has vertices only where
+    its seam is, so a cylinder's lowest vertex sits at its middle: measuring from
+    vertices put the bed 8mm above the actual bottom of a cylinder, marked every face
+    grounded, and turned the overhang rule off without any sign that it had happened.
+
+    Exact for an axis-aligned build direction, which is what a part placed on a bed
+    has. Conservative otherwise.
+    """
+    box = shape.bounding_box()
+    corners = [
+        Vector(x, y, z)
+        for x in (box.min.X, box.max.X)
+        for y in (box.min.Y, box.max.Y)
+        for z in (box.min.Z, box.max.Z)
+    ]
+    reach = [c.dot(up) for c in corners]
+    return min(reach), max(reach)
+
+
+@rule("overhang")
+def overhang(shape, ctx):
+    """Downward faces steeper than the printer will bridge.
+
+    Angle is measured from the build direction, so a vertical wall is 0 and a flat
+    ceiling is 90. Faces sitting on the bed are skipped: they are the first layer,
+    not an overhang.
+    """
+    up = Vector(*ctx.up).normalized()
+    bed, _ = _span(shape, up)
+    found = []
+    for face in shape.faces():
+        if _span(face, up)[1] <= bed + 1e-4:
+            continue  # grounded, so it is the first layer rather than an overhang
+        worst = max(
+            degrees(asin(max(-1.0, min(1.0, -n.dot(up))))) for n in _sample_normals(face)
+        )
+        if worst > ctx.overhang_limit + 1e-6:
+            found.append(
+                Finding(
+                    "overhang",
+                    WARN if worst < 90 else FAIL,
+                    f"{worst:.0f}deg overhang over {face.area:.1f}mm2, "
+                    f"limit {ctx.overhang_limit:.0f}deg",
+                    value=round(worst, 1),
+                    where=tuple(round(v, 2) for v in face.center()),
+                )
+            )
+    return found
+
+
+@rule("stability")
+def stability(shape, ctx):
+    """Will it stand on the bed, or tip while printing."""
+    up = Vector(*ctx.up).normalized()
+    bed, _ = _span(shape, up)
+    footing = [f for f in shape.faces() if _span(f, up)[1] <= bed + 1e-4]
+    if not footing:
+        return [Finding("stability", FAIL, "nothing flat to stand on")]
+    com = shape.center(CenterOf.MASS)
+    axes = [a for a in (Vector(1, 0, 0), Vector(0, 1, 0), Vector(0, 0, 1)) if abs(a.dot(up)) < 0.9]
+    for axis in axes:
+        reach = [end for f in footing for end in _span(f, axis)]
+        here = com.dot(axis)
+        if not min(reach) <= here <= max(reach):
+            return [
+                Finding(
+                    "stability",
+                    WARN,
+                    "center of mass falls outside the footprint, it will tip",
+                    where=tuple(round(v, 2) for v in com),
+                )
+            ]
+    return []

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -33,16 +33,16 @@ class Finding:
 class Context:
     """What a rule needs to know beyond the geometry itself.
 
-    `up` is the build direction, and it is not the model's z. A part is modelled on
-    whatever datums make its function readable and printed on whatever face keeps it
-    off supports, and those are rarely the same. Notch parts hang from a slab top at
-    z=0 and print on their backs, so every overhang question about them is asked
-    about -x. Getting this wrong does not error, it just reports confident nonsense.
+    `up` is the build direction, which is the model's z only when a part is printed
+    the way it is modelled. Notch parts are, so +z is right for them. Nothing
+    guarantees that in general, and getting it wrong does not error: it reports
+    confident nonsense about every face in the part.
     """
 
     bed: tuple = (256.0, 256.0, 256.0)
     up: tuple = (0.0, 0.0, 1.0)
     overhang_limit: float = 45.0  # degrees away from the build direction
+    bridge_limit: float = 30.0  # how far this printer will span unsupported
     sliver_area: float = 1.0
     accepted: dict = field(default_factory=dict)  # rule -> how many are already known
 
@@ -223,16 +223,47 @@ def _span(shape, up):
     return min(reach), max(reach)
 
 
+def _bridged(solid, face, up, ctx):
+    """The shortest span this face is supported across, or None if it is cantilevered.
+
+    A downward face with material on both sides of it is a bridge, and a printer walks
+    across a short one without help. A face with material on one side only is a
+    cantilever and needs support. Both are 90 degrees to the build direction and
+    nothing about the normal tells them apart, which is why the overhang angle alone
+    reports a channel roof and a shelf underside as the same problem.
+
+    Both sides get probed just outside the face and just below it, which is the same
+    containment test the convexity work was checked against.
+    """
+    below = face.center() - up * PROBE
+    best = None
+    for axis in (Vector(1, 0, 0), Vector(0, 1, 0), Vector(0, 0, 1)):
+        if abs(axis.dot(up)) > 0.9:
+            continue
+        low, high = _span(face, axis)
+        here = below.dot(axis)
+        ends = [
+            below + axis * (low - here - PROBE),
+            below + axis * (high - here + PROBE),
+        ]
+        if all(solid.is_inside((p.X, p.Y, p.Z)) for p in ends):
+            reach = high - low
+            best = reach if best is None else min(best, reach)
+    return best
+
+
 @rule("overhang")
 def overhang(shape, ctx):
-    """Downward faces steeper than the printer will bridge.
+    """Downward faces the printer cannot lay down unaided.
 
     Angle is measured from the build direction, so a vertical wall is 0 and a flat
-    ceiling is 90. Faces sitting on the bed are skipped: they are the first layer,
-    not an overhang.
+    ceiling is 90. Two things are deliberately not findings: a face on the bed, which
+    is the first layer, and a short bridge, which a printer spans on its own. Warning
+    about either is how a checker gets switched off.
     """
     up = Vector(*ctx.up).normalized()
     bed, _ = _span(shape, up)
+    solid = shape.solids()[0] if shape.solids() else None
     found = []
     for face in shape.faces():
         if _span(face, up)[1] <= bed + 1e-4:
@@ -240,12 +271,28 @@ def overhang(shape, ctx):
         worst = max(
             degrees(asin(max(-1.0, min(1.0, -n.dot(up))))) for n in _sample_normals(face)
         )
-        if worst > ctx.overhang_limit + 1e-6:
+        if worst <= ctx.overhang_limit + 1e-6:
+            continue
+        crossing = _bridged(solid, face, up, ctx) if solid else None
+        if crossing is not None and crossing <= ctx.bridge_limit:
+            continue  # a bridge this printer walks across
+        if crossing is not None:
             found.append(
                 Finding(
                     "overhang",
-                    WARN if worst < 90 else FAIL,
-                    f"{worst:.0f}deg overhang over {face.area:.1f}mm2, "
+                    WARN,
+                    f"{crossing:.0f}mm bridge over {face.area:.1f}mm2, "
+                    f"past the {ctx.bridge_limit:.0f}mm this printer spans",
+                    value=round(crossing, 1),
+                    where=tuple(round(v, 2) for v in face.center()),
+                )
+            )
+        else:
+            found.append(
+                Finding(
+                    "overhang",
+                    FAIL,
+                    f"{worst:.0f}deg unsupported over {face.area:.1f}mm2, "
                     f"limit {ctx.overhang_limit:.0f}deg",
                     value=round(worst, 1),
                     where=tuple(round(v, 2) for v in face.center()),

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -47,6 +47,7 @@ class Context:
     overhang_reach: float = 1.0  # a ledge shorter than this cannot droop enough to matter
     forward: tuple | None = None  # which way a wall-mounted part cantilevers, if it does
     projection_limit: float = 2.5  # reach over height, past which height is the fix
+    cosmetic_chamfer: float = 1.0  # the size the polish pass uses
     sliver_area: float = 1.0
     accepted: dict = field(default_factory=dict)  # rule -> how many are already known
 
@@ -420,3 +421,93 @@ def projection_ratio(shape, ctx):
             value=round(ratio, 2),
         )
     ]
+
+
+@rule("bed_bevel")
+def bed_bevel(shape, ctx):
+    """Polish laid on the edges that meet the build plate.
+
+    A chamfer down there buys nothing and costs a mess: it turns the first layer into
+    a knife edge that squashes, and on a mount-facing part it stops the thing sitting
+    flat. Nothing has to identify a chamfer to find one, because a face touching the
+    bed that is neither flat on it nor square to it can only be a bevel.
+    """
+    up = Vector(*ctx.up).normalized()
+    bed, _ = _span(shape, up)
+    found = []
+    for face in shape.faces():
+        if _span(face, up)[0] > bed + 1e-4:
+            continue  # does not reach the plate
+        for normal in _sample_normals(face):
+            tilt = abs(normal.dot(up))
+            if 0.03 < tilt < 0.97:  # neither lying on the plate nor standing on it
+                found.append(
+                    Finding(
+                        "bed_bevel",
+                        WARN,
+                        f"{degrees(asin(min(1.0, tilt))):.0f}deg face meets the build "
+                        f"plate over {face.area:.1f}mm2, which is polish on the first layer",
+                        value=round(face.area, 2),
+                        where=tuple(round(v, 2) for v in face.center()),
+                    )
+                )
+                break
+    return found
+
+
+@rule("concave_cosmetic")
+def concave_cosmetic(shape, ctx):
+    """Polish laid into an inside corner instead of across an outside one.
+
+    A cosmetic chamfer belongs on a convex edge, where it takes a sharp corner off. Run
+    over a concave one it does the opposite: it adds a thin wedge into the corner,
+    which prints as a feather edge and collects stress where the part is already
+    weakest. A concave junction that needs relieving wants a deliberate structural
+    chamfer sized for the load, not the polish pass.
+
+    Found by shape rather than by trying to identify chamfers: a strip about as wide as
+    the polish pass makes, whose long edges are all concave, is one. Width comes from
+    area over perimeter, which is the honest measure for a strip and does not care how
+    the strip is oriented.
+    """
+    neighbours = edge_faces(shape)
+    limit = 2 * ctx.cosmetic_chamfer * 1.42
+    found = []
+    for face in shape.faces():
+        if face.geom_type != GeomType.PLANE:
+            continue
+        perimeter = sum(e.length for e in face.edges())
+        if perimeter <= 0:
+            continue
+        width = 2 * face.area / perimeter
+        if width > limit:
+            continue
+        long_edges = [e for e in face.edges() if e.length > width * 1.5]
+        if len(long_edges) < 2:
+            continue
+        here = face.normal_at(face.center())
+        verdicts, oblique = [], []
+        for edge in long_edges:
+            pair = neighbours.get(edge, [])
+            if len(pair) != 2:
+                continue
+            verdicts.append(is_convex(edge, *pair))
+            # Compared by topology, not by `is`: shape.faces() hands back fresh
+            # objects each call, so identity would always pick this face itself and
+            # every junction would look oblique.
+            other = pair[1] if pair[0] == face else pair[0]
+            # A bevel leans against what it joins. A pocket floor is square to its
+            # walls, and a pocket is not polish however narrow it is.
+            oblique.append(abs(here.dot(other.normal_at(edge.center()))) > 0.3)
+        if verdicts and not any(verdicts) and oblique and all(oblique):
+            found.append(
+                Finding(
+                    "concave_cosmetic",
+                    WARN,
+                    f"{width:.1f}mm strip sitting in a concave junction over "
+                    f"{face.area:.1f}mm2, which is polish where a structural chamfer belongs",
+                    value=round(width, 2),
+                    where=tuple(round(v, 2) for v in face.center()),
+                )
+            )
+    return found

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -1,0 +1,173 @@
+"""Printability rules, run against the solid rather than against an export.
+
+Checking the B-rep instead of an STL means real faces with exact areas and normals
+instead of triangles, which is what makes most of these rules cheap and exact.
+
+A rule takes the shape and a Context and yields Findings. Rules compose: they never
+see each other, and `run` gathers them.
+"""
+
+from dataclasses import dataclass, field
+
+FAIL = "fail"  # this will not print, or will not work
+WARN = "warn"  # this needs attention, most often support
+
+
+@dataclass(frozen=True)
+class Finding:
+    rule: str
+    severity: str
+    message: str
+    value: float | None = None
+    where: tuple | None = None
+
+    def __str__(self):
+        spot = f"  at ({self.where[0]:.1f}, {self.where[1]:.1f}, {self.where[2]:.1f})" if self.where else ""
+        return f"{self.severity:4}  {self.rule:20} {self.message}{spot}"
+
+
+@dataclass
+class Context:
+    """What a rule needs to know beyond the geometry itself.
+
+    `up` is the build direction, and it is not the model's z. A part is modelled on
+    whatever datums make its function readable and printed on whatever face keeps it
+    off supports, and those are rarely the same. Notch parts hang from a slab top at
+    z=0 and print on their backs, so every overhang question about them is asked
+    about -x. Getting this wrong does not error, it just reports confident nonsense.
+    """
+
+    bed: tuple = (256.0, 256.0, 256.0)
+    up: tuple = (0.0, 0.0, 1.0)
+    overhang_limit: float = 45.0  # degrees away from the build direction
+    sliver_area: float = 1.0
+    accepted: dict = field(default_factory=dict)  # rule -> how many are already known
+
+
+RULES = {}
+
+
+def rule(name):
+    def register(fn):
+        RULES[name] = fn
+        return fn
+
+    return register
+
+
+def run(shape, ctx=None, only=None):
+    ctx = ctx or Context()
+    found = []
+    for name, fn in RULES.items():
+        if only and name not in only:
+            continue
+        found.extend(fn(shape, ctx))
+    return sorted(found, key=lambda f: (f.severity != FAIL, f.rule))
+
+
+# --- geometry helpers --------------------------------------------------------
+
+
+def edge_faces(shape):
+    """Every edge mapped to the faces sharing it."""
+    out = {}
+    for face in shape.faces():
+        for edge in face.edges():
+            out.setdefault(edge, []).append(face)
+    return out
+
+
+PROBE = 1e-3
+
+
+def _into_face(face, point, tangent):
+    """The direction leaving `point` across the face, perpendicular to the edge.
+
+    Which of the two candidates is the right one gets settled by stepping and asking
+    the face, rather than by trusting a winding convention. Aiming at the centroid
+    instead is tempting and wrong: a face that is L-shaped or has the rest of the part
+    merged into it puts its centroid somewhere that has nothing to do with which side
+    of this edge the material is on. That mistake showed up as convex slab edges
+    reported concave.
+    """
+    across = tangent.cross(face.normal_at(point)).normalized()
+    forward = face.distance_to(point + across * PROBE)
+    backward = face.distance_to(point - across * PROBE)
+    return across if forward <= backward else -across
+
+
+def is_convex(edge, f1, f2):
+    """True if the material folds away from itself across this edge.
+
+    The test is `n1 . u2`: does the second face extend in the direction the first
+    face's outward normal points? If it does, the solid is folding back on itself and
+    the edge is concave.
+
+    The obvious alternative, offsetting the edge along the averaged face normals and
+    asking whether that point is inside the solid, is recorded in the Fusion notes as
+    failing. It cannot work: at a concave edge the averaged normal points into open
+    space just as it does at a convex one, so both answer the same. What separates
+    them is where the faces go, not where they face, which is why this uses a
+    direction along the face and not the normal.
+    """
+    point = edge.center()
+    tangent = edge.tangent_at(0.5)
+    return f1.normal_at(point).dot(_into_face(f2, point, tangent)) < 0
+
+
+def concave_edges(shape):
+    """Every concave edge, which is where polish is forbidden and stress collects."""
+    out = []
+    for edge, faces in edge_faces(shape).items():
+        if len(faces) != 2:
+            continue  # seam or free edge, nothing to be convex about
+        if not is_convex(edge, faces[0], faces[1]):
+            out.append(edge)
+    return out
+
+
+# --- rules -------------------------------------------------------------------
+
+
+@rule("sliver")
+def sliver(shape, ctx):
+    """Faces too small to print as anything but a smear.
+
+    Chamfers meeting at a corner legitimately make a few, so a part declares how many
+    it has earned. A count above the baseline is a regression; at or below it is
+    silence. The count is the assertion, not the individual faces, because which face
+    is which shifts as soon as anything upstream of the polish pass moves.
+    """
+    small = [f for f in shape.faces() if f.area < ctx.sliver_area]
+    allowed = ctx.accepted.get("sliver", 0)
+    if len(small) <= allowed:
+        return []
+    worst = min(small, key=lambda f: f.area)
+    return [
+        Finding(
+            "sliver",
+            WARN,
+            f"{len(small)} faces under {ctx.sliver_area}mm2, {allowed} accounted for",
+            value=round(worst.area, 3),
+            where=tuple(round(v, 2) for v in worst.center()),
+        )
+    ]
+
+
+@rule("build_volume")
+def build_volume(shape, ctx):
+    """Does it fit on the printer at all."""
+    size = shape.bounding_box().size
+    got = sorted([size.X, size.Y, size.Z], reverse=True)
+    fits = sorted(ctx.bed, reverse=True)
+    if all(g <= b for g, b in zip(got, fits)):
+        return []
+    return [
+        Finding(
+            "build_volume",
+            FAIL,
+            f"{size.X:.0f} x {size.Y:.0f} x {size.Z:.0f}mm does not fit "
+            f"{ctx.bed[0]:.0f} x {ctx.bed[1]:.0f} x {ctx.bed[2]:.0f}mm in any orientation",
+            value=round(max(got), 1),
+        )
+    ]

--- a/src/nurb/cli.py
+++ b/src/nurb/cli.py
@@ -77,6 +77,31 @@ def cmd_build(args):
             print(f"  {path.stem}: {type(exc).__name__}: {exc}")
 
 
+def cmd_check(args):
+    from . import builder, checks
+
+    root = project_root()
+    worst = 0
+    for path in _resolve(root, args.part):
+        try:
+            shape, _, _ = builder.build(path, draft=False)
+            found = checks.run(shape, checks.from_card(path))
+        except Exception as exc:
+            print(f"  {path.stem}: {type(exc).__name__}: {exc}")
+            worst = 2
+            continue
+        if not found:
+            print(f"  {path.stem}: clean")
+            continue
+        fails = sum(1 for f in found if f.severity == checks.FAIL)
+        print(f"  {path.stem}: {len(found)} finding(s), {fails} to fix")
+        for finding in found:
+            print(f"      {finding}")
+        worst = max(worst, 2 if fails else 1)
+    if args.strict and worst:
+        sys.exit(1)
+
+
 def cmd_export(args):
     from build123d import export_step, export_stl
 
@@ -128,6 +153,11 @@ def main(argv=None):
     s.add_argument("part", nargs="?")
     s.add_argument("--draft", action="store_true")
     s.set_defaults(fn=cmd_build)
+
+    s = sub.add_parser("check", help="run the printability rules")
+    s.add_argument("part", nargs="?")
+    s.add_argument("--strict", action="store_true", help="exit non-zero on any finding")
+    s.set_defaults(fn=cmd_check)
 
     s = sub.add_parser("export", help="write STL/STEP/GLB to build/")
     s.add_argument("part", nargs="?")

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -133,6 +133,7 @@ class Server:
 
     def watch(self):
         server = self
+        parts_dir = self.root / "parts"
 
         class Handler(FileSystemEventHandler):
             def on_any_event(self, event):
@@ -140,15 +141,19 @@ class Server:
                     return
                 path = pathlib.Path(getattr(event, "dest_path", "") or event.src_path)
                 # "." skips the atomic-save temp files editors and sed leave behind
-                if path.suffix == ".py" and not path.name.startswith((".", "_")):
-                    server.loop.call_soon_threadsafe(server.queue.put_nowait, str(path))
+                if path.suffix != ".py" or path.name.startswith((".", "_")):
+                    return
+                # A shared module (system.py) can feed every part, so rebuild all.
+                changed = [path] if path.parent == parts_dir else builder.find_parts(server.root)
+                for target in changed:
+                    server.loop.call_soon_threadsafe(server.queue.put_nowait, str(target))
 
-        parts_dir = self.root / "parts"
         parts_dir.mkdir(parents=True, exist_ok=True)
         # Held on self: a dropped Observer can be collected and take its
         # FSEvents stream with it, and the watcher silently stops firing.
         self.observer = Observer()
         self.observer.schedule(Handler(), str(parts_dir), recursive=False)
+        self.observer.schedule(Handler(), str(self.root), recursive=False)
         self.observer.daemon = True
         self.observer.start()
 

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -51,7 +51,7 @@ class Server:
 
     def rebuild(self, path):
         name = pathlib.Path(path).stem
-        entry = {"name": name, "token": secrets.token_hex(4)}
+        entry = {"name": name, "token": secrets.token_hex(4), "findings": None}
         try:
             shape, params, ms = builder.build(path, draft=self.draft)
             entry["glb"] = builder.to_glb(shape, self.tolerance)
@@ -59,18 +59,59 @@ class Server:
             entry["params"] = params
             entry["ms"] = round(ms, 1)
             entry["error"] = None
+            entry["shape"] = shape  # kept for the check pass, never serialized
         except Exception as exc:
             entry["glb"] = None
+            entry["shape"] = None
             entry["error"] = f"{type(exc).__name__}: {exc}"
             entry["traceback"] = _user_traceback(exc, path)
         self.state[name] = entry
         return entry
 
+    def check(self, path):
+        """Run the rules on the last good build.
+
+        Separate from `rebuild` and broadcast separately, because checking the shelf
+        costs about as much again as building it. Geometry should land at the speed it
+        always did and the findings can arrive a beat later.
+        """
+        from . import checks
+
+        entry = self.state.get(pathlib.Path(path).stem)
+        if not entry or entry.get("shape") is None:
+            return entry
+        try:
+            found = checks.run(entry["shape"], checks.from_card(path))
+            entry["findings"] = [
+                {
+                    "rule": f.rule,
+                    "severity": f.severity,
+                    "message": f.message,
+                    "where": list(f.where) if f.where else None,
+                }
+                for f in found
+            ]
+        except Exception as exc:
+            entry["findings"] = [
+                {
+                    "rule": "check",
+                    "severity": "fail",
+                    "message": f"{type(exc).__name__}: {exc}",
+                    "where": None,
+                }
+            ]
+        return entry
+
     def rebuild_all(self):
         for path in builder.find_parts(self.root):
             entry = self.rebuild(path)
+            self.check(path)
             status = entry["error"] or f"{entry['ms']}ms"
-            print(f"  {entry['name']}: {status}", flush=True)
+            note = ""
+            if entry.get("findings"):
+                bad = sum(1 for f in entry["findings"] if f["severity"] == "fail")
+                note = f"  {len(entry['findings'])} finding(s), {bad} to fix"
+            print(f"  {entry['name']}: {status}{note}", flush=True)
 
     # ---------- http ----------
 
@@ -103,7 +144,7 @@ class Server:
 
     @staticmethod
     def _meta(entry):
-        return {k: v for k, v in entry.items() if k != "glb"}
+        return {k: v for k, v in entry.items() if k not in ("glb", "shape")}
 
     # ---------- websocket ----------
 
@@ -119,10 +160,10 @@ class Server:
         finally:
             self.clients.discard(connection)
 
-    async def broadcast(self, entry):
+    async def broadcast(self, entry, kind="rebuilt"):
         if not self.clients:
             return
-        payload = json.dumps({"type": "rebuilt", **self._meta(entry)})
+        payload = json.dumps({"type": kind, **self._meta(entry)})
         for client in list(self.clients):
             try:
                 await client.send(payload)
@@ -141,8 +182,14 @@ class Server:
                     return
                 path = pathlib.Path(getattr(event, "dest_path", "") or event.src_path)
                 # "." skips the atomic-save temp files editors and sed leave behind
-                if path.suffix != ".py" or path.name.startswith((".", "_")):
+                if path.suffix not in (".py", ".md") or path.name.startswith((".", "_")):
                     return
+                # A card carries what the part has already justified, so editing one
+                # changes the answer even though the geometry is untouched.
+                if path.suffix == ".md":
+                    path = path.with_suffix(".py")
+                    if not path.is_file():
+                        return
                 # A shared module (system.py) can feed every part, so rebuild all.
                 changed = [path] if path.parent == parts_dir else builder.find_parts(server.root)
                 for target in changed:
@@ -171,6 +218,16 @@ class Server:
                 status = entry["error"] or f"{entry['ms']}ms"
                 print(f"  {entry['name']}: {status}", flush=True)
                 await self.broadcast(entry)
+                # Geometry has landed, so the rules can take their time.
+                entry = await asyncio.to_thread(self.check, path)
+                if entry and entry.get("findings") is not None:
+                    await self.broadcast(entry, kind="checked")
+                    bad = sum(1 for f in entry["findings"] if f["severity"] == "fail")
+                    if entry["findings"]:
+                        print(
+                            f"    {len(entry['findings'])} finding(s), {bad} to fix",
+                            flush=True,
+                        )
 
     # ---------- run ----------
 

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -129,7 +129,7 @@ resize();
 
 // ---- camera persistence ----
 // A rebuild is a geometry swap, never a camera reset. Reloads restore per part.
-const camKey = n => `nurb.cam.${n}`;
+const camKey = n => `nurb.cam.v2.${n}`;  // v2: parts now sit on the plate, not under it
 let saveTimer = null;
 controls.addEventListener('change', () => {
   if (!current) return;
@@ -196,7 +196,11 @@ async function show(name, { keepCamera }) {
   scene.add(mesh);
 
   mesh.geometry.computeBoundingBox();
-  const box = mesh.geometry.boundingBox.clone();
+  // The grid is the build plate, so a part sits on it. Where a part's own origin
+  // falls is a modeling datum and nothing to do with printing: Notch hangs
+  // everything below z=0, which would put every part underneath the plate.
+  mesh.position.z = -mesh.geometry.boundingBox.min.z;
+  const box = mesh.geometry.boundingBox.clone().translate(mesh.position);
   const size = box.getSize(new THREE.Vector3()).length();
 
   // Only reframe when the part changed scale enough that the camera is lost.

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -33,7 +33,7 @@
      ResizeObserver, which calls setSize() again -- a resize loop that flickers. */
   canvas { display: block; position: absolute; inset: 0; width: 100%; height: 100%; z-index: 0; }
   /* The canvas is appended last, so overlays need to be lifted above it. */
-  #hud, #err, #reframe, #empty { z-index: 1; }
+  #hud, #err, #reframe, #empty, #checks { z-index: 1; }
   #hud {
     position: absolute; left: 16px; bottom: 14px; color: var(--dim);
     font-size: 11px; pointer-events: none; line-height: 1.7;
@@ -52,6 +52,20 @@
   }
   #reframe:hover { border-color: var(--dim); }
   #empty { position: absolute; inset: 0; display: grid; place-items: center; color: var(--dim); }
+  #checks {
+    position: absolute; top: 14px; left: 16px; max-width: 46%; max-height: 60%;
+    overflow: auto; display: none; font-size: 11px; line-height: 1.6;
+    background: rgba(29,32,39,.92); border: 1px solid var(--line);
+    border-radius: 8px; padding: 9px 11px;
+  }
+  #checks h2 { font-size: 11px; font-weight: 600; color: var(--dim); margin-bottom: 5px; letter-spacing: .04em; }
+  #checks .f { display: flex; gap: 7px; padding: 2px 0; cursor: default; }
+  #checks .f:hover { color: #fff; }
+  #checks .tag { flex: none; width: 30px; font-weight: 600; }
+  #checks .fail .tag { color: var(--bad); }
+  #checks .warn .tag { color: #f0c274; }
+  #checks .rule { flex: none; color: var(--dim); width: 92px; }
+  #checks .ok { color: var(--accent); }
 </style>
 </head>
 <body>
@@ -63,6 +77,7 @@
   <div id="empty">no parts yet &mdash; nurb new &lt;name&gt;</div>
   <button id="reframe">reframe</button>
   <div id="hud"></div>
+  <div id="checks"></div>
   <div id="err"></div>
 </main>
 
@@ -104,6 +119,15 @@ scene.add(key);
 const grid = new THREE.GridHelper(400, 40, 0x3a3f4a, 0x24272e);
 grid.rotation.x = Math.PI / 2;   // GridHelper is XZ; we want XY
 scene.add(grid);
+
+// Findings get a pin at their reported point, in the same shifted space as the mesh.
+const pins = new THREE.Group();
+scene.add(pins);
+const pinGeom = new THREE.SphereGeometry(1, 12, 8);
+const pinMat = {
+  fail: new THREE.MeshBasicMaterial({ color: 0xf87171 }),
+  warn: new THREE.MeshBasicMaterial({ color: 0xf0c274 }),
+};
 
 const material = new THREE.MeshStandardMaterial({
   color: 0x9aa6b8, metalness: 0.05, roughness: 0.62, flatShading: false,
@@ -181,6 +205,7 @@ async function show(name, { keepCamera }) {
       mesh.material.needsUpdate = true;
     }
     hud(entry);
+    checks(name);
     return;
   }
   err.style.display = 'none';
@@ -214,10 +239,39 @@ async function show(name, { keepCamera }) {
   }
   reframe.onclick = () => { frame(box); reframe.style.display = 'none'; };
   lastSize = size;
-  hud(entry);
+  hud(parts.get(name) || entry);
+  checks(name);
 }
 
 window.__nurb = { THREE, scene, camera, controls, get mesh() { return mesh; } };
+
+// Takes a name, not an entry. `show` awaits the GLB fetch, so an entry captured
+// before that await is stale by the time it resolves: the checks message has already
+// landed and repainted, and the old entry then hides the panel it just filled in.
+function checks(name) {
+  const e = parts.get(name);
+  const box = document.getElementById('checks');
+  pins.clear();
+  const found = e && e.findings;
+  if (!e || e.error || found === null || found === undefined) { box.style.display = 'none'; return; }
+  box.style.display = 'block';
+  if (!found.length) {
+    box.innerHTML = '<h2>checks</h2><div class="ok">clean</div>';
+    return;
+  }
+  const rows = found.map(f =>
+    `<div class="f ${f.severity}"><span class="tag">${f.severity}</span>`
+    + `<span class="rule">${f.rule}</span><span>${f.message}</span></div>`).join('');
+  box.innerHTML = `<h2>checks &mdash; ${found.length}</h2>${rows}`;
+  const lift = mesh ? mesh.position.z : 0;
+  for (const f of found) {
+    if (!f.where) continue;
+    const pin = new THREE.Mesh(pinGeom, pinMat[f.severity] || pinMat.warn);
+    pin.position.set(f.where[0], f.where[1], f.where[2] + lift);
+    pin.scale.setScalar(Math.max(0.6, lastSize ? lastSize / 90 : 1));
+    pins.add(pin);
+  }
+}
 
 function hud(e) {
   document.getElementById('hud').innerHTML = e.error
@@ -269,6 +323,11 @@ function connect() {
       render();
       flash(msg.name);
       if (msg.name === current) show(msg.name, { keepCamera: true });
+    }
+    // Checks arrive after the geometry, so this only repaints the panel.
+    if (msg.type === 'checked') {
+      parts.set(msg.name, msg);
+      if (msg.name === current) checks(msg.name);
     }
   };
 }

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -1,0 +1,56 @@
+"""A card carries a part's check settings, so parsing it has to fail loudly."""
+
+import pytest
+
+from nurb.checks import Context, from_card
+
+
+def write(tmp_path, body):
+    (tmp_path / "thing.md").write_text(body)
+    return tmp_path / "thing.py"
+
+
+def test_no_card_means_nothing_is_excused(tmp_path):
+    ctx = from_card(tmp_path / "absent.py")
+    assert ctx.accepted == {}
+
+
+def test_card_without_a_settings_block_is_fine(tmp_path):
+    part = write(tmp_path, "# thing\n\n## Design notes\n\nJust prose.\n")
+    assert from_card(part).accepted == {}
+
+
+def test_accepted_counts_are_read(tmp_path):
+    part = write(tmp_path, "## Accepted\n\n```toml\n[accepted]\nsliver = 18\n```\n")
+    assert from_card(part).accepted == {"sliver": 18}
+
+
+def test_printer_settings_override_the_defaults(tmp_path):
+    part = write(
+        tmp_path,
+        "```toml\n[printer]\nbridge_limit = 8\nbed = [180, 180, 180]\n```\n",
+    )
+    ctx = from_card(part)
+    assert ctx.bridge_limit == 8
+    assert ctx.bed == (180, 180, 180)
+    assert ctx.overhang_limit == Context().overhang_limit  # untouched
+
+
+def test_a_typo_in_a_setting_name_is_an_error_not_a_shrug(tmp_path):
+    part = write(tmp_path, "```toml\n[printer]\nbridge_limt = 8\n```\n")
+    with pytest.raises(ValueError, match="bridge_limt"):
+        from_card(part)
+
+
+def test_broken_toml_says_which_card(tmp_path):
+    part = write(tmp_path, "```toml\n[accepted\nsliver = 3\n```\n")
+    with pytest.raises(ValueError, match="thing.md"):
+        from_card(part)
+
+
+def test_the_real_cards_parse(tmp_path):
+    import pathlib
+
+    parts = pathlib.Path(__file__).parents[1] / "examples" / "notch" / "parts"
+    for part in sorted(parts.glob("*.py")):
+        assert from_card(part).accepted.get("sliver") is not None, part.name

--- a/tests/test_convexity.py
+++ b/tests/test_convexity.py
@@ -1,0 +1,39 @@
+"""Both cases, explicitly.
+
+The naive version of this test classifies concave edges as convex, so agreeing with
+a box proves nothing on its own. Every shape here has a hand-counted answer.
+"""
+
+from build123d import Box, Pos
+
+from nurb.checks import concave_edges, edge_faces, is_convex
+
+
+def test_box_has_no_concave_edges():
+    box = Box(10, 10, 10)
+    assert len(box.edges()) == 12
+    assert concave_edges(box) == []
+
+
+def test_notched_box_has_exactly_one_concave_edge():
+    """An L in section: the inner corner is concave, the other 11 are not."""
+    shape = Box(10, 10, 10) - Pos(3, 0, 3) * Box(4, 20, 4)
+    concave = concave_edges(shape)
+    assert len(concave) == 1, [e.center() for e in concave]
+    assert concave[0].length == 10  # runs the full width of the notch
+
+
+def test_slot_has_two_concave_edges():
+    """A blind slot in the top face: two inner corners along its length."""
+    shape = Box(20, 20, 10) - Pos(0, 0, 4) * Box(6, 30, 4)
+    concave = concave_edges(shape)
+    assert len(concave) == 2, [e.center() for e in concave]
+    assert all(round(e.length, 6) == 20 for e in concave)
+
+
+def test_every_edge_is_classified_one_way_or_the_other():
+    shape = Box(10, 10, 10) - Pos(3, 0, 3) * Box(4, 20, 4)
+    shared = {e: f for e, f in edge_faces(shape).items() if len(f) == 2}
+    verdicts = [is_convex(e, *f) for e, f in shared.items()]
+    assert len(verdicts) == len(shared)
+    assert verdicts.count(False) == 1

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,90 @@
+"""The example parts are the calibration set, so the suite asserts against them.
+
+Every number here was recorded by hand in Fusion before nurb existed. They are worth
+more than a synthetic fixture: a rule that reproduces a figure someone measured off a
+different kernel months ago is a rule that is measuring the right thing.
+"""
+
+import pathlib
+
+import pytest
+
+from nurb import builder, checks
+
+PARTS = pathlib.Path(__file__).parents[1] / "examples" / "notch" / "parts"
+
+
+def build(name, **overrides):
+    return builder.build(PARTS / f"{name}.py", overrides=overrides or None)[0]
+
+
+def findings(name, shape=None):
+    shape = shape if shape is not None else build(name)
+    return checks.run(shape, checks.from_card(PARTS / f"{name}.py"))
+
+
+@pytest.mark.parametrize("name", ["hook_scissors", "shelf_gridfinity", "fit_coupon"])
+def test_every_example_is_one_solid_and_reports_clean(name):
+    """The credibility bar: nothing fires on a part that has printed fine."""
+    shape = build(name)
+    assert len(shape.solids()) == 1
+    assert findings(name, shape) == []
+
+
+@pytest.mark.parametrize(
+    "name,size",
+    [("hook_scissors", (34.0, 25.16, 30.0)), ("shelf_gridfinity", (94.0, 100.64, 42.0))],
+)
+def test_bounding_boxes_match_the_fusion_originals(name, size):
+    got = build(name).bounding_box().size
+    assert (got.X, got.Y, got.Z) == pytest.approx(size, abs=1e-3)
+
+
+@pytest.mark.parametrize("name,count", [("hook_scissors", 6), ("shelf_gridfinity", 18)])
+def test_sliver_baselines_are_what_the_cards_claim(name, count):
+    shape = build(name)
+    assert len([f for f in shape.faces() if f.area < 1.0]) == count
+
+
+@pytest.mark.parametrize(
+    "grid_x,grid_y,brackets", [(1, 2, 3), (2, 2, 4), (3, 2, 6), (2, 3, 4)]
+)
+def test_the_shelf_sliver_baseline_generalizes(grid_x, grid_y, brackets):
+    """4 per cell plus the two corner triangles, at every grid the card names."""
+    shape = build("shelf_gridfinity", grid_x=grid_x, grid_y=grid_y, bracket_count=brackets)
+    small = [f for f in shape.faces() if f.area < 1.0]
+    assert len(small) == 4 * grid_x * grid_y + 2
+
+
+def test_channel_floors_land_on_pitch(name="shelf_gridfinity"):
+    shape = build(name)
+    floors = sorted(
+        round(f.center().Y, 4)
+        for f in shape.faces()
+        if abs(f.bounding_box().min.X + 4.2) < 1e-3 and abs(f.bounding_box().max.X + 4.2) < 1e-3
+    )
+    assert floors == [round(k * 25.16, 4) for k in range(4)]
+
+
+def test_projection_ratio_reproduces_the_number_on_the_card():
+    """The card says grid_y 3 is a ratio of 3.2 at item_height 42, and 55 fixes it."""
+    deep = findings("shelf_gridfinity", build("shelf_gridfinity", grid_y=3))
+    ratio = [f for f in deep if f.rule == "projection_ratio"]
+    assert len(ratio) == 1
+    assert ratio[0].value == pytest.approx(3.24, abs=0.01)
+
+    taller = findings(
+        "shelf_gridfinity", build("shelf_gridfinity", grid_y=3, item_height=55)
+    )
+    assert [f for f in taller if f.rule == "projection_ratio"] == []
+
+
+def test_a_part_that_does_not_cantilever_opts_out():
+    shape = build("hook_scissors")
+    assert checks.run(shape, checks.Context(), only={"projection_ratio"}) == []
+
+
+def test_the_two_piece_guard_still_fires():
+    """Phase 1's High finding, pinned so it cannot come back."""
+    with pytest.raises(ValueError, match="item_depth"):
+        build("hook_scissors", item_depth=5.0)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -111,3 +111,35 @@ def test_build_volume_uses_the_best_orientation():
     assert only(tall, "build_volume", Context(bed=(256, 256, 300))) == [], "stands up"
     assert only(tall, "build_volume", Context(bed=(256, 256, 256))) != [], "260 > 256"
     assert only(tall, "build_volume", Context(bed=(100, 100, 100)))[0].severity == FAIL
+
+
+# --- bridges vs cantilevers --------------------------------------------------
+
+
+def test_short_bridge_is_not_a_finding():
+    """A slot through a block: its roof is 90deg, and every printer spans 10mm."""
+    shape = Box(40, 40, 20) - Pos(0, 0, 6) * Box(10, 60, 6)
+    assert only(shape, "overhang") == []
+
+
+def test_long_bridge_warns_but_does_not_fail():
+    shape = Box(80, 40, 20) - Pos(0, 0, 6) * Box(50, 60, 6)
+    found = only(shape, "overhang")
+    assert len(found) == 1
+    assert found[0].severity == WARN
+    assert found[0].value == pytest.approx(50, abs=0.1)
+
+
+def test_bridge_limit_is_per_printer():
+    shape = Box(40, 40, 20) - Pos(0, 0, 6) * Box(10, 60, 6)
+    assert only(shape, "overhang", Context(bridge_limit=5)) != []
+    assert only(shape, "overhang", Context(bridge_limit=30)) == []
+
+
+def test_cantilever_still_fails_even_though_it_is_also_90_degrees():
+    """The distinction the whole rule turns on: same angle, no support on one side."""
+    shape = Box(6, 6, 20) + Pos(0, 0, 12) * Box(30, 30, 4)
+    found = only(shape, "overhang")
+    assert len(found) == 1
+    assert found[0].severity == FAIL
+    assert "unsupported" in found[0].message

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -143,3 +143,43 @@ def test_cantilever_still_fails_even_though_it_is_also_90_degrees():
     assert len(found) == 1
     assert found[0].severity == FAIL
     assert "unsupported" in found[0].message
+
+
+# --- polish in the wrong place -----------------------------------------------
+
+
+def test_bed_bevel_catches_a_chamfer_on_the_first_layer():
+    from build123d import Axis, chamfer
+
+    box = Box(20, 20, 20)
+    bottom = chamfer(box.edges().group_by(Axis.Z)[0], 2)
+    assert len(only(bottom, "bed_bevel")) == 4
+
+
+def test_bed_bevel_ignores_a_chamfer_anywhere_else():
+    from build123d import Axis, chamfer
+
+    box = Box(20, 20, 20)
+    assert only(chamfer(box.edges().group_by(Axis.Z)[-1], 2), "bed_bevel") == []
+
+
+def test_concave_cosmetic_catches_polish_in_an_inside_corner():
+    from build123d import chamfer
+
+    shape = Box(20, 20, 20) - Pos(6, 0, 6) * Box(10, 30, 10)
+    inner = [e for e in shape.edges()
+             if abs(e.center().X - 1) < 1e-6 and abs(e.center().Z - 1) < 1e-6]
+    assert len(inner) == 1
+    assert len(only(chamfer(inner, 1), "concave_cosmetic")) == 1
+
+
+def test_concave_cosmetic_ignores_polish_on_an_outside_corner():
+    from build123d import Axis, chamfer
+
+    shape = chamfer(Box(20, 20, 20).edges().filter_by(Axis.Z), 1)
+    assert only(shape, "concave_cosmetic") == []
+
+
+def test_concave_cosmetic_does_not_mistake_a_pocket_for_a_chamfer():
+    """A narrow pocket floor is bounded by concave edges too, and is square to them."""
+    assert only(Box(20, 20, 20) - Pos(0, 0, 8) * Box(6, 6, 6), "concave_cosmetic") == []

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -51,8 +51,9 @@ def test_sloped_underside_flags_only_past_the_limit(angle, flagged):
 def test_overhang_is_measured_from_the_build_direction_not_model_z():
     """The same solid, printed on a different face, has a different answer.
 
-    This is the trap the Notch parts sit in: they are modelled hanging and printed on
-    their backs.
+    Notch happens to print exactly as modelled, so its build direction is +z. Nothing
+    guarantees that in general, and a rule that assumes it does not error when it is
+    wrong, it just reports confident nonsense.
     """
     shape = Box(6, 6, 20) + Pos(0, 0, 12) * Box(30, 30, 4)
     assert only(shape, "overhang") != [], "cap underside hangs over nothing"
@@ -183,3 +184,40 @@ def test_concave_cosmetic_ignores_polish_on_an_outside_corner():
 def test_concave_cosmetic_does_not_mistake_a_pocket_for_a_chamfer():
     """A narrow pocket floor is bounded by concave edges too, and is square to them."""
     assert only(Box(20, 20, 20) - Pos(0, 0, 8) * Box(6, 6, 6), "concave_cosmetic") == []
+
+
+# --- wall thickness ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("thickness,flagged", [(2.0, False), (1.5, False), (0.8, True), (0.4, True)])
+def test_min_wall_measures_a_plain_plate(thickness, flagged):
+    found = only(Box(30, 30, thickness), "min_wall")
+    assert bool(found) is flagged
+    if flagged:
+        assert found[0].value == pytest.approx(thickness, abs=0.01)
+
+
+def test_min_wall_measures_a_tube_wall():
+    from build123d import Cylinder
+
+    tube = Cylinder(10, 20) - Cylinder(9, 30)  # 1mm wall
+    found = only(tube, "min_wall", Context(min_wall=1.5))
+    assert found and found[0].value == pytest.approx(1.0, abs=0.05)
+
+
+def test_min_wall_floor_is_per_part():
+    plate = Box(30, 30, 1.0)
+    assert only(plate, "min_wall", Context(min_wall=1.2)) != []
+    assert only(plate, "min_wall", Context(min_wall=0.8)) == []
+
+
+def test_min_wall_does_not_measure_across_a_chamfer_corner():
+    """A ray that has already left the material must not count what it hits next.
+
+    Without that filter a 1mm chamfer two corners away reads as a sub-millimetre wall
+    on a part that is 20mm thick.
+    """
+    from build123d import Axis, chamfer
+
+    shape = chamfer(Box(20, 20, 20).edges().filter_by(Axis.Z), 1)
+    assert only(shape, "min_wall", Context(min_wall=2.0)) == []

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,113 @@
+"""Every rule gets a shape whose answer was worked out by hand, not by running it.
+
+A rule that agrees with itself proves nothing. These are all cases where the expected
+finding is obvious from the geometry: a known angle, a known count, a known tip.
+"""
+
+from math import tan, radians
+
+from build123d import Box, Cylinder, Plane, Pos, Rot, extrude, Polygon
+import pytest
+
+from nurb.checks import FAIL, WARN, Context, run
+
+
+def only(shape, rule, ctx=None):
+    return [f for f in run(shape, ctx, only={rule}) for _ in [1] if f.rule == rule]
+
+
+# --- overhang ----------------------------------------------------------------
+
+
+def test_box_has_no_overhang():
+    """Six faces, and the only downward one is on the bed."""
+    assert only(Box(20, 20, 20), "overhang") == []
+
+
+def test_flat_ceiling_is_a_90_degree_overhang():
+    """A T: the underside of the cap hangs over nothing."""
+    shape = Box(6, 6, 20) + Pos(0, 0, 12) * Box(30, 30, 4)
+    found = only(shape, "overhang")
+    assert len(found) == 1
+    assert found[0].value == pytest.approx(90.0)
+    assert found[0].severity == FAIL
+
+
+@pytest.mark.parametrize("angle,flagged", [(30, False), (44, False), (60, True), (75, True)])
+def test_sloped_underside_flags_only_past_the_limit(angle, flagged):
+    """A wedge whose underside sits at a known angle from vertical."""
+    run_out = 20 * tan(radians(angle))
+    # Right triangle standing on its point: the hypotenuse from (0,0) up to
+    # (run_out, 20) is the underside, and it leans `angle` off vertical by
+    # construction.
+    section = Plane.XZ * Polygon((0, 0), (0, 20), (run_out, 20), align=None)
+    shape = extrude(section, 5, both=True)
+    found = only(shape, "overhang")
+    assert bool(found) is flagged
+    if flagged:
+        assert found[0].value == pytest.approx(angle, abs=0.5)
+
+
+def test_overhang_is_measured_from_the_build_direction_not_model_z():
+    """The same solid, printed on a different face, has a different answer.
+
+    This is the trap the Notch parts sit in: they are modelled hanging and printed on
+    their backs.
+    """
+    shape = Box(6, 6, 20) + Pos(0, 0, 12) * Box(30, 30, 4)
+    assert only(shape, "overhang") != [], "cap underside hangs over nothing"
+    flipped = Context(up=(0, 0, -1))
+    assert only(shape, "overhang", flipped) == [], "printed cap-down, nothing hangs"
+
+
+def test_curved_face_is_sampled_not_guessed():
+    """A sphere-like face is fine at its equator and 90 degrees underneath.
+
+    A single normal at the face centre would miss it entirely.
+    """
+    shape = Pos(0, 0, 20) * Cylinder(8, 6, rotation=(90, 0, 0))
+    found = only(shape, "overhang")
+    assert found, "the underside of a floating cylinder is an overhang"
+    assert found[0].value == pytest.approx(90, abs=1)
+
+
+# --- stability ---------------------------------------------------------------
+
+
+def test_box_is_stable():
+    assert only(Box(20, 20, 20), "stability") == []
+
+
+def test_top_heavy_lean_tips():
+    """Mass parked well outside a small foot."""
+    shape = Box(4, 4, 30) + Pos(20, 0, 28) * Box(20, 20, 4)
+    found = only(shape, "stability")
+    assert len(found) == 1
+    assert found[0].severity == WARN
+
+
+# --- sliver ------------------------------------------------------------------
+
+
+def test_sliver_counts_and_the_baseline_silences_it():
+    from build123d import chamfer
+
+    shape = Box(20, 20, 20)
+    shape = chamfer(shape.edges(), 1)  # three-chamfer corners: 8 tiny triangles
+    found = only(shape, "sliver")
+    assert len(found) == 1
+    count = int(found[0].message.split()[0])
+    assert count == 8
+    assert only(shape, "sliver", Context(accepted={"sliver": count})) == []
+    assert only(shape, "sliver", Context(accepted={"sliver": count - 1})) != []
+
+
+# --- build volume ------------------------------------------------------------
+
+
+def test_build_volume_uses_the_best_orientation():
+    """300 x 10 x 10 does not fit a 256 bed lying down, but it fits standing up."""
+    tall = Box(260, 10, 10)
+    assert only(tall, "build_volume", Context(bed=(256, 256, 300))) == [], "stands up"
+    assert only(tall, "build_volume", Context(bed=(256, 256, 256))) != [], "260 > 256"
+    assert only(tall, "build_volume", Context(bed=(100, 100, 100)))[0].severity == FAIL

--- a/uv.lock
+++ b/uv.lock
@@ -226,6 +226,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "ipython"
 version = "9.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -371,6 +380,11 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "build123d", specifier = ">=0.11.1" },
@@ -378,6 +392,9 @@ requires-dist = [
     { name = "watchdog", specifier = ">=6.0.0" },
     { name = "websockets", specifier = ">=16.1.1" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0" }]
 
 [[package]]
 name = "ocp-gordon"
@@ -407,6 +424,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "parso"
 version = "0.8.7"
 source = { registry = "https://pypi.org/simple" }
@@ -425,6 +451,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -510,6 +545,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Two phases from `docs/core/IMPLEMENTATION.md`. Phase 1 answers whether OCCT can build real Notch geometry; Phase 2 builds the printability rules on top of it.

## Phase 1: the kernel question is settled

Two real Notch parts ported from Fusion, plus a calibration coupon. All build to one solid, and both library parts match their Fusion originals dimension for dimension.

The strongest evidence isn't that they built, it's the sliver counts. The polish exclusion rule was derived from the doctrine, and the counts came out at the baselines the catalog cards recorded months ago in a different kernel: **6 on the hook, 18 on the shelf**, untuned. The shelf's generalizes to `4 * grid_x * grid_y + 2`, confirmed at four grid sizes.

**One rule explains every chamfer failure hit along the way:** two chamfered convex edges need more than `2 * chamfer_size` of face between them, or OCCT gives up. That's the analogue of Fusion's `ASM_BL_NO_MATE`. The trap is that every edge chamfers fine alone and only the batch fails, so testing one at a time reports all-clear. It's in CLAUDE.md now.

**The fit came off a real wall, not a table.** The channel was read off the live Fusion model rather than derived from the constants, which was necessary: the table documents the bracket pocket, and clearance differs by axis. The final 0.25mm/side came from printed coupons, with 0.20 too tight to seat and 0.30 loose. Three increasingly careful models of pitch-scatter compensation were built and all three deleted, because the wall doesn't scatter.

## Phase 2: `nurb check`

Eight rules against the in-memory B-rep. **All three parts report clean**, which is the credibility bar: a warning fired at a part that prints fine is a bug in the rule.

It caught a real defect in Phase 1's output: four 1mm cosmetic chamfers laid into concave gusset roots. Invisible in code, and the part built, exported watertight, and printed.

Verification worth noting:

- Convexity checked two independent ways: hand-counted unit tests covering both cases, plus 484 real edges cross-checked against ring sampling with zero disagreements. The centroid-based first version passed every unit test and was still wrong.
- Overhang tells a bridge from a cantilever. Both are 90 degrees and the normal can't separate them; without it, both parts fire twice per channel on geometry that's printed for months.
- `min_wall` is approximate and the docstring says so. It reads a taper and a relief as walls, so parts declare their own floor next to the reason.

## Deferred, on purpose

- `chamfer_clearance` is not a check rule. By the time checks run, a violation has already failed the build, so it belongs at build time.
- `check` does not gate `export`, answering RESEARCH's open question the way it leaned. `--strict` is there for CI.

## Verification

- `uv run pytest` - 54 tests, both cases per rule, examples asserted against their cards
- `nurb check` clean on all three parts, `--strict` exits 0
- STL exports watertight, single body, euler 2; BambuStudio reports `manifold = yes`
- Viewer driven in a browser, zero console errors, findings panel verified in both states

## Not verified

The 0.25mm fit is confirmed on 1x and on runs up to 6 brackets at 0.30. The full 0.25 ladder across every bracket count was generated but the print wasn't back at time of writing.