### PR TITLE
Shim tells the agent to ask for fit measurements before modeling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,15 @@
 # nurb
 
-A part is a Python function and its keyword defaults are its parameters. A project is any directory with a `parts/` folder; there is no init step. You are the CAD operator: the user describes the part and you do everything else, including creating the project and modelling. Keep `nurb dev` running in the background and hand the user its URL, because the browser it serves is where they judge the result.
+A part is a Python function and its keyword defaults are its parameters. A project is any directory with a `parts/` folder; there is no init step. You are the CAD operator: the user describes the part and you do everything else, including creating the project and modelling.
 
-**Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
+**Start `nurb dev` in the background and hand the user its URL before anything else.** It prints one, and the viewer it serves is where the user watches the part take shape: every save rebuilds and repaints without moving their camera. So work in saves, not in silence. `nurb new` already emits a working part; put that blocky draft on screen in the first minute and refine it while they watch. Ten correct but invisible minutes of modelling read as a hang.
 
-**Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch before the first build, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
+**Run `nurb rules` before you design.** It prints the doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
+
+**Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch, up front, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
 
 ```
-nurb rules            the doctrine, read this first
+nurb rules            the doctrine, read this before designing
 nurb new <name>       create parts/<name>.py and its card
 nurb build [part]     build once, report size and timing
 nurb check [part]     the printability rules, --strict for CI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ A part is a Python function and its keyword defaults are its parameters. A proje
 
 **Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
 
+**Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch before the first build, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
+
 ```
 nurb rules            the doctrine, read this first
 nurb new <name>       create parts/<name>.py and its card

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,6 +9,8 @@ A part is a Python function and its keyword defaults are its parameters. A proje
 
 **Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
 
+**Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch before the first build, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
+
 ```
 nurb rules            the doctrine, read this first
 nurb new <name>       create parts/<name>.py and its card

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,14 +5,16 @@ description: Design 3D-printable parts as Python functions with nurb. Use when t
 
 # nurb
 
-A part is a Python function and its keyword defaults are its parameters. A project is any directory with a `parts/` folder; there is no init step. You are the CAD operator: the user describes the part and you do everything else, including creating the project and modelling. Keep `nurb dev` running in the background and hand the user its URL, because the browser it serves is where they judge the result.
+A part is a Python function and its keyword defaults are its parameters. A project is any directory with a `parts/` folder; there is no init step. You are the CAD operator: the user describes the part and you do everything else, including creating the project and modelling.
 
-**Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
+**Start `nurb dev` in the background and hand the user its URL before anything else.** It prints one, and the viewer it serves is where the user watches the part take shape: every save rebuilds and repaints without moving their camera. So work in saves, not in silence. `nurb new` already emits a working part; put that blocky draft on screen in the first minute and refine it while they watch. Ten correct but invisible minutes of modelling read as a hang.
 
-**Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch before the first build, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
+**Run `nurb rules` before you design.** It prints the doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
+
+**Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch, up front, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
 
 ```
-nurb rules            the doctrine, read this first
+nurb rules            the doctrine, read this before designing
 nurb new <name>       create parts/<name>.py and its card
 nurb build [part]     build once, report size and timing
 nurb check [part]     the printability rules, --strict for CI

--- a/src/nurb/agents.md
+++ b/src/nurb/agents.md
@@ -1,13 +1,15 @@
 # nurb
 
-A part is a Python function and its keyword defaults are its parameters. A project is any directory with a `parts/` folder; there is no init step. You are the CAD operator: the user describes the part and you do everything else, including creating the project and modelling. Keep `nurb dev` running in the background and hand the user its URL, because the browser it serves is where they judge the result.
+A part is a Python function and its keyword defaults are its parameters. A project is any directory with a `parts/` folder; there is no init step. You are the CAD operator: the user describes the part and you do everything else, including creating the project and modelling.
 
-**Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
+**Start `nurb dev` in the background and hand the user its URL before anything else.** It prints one, and the viewer it serves is where the user watches the part take shape: every save rebuilds and repaints without moving their camera. So work in saves, not in silence. `nurb new` already emits a working part; put that blocky draft on screen in the first minute and refine it while they watch. Ten correct but invisible minutes of modelling read as a hang.
 
-**Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch before the first build, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
+**Run `nurb rules` before you design.** It prints the doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
+
+**Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch, up front, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
 
 ```
-nurb rules            the doctrine, read this first
+nurb rules            the doctrine, read this before designing
 nurb new <name>       create parts/<name>.py and its card
 nurb build [part]     build once, report size and timing
 nurb check [part]     the printability rules, --strict for CI

--- a/src/nurb/agents.md
+++ b/src/nurb/agents.md
@@ -4,6 +4,8 @@ A part is a Python function and its keyword defaults are its parameters. A proje
 
 **Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
 
+**Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch before the first build, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
+
 ```
 nurb rules            the doctrine, read this first
 nurb new <name>       create parts/<name>.py and its card

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -9,6 +9,8 @@ A part is a Python function and its keyword defaults are its parameters. A proje
 
 **Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
 
+**Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch before the first build, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
+
 ```
 nurb rules            the doctrine, read this first
 nurb new <name>       create parts/<name>.py and its card

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -5,14 +5,16 @@ description: Design 3D-printable parts as Python functions with nurb. Use when t
 
 # nurb
 
-A part is a Python function and its keyword defaults are its parameters. A project is any directory with a `parts/` folder; there is no init step. You are the CAD operator: the user describes the part and you do everything else, including creating the project and modelling. Keep `nurb dev` running in the background and hand the user its URL, because the browser it serves is where they judge the result.
+A part is a Python function and its keyword defaults are its parameters. A project is any directory with a `parts/` folder; there is no init step. You are the CAD operator: the user describes the part and you do everything else, including creating the project and modelling.
 
-**Run `nurb rules` first.** It prints the design doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
+**Start `nurb dev` in the background and hand the user its URL before anything else.** It prints one, and the viewer it serves is where the user watches the part take shape: every save rebuilds and repaints without moving their camera. So work in saves, not in silence. `nurb new` already emits a working part; put that blocky draft on screen in the first minute and refine it while they watch. Ten correct but invisible minutes of modelling read as a hang.
 
-**Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch before the first build, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
+**Run `nurb rules` before you design.** It prints the doctrine: printability, load paths, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
+
+**Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch, up front, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
 
 ```
-nurb rules            the doctrine, read this first
+nurb rules            the doctrine, read this before designing
 nurb new <name>       create parts/<name>.py and its card
 nurb build [part]     build once, report size and timing
 nurb check [part]     the printability rules, --strict for CI


### PR DESCRIPTION
The doctrine already forbids improvising a measurement, but the shim never told the agent to front-load the asking, so an agent only met that rule after it had guessed. All four shim copies (SKILL.md, AGENTS.md, and their src/nurb twins) gain an 'Ask before you model' paragraph: ask for everything the part must fit in one batch up front, record the answers in measurements.toml, and turn taste into parameters instead of questions because the viewer's sliders are how the user answers those. Phrased harness-neutral on purpose, since naming a specific tool like Claude Code's AskUserQuestion would be noise in every other harness.

The shim also now opens with the dev server: start nurb dev in the background and hand the user its URL before anything else, then work in saves so the part takes shape on their screen instead of in private. This came from a real first run where seventeen minutes of correct modelling looked like a hang because nothing told the agent the viewer was for the user to watch, not just to judge at the end.