### PR TITLE
Finish the README's not-built-yet list: profiles, sphere min_wall, viewer export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ never should be.
 src/nurb/registry.py      @part, signature introspection
 src/nurb/builder.py       load, build, tessellate, GLB
 src/nurb/checks.py        printability rules, convexity, Finding/Context, variants
+src/nurb/printers.toml    shipped printer profiles, named by a project's printer.toml
 src/nurb/card.py          the card's AUTO block
 src/nurb/extract.py       duplication across sibling parts, up to alpha-equivalence
 src/nurb/measurements.py  measured(), and the refusal to guess
@@ -231,6 +232,15 @@ OCP's iterator over that array is pathological: 7790 triangles cost 536ms to ite
 and 6.8ms to read by index, against 10ms for the meshing itself. `builder._triangulate`
 reads them by index and returns bit-identical geometry. Phase 1's recorded conclusion
 that "tessellation is the loop" was measuring that iterator.
+
+The README's original "not built yet" list is built. Printer profiles ship in
+`src/nurb/printers.toml`, named once per project by `printer.toml` (`nurb check
+--printer x` tries another machine). `min_wall` corrects its ray chords with an
+inscribed sphere on exact kernel distances, gated so the sphere is only paid for where
+it could change the verdict; the far contact gets the same 0.3 cosine floor as the
+ray's exit filter, or a dimple's bowl reads as a thin wall (it did: 1.07mm in a 2.3mm
+web on the scraper). And the viewer is the configurator: `stl`/`step` buttons build at
+the slider values, polished, and hand back the file.
 
 `docs/core/PROGRESS.md` has the findings, including several claims from RESEARCH.md and
 earlier phases that a real part, a real print, or a real measurement disproved. Read

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ parts/<name>.py     the part
 parts/<name>.md     its card: what it is, why, what not to retry
 system.py           optional: shared constants and geometry, importable from a part
 measurements.toml   optional: real-world dimensions with how they were obtained
+printer.toml        optional: which machine this project prints on
 build/              generated, gitignored
 ```
 
@@ -101,7 +102,7 @@ mesh, so it sees real faces with exact areas and normals instead of triangles.
 
 ```
 overhang          downward faces past 45 degrees, bridges told from cantilevers
-min_wall          thinnest section, by ray cast
+min_wall          thinnest section, ray cast corrected by an inscribed sphere
 sliver            faces too small to print as anything but a smear
 concave_cosmetic  polish laid into an inside corner
 bed_bevel         polish laid on the edges that meet the build plate
@@ -109,6 +110,25 @@ stability         center of mass outside the footprint
 projection_ratio  reach over height, for a part cantilevered off a wall
 build_volume      does it fit the printer at all
 ```
+
+`min_wall`'s ray is exact on flat parallel walls and measures the slant through a skewed
+one, so any chord thin enough to change the verdict is corrected by the largest sphere
+tangent at that point, computed against the solid with exact kernel distances. A sphere
+whose far contact is a graze rather than a wall is rejected by the same 0.3 cosine floor
+the ray's exit filter uses, which is what keeps a detent dimple's bowl from reading as a
+thin section of the web it is pressed into.
+
+The bed size belongs to the machine, not to a part, so it is not written on cards.
+A project picks a shipped profile once, in `printer.toml` at the root:
+
+```toml
+profile = "bambu_a1_mini"
+```
+
+Any check setting can be overridden in the same file, machine-wide. A card still wins
+for what its part has justified. `nurb check --printer prusa_mk4s` answers "does this
+fit that machine" without touching the file, and naming a profile that does not exist
+lists the ones that do.
 
 Every part carries what it has already justified on its card, so a known finding is
 silent and a new one is a regression:
@@ -202,13 +222,23 @@ no more, for every shipped configuration. Its numbers are literals rather than i
 from the part's own constants, because a fit test that reads the same constant the part
 built from agrees with the part however wrong the constant is.
 
+## The viewer is the configurator
+
+A part's parameters were always introspectable, so the sliders come from the signature
+and nothing else. The `stl` and `step` buttons build the part at whatever the sliders
+are holding, at full polish whatever the preview economy, and hand back the file: what
+is on screen is what lands in the slicer. Point somebody at your `nurb dev` and they
+can configure and download a part without touching Python.
+
 ## Not built yet
 
-- `min_wall` is a ray cast, so it is exact on flat parallel walls and approximate
-  everywhere else. An inscribed sphere is the correct answer and an expensive one.
-- Printer profiles, shipped rather than written per card
-- A configurator: a part's parameters are already introspectable, so the missing piece
-  is publishing, not modelling
+- A hosted configurator. `nurb dev` already is one for anybody who can reach it, but
+  publishing without a running kernel is a different problem: MakerWorld's customizer
+  runs OpenSCAD, which build123d does not transpile to.
+- Measurement tools in the viewer. The section view shows an interior; it does not
+  yet measure it.
+- `min_wall` probes sample faces, so a pinch nothing lands near is still missed. A
+  clean result means "no thin walls found", not "no thin walls".
 
 ## Debugging the viewer
 

--- a/docs/core/IMPLEMENTATION.md
+++ b/docs/core/IMPLEMENTATION.md
@@ -348,16 +348,21 @@ src/nurb/cli.py               extract
 All five phases are complete. What is left, in the order it looks worth doing:
 
 - [x] `min_wall` rule, shipped in Phase 2 as a ray cast and stated as an approximation
-- [ ] `min_wall` by inscribed sphere. The ray cast is exact on flat parallel walls and
-      wrong in both directions everywhere else, and thirteen parts have not yet produced
-      a case where that mattered. Revisit when one does, not before.
-- [ ] Printer profiles: shipped defaults vs user-authored. Every card currently carries
-      its own, which is right for a `min_wall` a part has justified and wrong for a bed
-      size that belongs to a machine.
+- [x] `min_wall` by inscribed sphere, as a correction of the ray rather than a
+      replacement. A full tangent-sphere pass proved wrong on this library before it
+      shipped: it reads curvature as thickness (0.033mm on the shelf, 0.8mm at every
+      detent dimple), so the sphere only refines chords thin enough to change the
+      verdict, and a contact that grazes rather than crosses is rejected by the same
+      0.3 cosine floor the ray's exit filter uses. See PROGRESS.md.
+- [x] Printer profiles: shipped. Machine facts live in `src/nurb/printers.toml`, a
+      project names one in `printer.toml`, and a card still wins for what its part
+      has justified. `nurb check --printer x` tries another machine.
 - [ ] Decide `nurb` vs `nurb-cad` for the PyPI package name
 - [ ] Claim PyPI `nurb`, npm `nurb`, nurb.dev
-- [ ] Publishing path: does a nurb part export to an OpenSCAD file for MakerWorld's
-      customizer, or does nurb host its own configurator?
+- [x] Publishing path, half-answered: nurb hosts its own. The dev server's viewer is
+      the configurator, with `stl`/`step` downloads built at the slider values. An
+      OpenSCAD export for MakerWorld's customizer is not a target, because build123d
+      does not transpile to OpenSCAD. Hosting without a running kernel stays open.
 
 ## Notes
 

--- a/docs/core/PROGRESS.md
+++ b/docs/core/PROGRESS.md
@@ -1,6 +1,6 @@
 # nurb core progress
 
-## Status: Phases 1 through 5 complete.
+## Status: Phases 1 through 5 complete, and the README's "not built yet" list built.
 
 **The whole Notch catalog is in nurb.** Sixteen catalog entries out of thirteen part
 files and nineteen shipped configurations, every one a single solid matching its Fusion
@@ -1020,6 +1020,50 @@ and now has evidence.
 ---
 
 ## Session log
+
+### 2026-07-27: The README's "not built yet" list
+
+Three items, and the middle one produced this session's finding.
+
+**Printer profiles ship in the package.** `src/nurb/printers.toml` holds machine facts,
+a project names one in `printer.toml` at the root, and `nurb check --printer x` tries
+another machine without touching the file. The split the docs kept circling is now
+enforced by layering: Context defaults, then the profile, then the file's own overrides,
+then the card, so a card keeps winning for exactly what its part has justified and
+nothing else. The watcher now rebuilds the project when `printer.toml` or
+`measurements.toml` changes; the second was an existing gap the first exposed, since
+editing a measurement always could change geometry and never triggered a rebuild.
+
+**`min_wall` grew its inscribed sphere, and the naive version was disproved before it
+shipped.** A tangent sphere at every probe, which is what the literature describes,
+reads curvature as thickness: every detent dimple in the library reported its bowl's
+0.8mm, and the shelf reported 0.033mm at a knife edge. Values like that do not measure
+walls and cannot be carded. What shipped instead is a correction of the ray: any chord
+thin enough that the true section could still be under `min_wall` gets the shrinking
+ball, on exact `distance_to_with_closest_points` queries so the check stays on the
+solid, and the gate follows from the ray's own exit filter (an accepted chord leaves
+within a 0.3 cosine, so a chord past `min_wall / 0.3` cannot be hiding a failure).
+
+The filter that matters was found by a part, again. The scraper measured 1.07mm sitting
+in a 2.3mm web: a sphere wedged between the channel floor and the detent dimple's bowl,
+two surfaces bounding the same air. The fix is the ray's own rule applied to the
+sphere's contact, whose normal comes free as `(q - c) / r`: the far surface has to face
+back at the measurement, same 0.3 floor. Algebraically that is `|w|^2 / 2r^2 - 1 > 0.3`,
+one comparison. With it, every library value lands exactly on its card or above:
+flat-parallel parts unchanged at 1.0, akrobin's 1.98 chord corrected to a true 1.64
+diagonal, the spool 1.42 to 1.18, the shelves 1.0 to 0.84 at the mouth chamfers against
+a 0.7 card. Nothing fires. The whole-library strict check went from ~9s to ~14s, which
+is what "correct and expensive" was supposed to cost. The skew case has a hand-derived
+test: a wedge where the shortest chord is 10.0mm and the tangent sphere is
+2 * 8 / 1.8 = 8.89mm, with the limit between them.
+
+**The viewer is the configurator.** `/export/<part>.stl|step` builds at whatever the
+sliders hold, polished regardless of the draft economy, behind the same lock as the
+rebuild loop so two OCCT builds cannot overlap. Verified in a real browser: slider from
+200 to 150, download, and the STL measures 150 x 200 x 10 and is watertight. What
+remains of "publish a configurator" is hosting without a running kernel, which is a
+different problem and stays on the list; MakerWorld's customizer runs OpenSCAD, which
+build123d does not transpile to, so that path is closed rather than pending.
 
 ### 2026-07-26 (last): Phase 5
 

--- a/docs/core/RESEARCH.md
+++ b/docs/core/RESEARCH.md
@@ -516,7 +516,10 @@ Phase 1 and are kept here with their outcomes, since the outcomes are the useful
   3x2) become one file with different defaults? The three gridfinity shelves are the
   same part flexed, which argues for one parameterized file and separate export
   configs.
-- Printer profiles: shipped defaults, or user-authored from the start?
+- ~~Printer profiles: shipped defaults, or user-authored from the start?~~ **Answered
+  post-Phase 5: shipped.** Machine facts live in `src/nurb/printers.toml`; a project
+  names one in `printer.toml` and can override any check setting machine-wide. Cards
+  keep only what a part has justified.
 - Is `nurb` also the name of the published PyPI package, given `nurb` is free there
   today, or does the package become `nurb-cad` with `nurb` as the console script?
 

--- a/examples/notch/parts/shelf_gridfinity.md
+++ b/examples/notch/parts/shelf_gridfinity.md
@@ -61,10 +61,10 @@ which are gridfinity spec geometry and come four to a cell, plus two three-chamf
 corner triangles at 0.866mm2. It generalizes as `4 * grid_x * grid_y + 2`, so a
 different grid wants a different number here. A nineteenth at 2x2 is a regression.
 
-The thinnest section the ray cast finds is 0.76mm, at the front mouth rim. That
-is a knife edge flush with the platform edge, which is gridfinity spec and
-deliberate, and any straight line across the tip of a wedge is short. The real
-wall behind the detent is 1.0mm.
+The thinnest section measured is 0.84mm, tangent to the 45 degree mouth chamfers
+at the front rims. That is a knife edge flush with the platform edge, which is
+gridfinity spec and deliberate, and every section near the tip of a wedge is
+short, sphere and chord alike. The real wall behind the detent is 1.0mm.
 
 ```toml
 [part]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,5 +43,6 @@ source-include = [
     "src/nurb/viewer.html",
     "src/nurb/doctrine.md",
     "src/nurb/agents.md",
+    "src/nurb/printers.toml",
     "src/nurb/vendor/**/*",
 ]

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -349,6 +349,55 @@ def stability(shape, ctx):
     return []
 
 
+# --- printer profiles --------------------------------------------------------
+
+PRINTERS = pathlib.Path(__file__).parent / "printers.toml"
+PRINTER_FILE = "printer.toml"  # optional, at the project root, like measurements.toml
+
+
+def profiles():
+    """The shipped printer profiles: machine facts, keyed by name."""
+    import tomllib
+
+    return tomllib.loads(PRINTERS.read_text(encoding="utf-8"))
+
+
+def _project_root(part_path):
+    """The project a part belongs to, by the same rule the builder uses."""
+    path = pathlib.Path(part_path).resolve()
+    return path.parent.parent if path.parent.name == "parts" else path.parent
+
+
+def printer(root, name=None):
+    """The machine's Context: a shipped profile, then the project's printer.toml.
+
+    A bed size belongs to the machine, not to a part, so it is picked once here
+    rather than written onto every card. The file names a shipped profile and can
+    override any check setting machine-wide; a card still wins for what its part
+    has justified, because `_apply` runs the card on top of this.
+    """
+    import tomllib
+
+    ctx = Context()
+    block = {}
+    file = pathlib.Path(root) / PRINTER_FILE
+    if file.is_file():
+        try:
+            block = tomllib.loads(file.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError as exc:
+            raise ValueError(f"{PRINTER_FILE}: not valid TOML ({exc})") from exc
+    name = name or block.pop("profile", None)
+    if name:
+        have = profiles()
+        if name not in have:
+            raise ValueError(
+                f"no printer profile called {name!r}. have: {', '.join(sorted(have))}"
+            )
+        _apply(ctx, {"printer": have[name]}, f"profile {name!r}")
+    block.pop("profile", None)  # named on the command line, so the file's loses
+    return _apply(ctx, {"printer": block}, PRINTER_FILE)
+
+
 # --- per part settings -------------------------------------------------------
 
 CARD_SETTINGS = "toml"  # the fence a card uses to carry them
@@ -396,7 +445,8 @@ def from_card(part_path, base=None):
     A card with no settings block is normal and means no findings are excused.
     """
     card = pathlib.Path(part_path).with_suffix(".md")
-    return _apply(base or Context(), settings(part_path), card.name)
+    base = base or printer(_project_root(part_path))
+    return _apply(base, settings(part_path), card.name)
 
 
 def configurations(part_path, base=None):
@@ -416,9 +466,10 @@ def configurations(part_path, base=None):
     stem = pathlib.Path(part_path).stem
     card = pathlib.Path(part_path).with_suffix(".md")
     block = settings(part_path)
+    base = base or printer(_project_root(part_path))
 
     def fresh():
-        return _apply(replace(base) if base else Context(), block, card.name)
+        return _apply(replace(base), block, card.name)
 
     out = [(stem, {}, fresh())]
     for name, variant in block.get("variants", {}).items():
@@ -619,29 +670,75 @@ def _probes(face, grid=2):
     return out
 
 
+def _sphere_at(shape, point, outward, chord):
+    """The largest sphere tangent to the solid at `point`, as a diameter, or None.
+
+    The shrinking ball: start at half the ray's chord, ask the kernel for the nearest
+    boundary point to the center, and where something is nearer than the radius, shrink
+    to the sphere through it. Distances are exact B-rep queries, so this stays a check
+    on the solid rather than on a mesh, and it converges in a handful of steps because
+    the tangency update jumps straight to the answer rather than bisecting toward it.
+
+    None means the far contact was a graze rather than a wall. The contact normal comes
+    free, as (q - c) / r, and it gets the same 0.3 floor the ray's exit filter uses,
+    with the same meaning: a measurement has to leave through a surface facing back at
+    it. Without this, a shallow depression reads as a thin section of whatever it is
+    pressed into: the scraper's detent dimple measured 1.07mm sitting in a 2.3mm web,
+    between two surfaces bounding the same air.
+    """
+    inward = -outward
+    r = chord / 2
+    w = None
+    for _ in range(12):
+        center = point + inward * r
+        d, q, _ = shape.distance_to_with_closest_points(center)
+        if d >= r - 1e-5:
+            break
+        w = point - q
+        if w.length < 1e-6:
+            return None  # pinned at the tangent point, which is curvature, not a wall
+        denom = 2 * w.dot(outward)
+        if denom <= 1e-9:
+            return None  # the contact is behind the tangent plane, nothing to measure
+        grown = w.dot(w) / denom
+        if grown >= r - 1e-6:
+            break
+        r = grown
+    if w is not None and w.dot(w) / (2 * r * r) - 1 <= 0.3:
+        return None
+    return 2 * r
+
+
 @rule("min_wall")
 def min_wall(shape, ctx):
-    """The thinnest section in the solid, by shooting inward and seeing what it hits.
+    """The thinnest section in the solid: a ray cast, corrected by an inscribed sphere
+    wherever the correction could change the verdict.
 
-    This is a ray cast, not an inscribed sphere, and it is the weakest rule here. It is
-    exact on the flat parallel walls that make up most of a printed part. It is wrong in
-    two directions everywhere else, and both showed up on the first run against this
-    library:
+    The ray is exact on the flat parallel walls that make up most of a printed part,
+    and an overestimate everywhere else: through a skewed wall it measures the slant,
+    up to 1/0.3 of the true section at its own exit filter's floor. So any chord thin
+    enough that the true section might still be under `min_wall` gets refined by
+    `_sphere_at`, which measures the way a wall is actually thin, perpendicular to
+    nothing in particular. The gate follows from the filter rather than being tuned: an
+    accepted chord leaves within the 0.3 cosine floor, so a chord past `min_wall / 0.3`
+    cannot be hiding a failing section, and the sphere is only paid for where it could
+    matter. That also prices `min_wall = 0`, the card's way of saying "this rule cannot
+    measure this part", at nothing.
 
-    - It reads a taper as a wall. The shelf's mouth rims are knife edges by design, and
-      near the tip of a wedge any straight line across it is short. 0.76mm there is a
-      true measurement of something that is not a wall.
-    - It reads a relief as a wall. The calibration coupon's raised label is 0.5mm proud,
-      and that is what the ray finds.
+    Two caveats survive the correction, and live on cards rather than in code:
 
-    Neither is a defect and all three parts print. So the number a part is allowed lives
-    on its card next to the reason, and the default is what the printer manages rather
-    than what a textbook says. It also misses the case an inscribed sphere would catch,
-    a thin spot in an inside corner, where the smallest sphere that fits is smaller than
-    any straight line across. Treat a clean result as "no thin walls found", not as
-    "no thin walls".
+    - A taper reads as a wall. Near the tip of a designed knife edge every section is
+      short, sphere and chord alike. The gridfinity shelves' sockets measure 0.84mm
+      where their 45 degree walls meet, and their cards allow 0.7 next to the sentence
+      saying why.
+    - A relief reads as a wall. The calibration coupon's raised label is 0.5mm proud,
+      and that is what gets measured, so its card sets `min_wall = 0`.
+
+    Probes sample faces, so a pinch nothing lands near is still missed. Treat a clean
+    result as "no thin walls found", not as "no thin walls".
     """
     thinnest, spot = None, None
+    floor = ctx.min_wall * 0.01
     for face in shape.faces():
         if face.area < ctx.sliver_area:
             continue  # a face this small has no wall to speak of
@@ -655,12 +752,22 @@ def min_wall(shape, ctx):
             reach = [
                 (hit - point).length
                 for hit, hit_normal in hits
-                if (hit - point).dot(inward) > ctx.min_wall * 0.01
+                if (hit - point).dot(inward) > floor
                 and hit_normal.dot(inward) > 0.3
             ]
             if not reach:
                 continue
             near = min(reach)
+            if near * 0.3 < ctx.min_wall:
+                # The sphere starts from the first boundary crossing rather than from
+                # the accepted chord, because half of that is guaranteed to sit inside
+                # the material, and the shrink only ever moves down from there.
+                first = min(
+                    (hit - point).length for hit, _ in hits if (hit - point).length > floor
+                )
+                section = _sphere_at(shape, point, normal, first)
+                if section is not None and floor < section < near:
+                    near = section
             if thinnest is None or near < thinnest:
                 thinnest, spot = near, point
     # Slack, because a card declaring the value it measured should not then fail on the
@@ -676,7 +783,7 @@ def min_wall(shape, ctx):
             "min_wall",
             WARN,
             f"{thinnest:.2f}mm section, under the {ctx.min_wall:.2f}mm this printer "
-            f"lays down reliably (ray cast, so corners may be thinner still)",
+            f"lays down reliably",
             value=round(thinnest, 3),
             where=tuple(round(v, 2) for v in spot),
         )

--- a/src/nurb/cli.py
+++ b/src/nurb/cli.py
@@ -108,7 +108,7 @@ def _resolve(root, name):
     return match
 
 
-def _configs(path):
+def _configs(path, base=None):
     """A part's configurations: itself, then whatever variants its card declares.
 
     Every command that walks parts walks these instead, so a variant is checked,
@@ -119,7 +119,7 @@ def _configs(path):
     from . import checks
 
     try:
-        return checks.configurations(path)
+        return checks.configurations(path, base=base)
     except Exception as exc:
         print(f"  {path.stem}: {type(exc).__name__}: {exc}")
         return []
@@ -144,9 +144,18 @@ def cmd_check(args):
     from . import builder, checks
 
     root = project_root()
+    # Resolved once, and only when asked for: `--printer a1_mini` answers "does this
+    # fit that machine" without touching printer.toml. The file, when present, is
+    # already the default inside `checks.configurations`.
+    base = None
+    if args.printer:
+        try:
+            base = checks.printer(root, args.printer)
+        except ValueError as exc:
+            sys.exit(f"  {exc}")
     worst = 0
     for path in _resolve(root, args.part):
-        configs = _configs(path)
+        configs = _configs(path, base=base)
         if not configs:
             worst = 2
         for name, overrides, ctx in configs:
@@ -488,6 +497,9 @@ def main(argv=None):
     s = sub.add_parser("check", help="run the printability rules")
     s.add_argument("part", nargs="?")
     s.add_argument("--strict", action="store_true", help="exit non-zero on any finding")
+    # Not argparse `choices`: reading them would parse the shipped profiles on every
+    # `nurb --help`, and the error for an unknown name already lists what exists.
+    s.add_argument("--printer", help="check against a shipped profile instead of printer.toml")
     s.set_defaults(fn=cmd_check)
 
     s = sub.add_parser("rules", help="print the design doctrine")

--- a/src/nurb/doctrine.md
+++ b/src/nurb/doctrine.md
@@ -225,7 +225,10 @@ Plus two machine-facing pieces:
   produces no diff.
 - The **accepted baselines**, a TOML fence carrying what this part has already justified:
   its sliver count, its real minimum wall, its printer settings. The number goes next to
-  the sentence that earns it, because a count on its own is a magic number.
+  the sentence that earns it, because a count on its own is a magic number. Machine facts
+  stay out of it: a bed size belongs to the machine, so it lives in `printer.toml` at the
+  project root, which names a shipped profile (`profile = "bambu_a1_mini"`) and can
+  override any check setting machine-wide.
 
 ```toml
 [part]

--- a/src/nurb/printers.toml
+++ b/src/nurb/printers.toml
@@ -1,0 +1,35 @@
+# Shipped printer profiles: machine facts, not part judgements.
+#
+# A bed size belongs to the machine, so it lives here and is picked once per project
+# in printer.toml, never per card. What a part has justified (its min_wall, its
+# accepted slivers) stays on its card next to the sentence explaining why.
+#
+# Every key must be a field of checks.Context. Sizes are manufacturer-published
+# build volumes in mm, X x Y x Z.
+
+[bambu_x1c]
+bed = [256.0, 256.0, 256.0]
+
+[bambu_p1s]
+bed = [256.0, 256.0, 256.0]
+
+[bambu_p1p]
+bed = [256.0, 256.0, 256.0]
+
+[bambu_a1]
+bed = [256.0, 256.0, 256.0]
+
+[bambu_a1_mini]
+bed = [180.0, 180.0, 180.0]
+
+[prusa_mk4s]
+bed = [250.0, 210.0, 220.0]
+
+[prusa_mini]
+bed = [180.0, 180.0, 180.0]
+
+[prusa_xl]
+bed = [360.0, 360.0, 360.0]
+
+[ender_3_v3]
+bed = [220.0, 220.0, 250.0]

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -51,6 +51,10 @@ class Server:
         self.queue = None
         self.observer = None
         self.drain_task = None
+        # One build at a time, shared by the rebuild loop and the export route. OCCT
+        # makes no thread-safety promises, and a download landing mid-rebuild is the
+        # ordinary way two builds would otherwise overlap.
+        self.building = asyncio.Lock()
 
     @property
     def origins(self):
@@ -142,10 +146,12 @@ class Server:
 
     # ---------- http ----------
 
-    def http(self, connection, request):
+    async def http(self, connection, request):
         path = request.path.split("?")[0]
         if path == "/":
             return self._resp(200, VIEWER.read_bytes(), "text/html; charset=utf-8")
+        if path.startswith("/export/"):
+            return await self.export(path[len("/export/") :])
         if path == "/api/parts":
             body = json.dumps([self._wire(e) for e in self.state.values()]).encode()
             return self._resp(200, body, "application/json")
@@ -166,7 +172,7 @@ class Server:
         return self._resp(404, b"not found", "text/plain")
 
     @staticmethod
-    def _resp(status, body, content_type):
+    def _resp(status, body, content_type, attach=None):
         headers = Headers(
             {
                 "Content-Type": content_type,
@@ -174,7 +180,48 @@ class Server:
                 "Cache-Control": "no-store",
             }
         )
+        if attach:
+            headers["Content-Disposition"] = f'attachment; filename="{attach}"'
         return Response(status, "OK" if status == 200 else "Error", headers, body)
+
+    # What the download button serves. This is the configurator: the parameters were
+    # always introspectable and the sliders already drive them, so publishing a part is
+    # `nurb dev` plus this route, not a second modelling stack.
+    EXPORTS = {"stl": "model/stl", "step": "application/step"}
+
+    async def export(self, filename):
+        name, _, fmt = filename.rpartition(".")
+        if fmt not in self.EXPORTS or name not in self.state:
+            return self._resp(404, b"not found", "text/plain")
+        try:
+            async with self.building:
+                body = await asyncio.to_thread(self._export, name, fmt)
+        except Exception as exc:
+            message = f"{type(exc).__name__}: {exc}"
+            return self._resp(500, message.encode(), "text/plain")
+        return self._resp(200, body, self.EXPORTS[fmt], attach=f"{name}.{fmt}")
+
+    def _export(self, name, fmt):
+        """Build at the values the sliders hold and export that.
+
+        Always the polished build, whatever the viewer is showing: draft is a preview
+        economy, and a file somebody downloads is on its way to a slicer.
+        """
+        import tempfile
+
+        from build123d import export_step, export_stl
+
+        path = next((p for p in builder.find_parts(self.root) if p.stem == name), None)
+        if path is None:  # deleted between the click and the build
+            raise builder.BuildError(f"{name} is no longer on disk")
+        shape, _, _ = builder.build(path, overrides=self.overrides.get(name), draft=False)
+        with tempfile.TemporaryDirectory() as scratch:
+            target = pathlib.Path(scratch) / f"{name}.{fmt}"
+            if fmt == "stl":
+                export_stl(shape, str(target))
+            else:
+                export_step(shape, str(target))
+            return target.read_bytes()
 
     @staticmethod
     def _meta(entry):
@@ -316,7 +363,15 @@ class Server:
                     return
                 path = pathlib.Path(getattr(event, "dest_path", "") or event.src_path)
                 # "." skips the atomic-save temp files editors and sed leave behind
-                if path.suffix not in (".py", ".md") or path.name.startswith((".", "_")):
+                if path.name.startswith((".", "_")):
+                    return
+                # printer.toml changes every part's checks and measurements.toml can
+                # feed any part's geometry, so either rebuilds the project the way
+                # system.py does: they land in the else branch below.
+                if path.suffix not in (".py", ".md") and path.name not in (
+                    "printer.toml",
+                    "measurements.toml",
+                ):
                     return
                 # A card carries what the part has already justified, so editing one
                 # changes the answer even though the geometry is untouched.
@@ -325,7 +380,12 @@ class Server:
                     if not path.is_file():
                         return
                 # A shared module (system.py) can feed every part, so rebuild all.
-                changed = [path] if path.parent == parts_dir else builder.find_parts(server.root)
+                # The suffix guard keeps a stray toml saved into parts/ from queueing
+                # itself as a part.
+                if path.suffix == ".py" and path.parent == parts_dir:
+                    changed = [path]
+                else:
+                    changed = builder.find_parts(server.root)
                 for target in changed:
                     server.loop.call_soon_threadsafe(server.queue.put_nowait, str(target))
 
@@ -356,12 +416,14 @@ class Server:
                         print(f"  {name}: gone", flush=True)
                         await self.send({"type": "gone", "name": name})
                     continue
-                entry = await asyncio.to_thread(self.rebuild, path)
+                async with self.building:
+                    entry = await asyncio.to_thread(self.rebuild, path)
                 status = entry["error"] or f"{entry['ms']}ms"
                 print(f"  {entry['name']}: {status}", flush=True)
                 await self.broadcast(entry)
                 # Geometry has landed, so the rules can take their time.
-                entry = await asyncio.to_thread(self.check, path)
+                async with self.building:
+                    entry = await asyncio.to_thread(self.check, path)
                 if entry and entry.get("findings") is not None:
                     await self.broadcast(entry, kind="checked")
                     bad = sum(1 for f in entry["findings"] if f["severity"] == "fail")

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -75,6 +75,8 @@
   button:hover { border-color: var(--dim); }
   button:focus-visible { outline: none; border-color: var(--accent); }
   #reframe { display: none; }
+  #download { display: flex; gap: 6px; }
+  #download button:disabled { color: var(--dim); cursor: default; }
   #section { display: flex; align-items: center; gap: 6px; }
   #section .on { border-color: var(--accent); color: var(--accent); }
   #cut { display: none; align-items: center; gap: 4px;
@@ -185,6 +187,10 @@
 <main>
   <div id="empty">no parts yet. nurb new &lt;name&gt;</div>
   <div id="tools">
+    <div id="download">
+      <button data-fmt="stl">stl</button>
+      <button data-fmt="step">step</button>
+    </div>
     <button id="reframe">reframe</button>
     <div id="section">
       <div id="cut">
@@ -377,6 +383,34 @@ function sectionUpdate() {
   plane.projectPoint(box.getCenter(new THREE.Vector3()), cap.position);
   cap.lookAt(cap.position.x - plane.normal.x, cap.position.y - plane.normal.y,
              cap.position.z - plane.normal.z);
+}
+
+// ---- download ----
+// This is the configurator. The sliders already hold an exploration, so the file
+// that comes back is the polished build of exactly what is on screen, whatever the
+// preview economy: draft is for the loop, a download is on its way to a slicer.
+// Fetched rather than navigated, so a failed build lands in the note instead of
+// replacing the viewer with a traceback.
+for (const b of document.querySelectorAll('#download button')) {
+  b.onclick = async () => {
+    if (!current) return;
+    const fmt = b.dataset.fmt, was = b.textContent;
+    b.disabled = true; b.textContent = 'building';
+    try {
+      const r = await fetch(`/export/${current}.${fmt}`);
+      if (!r.ok) throw new Error(await r.text());
+      const url = URL.createObjectURL(await r.blob());
+      const a = Object.assign(document.createElement('a'),
+                              { href: url, download: `${current}.${fmt}` });
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      const note = document.getElementById('note');
+      if (note) { note.classList.add('bad'); note.textContent = `export failed: ${e.message}`; }
+    } finally {
+      b.disabled = false; b.textContent = was;
+    }
+  };
 }
 
 document.getElementById('sectionbtn').onclick = ev => {

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -1,0 +1,78 @@
+"""Printer profiles: the machine's facts, picked once per project.
+
+A bed size belongs to the machine, so it lives in a shipped profile named by
+printer.toml, never on a card. A card still wins for what its part has justified,
+because the card is applied on top of the machine.
+"""
+
+import pytest
+
+from nurb.checks import Context, _apply, from_card, printer, profiles
+
+
+def project(tmp_path, printer_toml=None, card=None):
+    (tmp_path / "parts").mkdir()
+    if printer_toml is not None:
+        (tmp_path / "printer.toml").write_text(printer_toml)
+    part = tmp_path / "parts" / "thing.py"
+    if card is not None:
+        (tmp_path / "parts" / "thing.md").write_text(card)
+    return part
+
+
+def test_every_shipped_profile_is_valid_context_settings():
+    have = profiles()
+    assert have, "no shipped profiles"
+    for name, block in have.items():
+        ctx = _apply(Context(), {"printer": block}, name)  # raises on a bad key
+        assert len(ctx.bed) == 3, name
+        assert all(v > 0 for v in ctx.bed), name
+
+
+def test_no_printer_file_means_the_defaults(tmp_path):
+    assert printer(tmp_path).bed == Context().bed
+
+
+def test_the_file_names_a_shipped_profile(tmp_path):
+    part = project(tmp_path, 'profile = "bambu_a1_mini"\n')
+    assert from_card(part).bed == (180.0, 180.0, 180.0)
+
+
+def test_an_unknown_profile_says_what_exists(tmp_path):
+    project(tmp_path, 'profile = "made_up"\n')
+    with pytest.raises(ValueError, match="bambu_a1_mini"):
+        printer(tmp_path)
+
+
+def test_a_direct_setting_overrides_the_profile(tmp_path):
+    """The file can describe a machine no profile ships, or correct one that does."""
+    project(tmp_path, 'profile = "bambu_a1_mini"\nbed = [300, 300, 300]\n')
+    assert printer(tmp_path).bed == (300, 300, 300)
+
+
+def test_a_name_on_the_command_line_beats_the_file(tmp_path):
+    project(tmp_path, 'profile = "bambu_a1_mini"\n')
+    assert printer(tmp_path, "prusa_mk4s").bed == (250.0, 210.0, 220.0)
+
+
+def test_the_card_still_wins_for_what_the_part_justified(tmp_path):
+    part = project(
+        tmp_path,
+        'profile = "bambu_a1_mini"\nmin_wall = 1.5\n',
+        card="```toml\n[part]\nmin_wall = 1.0\n```\n",
+    )
+    ctx = from_card(part)
+    assert ctx.bed == (180.0, 180.0, 180.0)  # the machine's
+    assert ctx.min_wall == 1.0  # the part's
+
+
+def test_broken_toml_names_the_file(tmp_path):
+    project(tmp_path, "profile = \n")
+    with pytest.raises(ValueError, match="printer.toml"):
+        printer(tmp_path)
+
+
+def test_a_typo_in_a_setting_is_an_error_not_a_shrug(tmp_path):
+    project(tmp_path, "bedd = [1, 2, 3]\n")
+    with pytest.raises(ValueError, match="bedd"):
+        printer(tmp_path)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -258,6 +258,24 @@ def test_min_wall_floor_is_per_part():
     assert only(plate, "min_wall", Context(min_wall=0.8)) == []
 
 
+@pytest.mark.parametrize("allowed,flagged", [(9.5, True), (8.8, False)])
+def test_min_wall_measures_a_skewed_section_with_a_sphere(allowed, flagged):
+    """Through a skewed section the ray measures the slant, and the sphere corrects it.
+
+    A wedge whose hypotenuse leans over the back face. The highest probe on the back
+    sits 8mm from the hypotenuse plane, whose normal is 0.8 off the probe's axis, so
+    the shortest chord any probe accepts is 10.0mm while the largest tangent sphere is
+    2 * 8 / (1 + 0.8) = 8.89mm, both worked out by hand. A limit of 9.5 sits between
+    them, which is exactly the case a ray cast alone gets wrong.
+    """
+    section = Plane.XZ * Polygon((0, 0), (30, 0), (0, 40), align=None)
+    wedge = extrude(section, 10, both=True)
+    found = only(wedge, "min_wall", Context(min_wall=allowed))
+    assert bool(found) is flagged
+    if flagged:
+        assert found[0].value == pytest.approx(8.89, abs=0.05)
+
+
 def test_min_wall_does_not_measure_across_a_chamfer_corner():
     """A ray that has already left the material must not count what it hits next.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,48 @@
+"""The export route is the configurator's back end: what the sliders hold, polished."""
+
+import asyncio
+import io
+
+import pytest
+import trimesh
+
+from nurb.server import Server
+
+PART = """from nurb import *
+
+@part
+def thing(width=40.0, depth=30.0, height=5.0):
+    return Box(width, depth, height)
+"""
+
+
+def project(tmp_path):
+    (tmp_path / "parts").mkdir()
+    part = tmp_path / "parts" / "thing.py"
+    part.write_text(PART)
+    server = Server(tmp_path)
+    server.rebuild(part)
+    return server
+
+
+def test_export_builds_at_the_slider_values(tmp_path):
+    server = project(tmp_path)
+    server.overrides["thing"] = {"width": 15.0}
+    resp = asyncio.run(server.export("thing.stl"))
+    assert resp.status_code == 200
+    assert resp.headers["Content-Disposition"] == 'attachment; filename="thing.stl"'
+    mesh = trimesh.load(io.BytesIO(resp.body), file_type="stl")
+    assert mesh.extents == pytest.approx([15.0, 30.0, 5.0])
+    assert mesh.is_watertight
+
+
+def test_export_writes_step_too(tmp_path):
+    resp = asyncio.run(project(tmp_path).export("thing.step"))
+    assert resp.status_code == 200
+    assert resp.body.startswith(b"ISO-10303-21")
+
+
+def test_export_refuses_what_it_cannot_serve(tmp_path):
+    server = project(tmp_path)
+    assert asyncio.run(server.export("missing.stl")).status_code == 404
+    assert asyncio.run(server.export("thing.gcode")).status_code == 404


### PR DESCRIPTION
Ships the three items the README listed as not built. Printer profiles live in the package (`src/nurb/printers.toml`), picked once per project in `printer.toml` and overridable machine-wide, with `nurb check --printer` for trying another machine; cards keep winning for what a part has justified, and the dev server now rebuilds when `printer.toml` or `measurements.toml` changes. `min_wall` corrects its ray chords with a shrinking-sphere measurement on exact kernel distances, gated to run only where it could change the verdict, and the sphere's contact gets the same 0.3 cosine floor as the ray's exit filter after a naive tangent-sphere pass was disproved on the library (it reads curvature as thickness, e.g. a detent dimple's bowl as a 1.07mm wall in a 2.3mm web). The viewer is now the configurator: `stl`/`step` buttons build at the current slider values, always polished, behind the same lock as the rebuild loop, verified end to end in a browser. Every library value lands exactly on its card or above, 208 tests pass, and `nurb check --strict` stays clean across all 19 configurations. Docs updated throughout: README, doctrine, CLAUDE.md, PROGRESS/RESEARCH/IMPLEMENTATION, and the shelf card's stale 0.76 sentence.