### PR TITLE
Publish from CI over trusted publishing, and document the install paths

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: publish
+
+# Publishes to PyPI when a GitHub release is published. Trusted publishing: the
+# job proves its identity to PyPI over OIDC, so there is no long-lived token to
+# store, leak, or rotate. `uv publish` detects the exchange on its own inside
+# GitHub Actions.
+#
+# One-time setup on PyPI (Manage project -> Publishing -> add a publisher):
+#   owner Shpigford, repository nurb, workflow publish.yml, environment pypi.
+#
+# Releasing is: bump `version` in pyproject.toml, merge, publish a GitHub
+# release whose tag matches (v0.2.0). PyPI refuses re-uploads of a version that
+# already exists, which is the guard against releasing without the bump.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # the OIDC exchange; this is the whole credential
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - run: uv build
+
+      - run: uv publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,33 +1,68 @@
 name: publish
 
-# Publishes to PyPI when a GitHub release is published. Trusted publishing: the
-# job proves its identity to PyPI over OIDC, so there is no long-lived token to
-# store, leak, or rotate. `uv publish` detects the exchange on its own inside
-# GitHub Actions.
+# Releasing is one act: merge a version bump. On every push to main this reads
+# `version` from pyproject.toml and, if that version has no tag yet, publishes
+# to PyPI over trusted publishing and creates the GitHub release with generated
+# notes. One workflow does both on purpose: a release created by a workflow's
+# own token does not trigger other workflows, so a separate publish-on-release
+# job would silently never run.
+#
+# The release is also the license record: FSL-1.1-MIT converts each version to
+# MIT two years after its release date, and the release is that date, published.
+#
+# The PyPI existence check makes the job idempotent: a version already uploaded
+# (0.1.0 went up by hand) still gets its tag and release, without a doomed
+# re-upload failing the run.
 #
 # One-time setup on PyPI (Manage project -> Publishing -> add a publisher):
 #   owner Shpigford, repository nurb, workflow publish.yml, environment pypi.
-#
-# Releasing is: bump `version` in pyproject.toml, merge, publish a GitHub
-# release whose tag matches (v0.2.0). PyPI refuses re-uploads of a version that
-# already exists, which is the guard against releasing without the bump.
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      id-token: write # the OIDC exchange; this is the whole credential
-      contents: read
+      id-token: write # trusted publishing: the OIDC exchange is the credential
+      contents: write # the tag and the release
     steps:
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v5
 
-      - run: uv build
+      - name: Read the version
+        id: version
+        run: echo "version=$(uv version --short)" >> "$GITHUB_OUTPUT"
 
-      - run: uv publish
+      - name: Skip everything if this version is already tagged
+        id: tagged
+        run: |
+          if git ls-remote --exit-code --tags origin "v${{ steps.version.outputs.version }}" >/dev/null; then
+            echo "done=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to PyPI, unless this version is already there
+        if: steps.tagged.outputs.done != 'true'
+        run: |
+          if curl -sf "https://pypi.org/pypi/nurb/${{ steps.version.outputs.version }}/json" >/dev/null; then
+            echo "already on PyPI, tagging only"
+          else
+            uv build
+            uv publish
+          fi
+
+      - name: Create the release
+        if: steps.tagged.outputs.done != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -9,14 +9,28 @@ without moving your camera.
 Built on [build123d](https://build123d.readthedocs.io) (OCCT), so parts are real
 B-rep solids with working chamfers, fillets, and STEP export.
 
+## Install
+
+nurb is on [PyPI](https://pypi.org/project/nurb/):
+
+```bash
+uv tool install nurb       # or: pip install nurb
+uvx nurb rules             # or run it without installing anything
+```
+
+There is nothing to install from npm. The registry blocks the unscoped name for
+everyone, and [`@shpigford/nurb`](https://www.npmjs.com/package/@shpigford/nurb)
+exists only so `npx` users get pointed here instead of a 404.
+
 ## Try it
 
 ```bash
-uv run nurb new dispenser
-uv run nurb dev            # http://127.0.0.1:7373, or the next free port
+nurb new dispenser
+nurb dev                   # http://127.0.0.1:7373, or the next free port
 ```
 
-Edit `parts/dispenser.py` and watch it update.
+Edit `parts/dispenser.py` and watch it update. (Working from a checkout of this
+repo, prefix with `uv run`.)
 
 ## A part
 


### PR DESCRIPTION
Makes releasing a single act: merge a PR that bumps `version` in pyproject.toml, and CI does the rest. On every push to main, `publish.yml` reads the version and, if it has no tag yet, publishes to PyPI over trusted publishing (no stored token, the OIDC exchange is the credential) and creates the tagged GitHub release with auto-generated notes. One workflow does both deliberately: a release created by a workflow's own token does not trigger other workflows, so a separate publish-on-release job would silently never run. The PyPI existence check makes it idempotent, so the first merge backfills the v0.1.0 release for the hand-uploaded version without a doomed re-upload; the release date also starts each version's FSL-to-MIT two-year clock. The README gains an Install section pointing at PyPI and explaining the scoped npm pointer, and one-time setup remains adding the trusted publisher on PyPI (owner Shpigford, repo nurb, workflow publish.yml, environment pypi).