### PR TITLE
Make something means talking, not typing commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@
 
 A part is a Python function and its keyword defaults are its parameters. A project is any
 directory with a `parts/` folder; there is no init step. You are the CAD operator: the
-user describes the part, you model it, they judge it in the browser `nurb dev` serves.
+user describes the part and you do everything else, including creating the project and
+modelling. Keep `nurb dev` running in the background and hand the user its URL, because
+the browser it serves is where they judge the result.
 
 **Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the
 polish pass, the kernel traps, card discipline, and what to verify. This file stays thin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,8 @@
 # nurb
 
-A part is a Python function and its keyword defaults are its parameters. A project is any
-directory with a `parts/` folder; there is no init step. You are the CAD operator: the
-user describes the part and you do everything else, including creating the project and
-modelling. Keep `nurb dev` running in the background and hand the user its URL, because
-the browser it serves is where they judge the result.
+A part is a Python function and its keyword defaults are its parameters. A project is any directory with a `parts/` folder; there is no init step. You are the CAD operator: the user describes the part and you do everything else, including creating the project and modelling. Keep `nurb dev` running in the background and hand the user its URL, because the browser it serves is where they judge the result.
 
-**Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the
-polish pass, the kernel traps, card discipline, and what to verify. This file stays thin
-on purpose so there is one copy of that, in the package, which cannot drift.
+**Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
 
 ```
 nurb rules            the doctrine, read this first
@@ -23,7 +17,6 @@ nurb extract          find duplication across parts
 nurb dev              watch, rebuild, serve the viewer on :7373 or the next free port
 ```
 
-Read `parts/<name>.md` before editing `parts/<name>.py`. Its `## Don't` section is what
-was tried and rejected, and it is the only place that records it.
+Read `parts/<name>.md` before editing `parts/<name>.py`. Its `## Don't` section is what was tried and rejected, and it is the only place that records it.
 
 If `nurb` is not on PATH: `uv tool install nurb` or `pip install nurb`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,7 @@ as though every file will be read by a stranger.
   not obvious from the code.
 - No em-dashes in user-facing copy, docs, or comments.
 - Commit messages describe what changed and why, in plain sentences.
+- **Never hard-wrap prose. Ever.** One paragraph is one line; editors soft-wrap. This applies to every markdown and text file, and it applies even when the surrounding file is already wrapped: fix the paragraph you touch instead of matching the wrapping. Code, tables, and fenced blocks keep their formatting.
 
 ## Current state
 

--- a/README.md
+++ b/README.md
@@ -25,16 +25,11 @@ nurb skill >> AGENTS.md                                # or any harness that rea
 
 ## Make something
 
-```bash
-nurb new phone_stand
-nurb dev                   # http://127.0.0.1:7373
-```
+Open your agent in the directory where the project should live, and talk:
 
-Then tell your agent:
+> Make me a phone stand: 15 degree lean, a slot for the charging cable, fits a phone 78mm wide.
 
-> Run `nurb rules`, then make me a phone stand: 15 degree lean, a slot for the charging cable, fits a phone 78mm wide.
-
-`nurb rules` prints the design doctrine (printability, load paths, kernel traps), so the agent knows how to use the tool before it starts. From there it edits `parts/phone_stand.py`, the browser updates on every save without moving your camera, and check findings pin themselves to the geometry. When it looks right: drag the sliders if you want, click `stl`, print. The `stl` and `step` buttons build at whatever the sliders hold, and a `write` button saves your slider values back into the file's defaults, where the agent will see them.
+The agent does the rest: reads the design doctrine, creates the project, models the part, runs the printability checks, and starts `nurb dev` so you get a link to watch. Every save updates the browser without moving your camera, and check findings pin themselves to the geometry. When it looks right: drag the sliders if you want, click `stl`, print. A `write` button saves your slider values back into the file's defaults, where the agent will see them.
 
 ## A part
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,15 +5,9 @@ description: Design 3D-printable parts as Python functions with nurb. Use when t
 
 # nurb
 
-A part is a Python function and its keyword defaults are its parameters. A project is any
-directory with a `parts/` folder; there is no init step. You are the CAD operator: the
-user describes the part and you do everything else, including creating the project and
-modelling. Keep `nurb dev` running in the background and hand the user its URL, because
-the browser it serves is where they judge the result.
+A part is a Python function and its keyword defaults are its parameters. A project is any directory with a `parts/` folder; there is no init step. You are the CAD operator: the user describes the part and you do everything else, including creating the project and modelling. Keep `nurb dev` running in the background and hand the user its URL, because the browser it serves is where they judge the result.
 
-**Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the
-polish pass, the kernel traps, card discipline, and what to verify. This file stays thin
-on purpose so there is one copy of that, in the package, which cannot drift.
+**Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
 
 ```
 nurb rules            the doctrine, read this first
@@ -28,7 +22,6 @@ nurb extract          find duplication across parts
 nurb dev              watch, rebuild, serve the viewer on :7373 or the next free port
 ```
 
-Read `parts/<name>.md` before editing `parts/<name>.py`. Its `## Don't` section is what
-was tried and rejected, and it is the only place that records it.
+Read `parts/<name>.md` before editing `parts/<name>.py`. Its `## Don't` section is what was tried and rejected, and it is the only place that records it.
 
 If `nurb` is not on PATH: `uv tool install nurb` or `pip install nurb`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,9 @@ description: Design 3D-printable parts as Python functions with nurb. Use when t
 
 A part is a Python function and its keyword defaults are its parameters. A project is any
 directory with a `parts/` folder; there is no init step. You are the CAD operator: the
-user describes the part, you model it, they judge it in the browser `nurb dev` serves.
+user describes the part and you do everything else, including creating the project and
+modelling. Keep `nurb dev` running in the background and hand the user its URL, because
+the browser it serves is where they judge the result.
 
 **Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the
 polish pass, the kernel traps, card discipline, and what to verify. This file stays thin

--- a/src/nurb/agents.md
+++ b/src/nurb/agents.md
@@ -2,7 +2,9 @@
 
 A part is a Python function and its keyword defaults are its parameters. A project is any
 directory with a `parts/` folder; there is no init step. You are the CAD operator: the
-user describes the part, you model it, they judge it in the browser `nurb dev` serves.
+user describes the part and you do everything else, including creating the project and
+modelling. Keep `nurb dev` running in the background and hand the user its URL, because
+the browser it serves is where they judge the result.
 
 **Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the
 polish pass, the kernel traps, card discipline, and what to verify. This file stays thin

--- a/src/nurb/agents.md
+++ b/src/nurb/agents.md
@@ -1,14 +1,8 @@
 # nurb
 
-A part is a Python function and its keyword defaults are its parameters. A project is any
-directory with a `parts/` folder; there is no init step. You are the CAD operator: the
-user describes the part and you do everything else, including creating the project and
-modelling. Keep `nurb dev` running in the background and hand the user its URL, because
-the browser it serves is where they judge the result.
+A part is a Python function and its keyword defaults are its parameters. A project is any directory with a `parts/` folder; there is no init step. You are the CAD operator: the user describes the part and you do everything else, including creating the project and modelling. Keep `nurb dev` running in the background and hand the user its URL, because the browser it serves is where they judge the result.
 
-**Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the
-polish pass, the kernel traps, card discipline, and what to verify. This file stays thin
-on purpose so there is one copy of that, in the package, which cannot drift.
+**Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
 
 ```
 nurb rules            the doctrine, read this first
@@ -23,7 +17,6 @@ nurb extract          find duplication across parts
 nurb dev              watch, rebuild, serve the viewer on :7373 or the next free port
 ```
 
-Read `parts/<name>.md` before editing `parts/<name>.py`. Its `## Don't` section is what
-was tried and rejected, and it is the only place that records it.
+Read `parts/<name>.md` before editing `parts/<name>.py`. Its `## Don't` section is what was tried and rejected, and it is the only place that records it.
 
 If `nurb` is not on PATH: `uv tool install nurb` or `pip install nurb`.

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -5,15 +5,9 @@ description: Design 3D-printable parts as Python functions with nurb. Use when t
 
 # nurb
 
-A part is a Python function and its keyword defaults are its parameters. A project is any
-directory with a `parts/` folder; there is no init step. You are the CAD operator: the
-user describes the part and you do everything else, including creating the project and
-modelling. Keep `nurb dev` running in the background and hand the user its URL, because
-the browser it serves is where they judge the result.
+A part is a Python function and its keyword defaults are its parameters. A project is any directory with a `parts/` folder; there is no init step. You are the CAD operator: the user describes the part and you do everything else, including creating the project and modelling. Keep `nurb dev` running in the background and hand the user its URL, because the browser it serves is where they judge the result.
 
-**Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the
-polish pass, the kernel traps, card discipline, and what to verify. This file stays thin
-on purpose so there is one copy of that, in the package, which cannot drift.
+**Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
 
 ```
 nurb rules            the doctrine, read this first
@@ -28,7 +22,6 @@ nurb extract          find duplication across parts
 nurb dev              watch, rebuild, serve the viewer on :7373 or the next free port
 ```
 
-Read `parts/<name>.md` before editing `parts/<name>.py`. Its `## Don't` section is what
-was tried and rejected, and it is the only place that records it.
+Read `parts/<name>.md` before editing `parts/<name>.py`. Its `## Don't` section is what was tried and rejected, and it is the only place that records it.
 
 If `nurb` is not on PATH: `uv tool install nurb` or `pip install nurb`.

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -7,7 +7,9 @@ description: Design 3D-printable parts as Python functions with nurb. Use when t
 
 A part is a Python function and its keyword defaults are its parameters. A project is any
 directory with a `parts/` folder; there is no init step. You are the CAD operator: the
-user describes the part, you model it, they judge it in the browser `nurb dev` serves.
+user describes the part and you do everything else, including creating the project and
+modelling. Keep `nurb dev` running in the background and hand the user its URL, because
+the browser it serves is where they judge the result.
 
 **Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the
 polish pass, the kernel traps, card discipline, and what to verify. This file stays thin


### PR DESCRIPTION
The README's Make-something section still told the human to run `nurb new` and `nurb dev`, which is the agent's job and the whole point. Now it says: open your agent in the directory where the project should live, describe the part, and the agent does the rest. The shim body backs that up by telling the agent it owns project creation and keeping `nurb dev` running with its URL handed to the user; skill.md, SKILL.md, and AGENTS.md are recomposed from the one body as the tests require.