### PR TITLE
Viewer shows the installed version and checks PyPI for a newer one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,10 +177,7 @@ as though every file will be read by a stranger.
   what to do, never just "invalid input".
 - **The doctrine ships in the package**, exposed via `nurb rules`. One source of
   truth. `SKILL.md` and `AGENTS.md` are thin shims that point at it, never copies.
-- **The viewer works offline** and has to stay that way. three.js is vendored in
-  `src/nurb/vendor/three`, because a CAD tool that needs a CDN is broken on a plane and
-  `nurb render` drives the same page. Anything new the viewer imports gets vendored
-  too, and `pyproject.toml`'s `source-include` has to carry it.
+- **The viewer works offline.** Everything it *needs* is local: three.js is vendored in `src/nurb/vendor/three`, because a CAD tool that needs a CDN is broken on a plane, and `nurb render` drives the same page. Anything new the viewer imports gets vendored too, and `pyproject.toml`'s `source-include` has to carry it. Network is allowed for nudges that degrade silently, like the daily PyPI update check, which also stays out of headless renders.
 - **Examples are tests.** `examples/` holds real parts that the suite builds, so a
   broken example is a red build rather than a stale README.
 

--- a/docs/core/PROGRESS.md
+++ b/docs/core/PROGRESS.md
@@ -1021,7 +1021,9 @@ and now has evidence.
 
 ## Session log
 
-### 2026-07-27: The README's "not built yet" list
+### 2026-07-27: The viewer says what version it is, and whether PyPI has a newer one
+
+`__version__` now comes from `importlib.metadata`, so `pyproject.toml` is the only place the number lives; the old second copy in `__init__.py` was already one release away from drifting. The dev server sends the installed version in the sync message and the viewer shows it in a sidebar footer next to github and send-feedback links. Once a day (localStorage remembers) the viewer asks `pypi.org/pypi/nurb/json`, which sends `Access-Control-Allow-Origin: *`, and a newer release turns the badge into `v0.1.0 → 0.2.0` in the accent color with the upgrade command in the tooltip. The server does the same check on `nurb dev` startup, in a daemon thread with a one-day disk cache under `~/.cache/nurb/`, and prints one stdout line, because the primary user is an agent that reads stdout and never opens the page. Every failure path is silence: offline, slow, or odd response, the badge is just the version. `?bare=1` renders never fetch, so `nurb render` in CI stays off the network, and the check lives in `Server.run()`, which `nurb render`'s `_host` does not call. The "viewer works offline" rule in CLAUDE.md was reworded from a ban on network to what it always meant: everything the viewer *needs* is vendored, and a nudge that degrades silently is allowed.
 
 Three items, and the middle one produced this session's finding.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ dependencies = [
     "websockets>=16.1.1",
 ]
 
+[project.urls]
+Repository = "https://github.com/Shpigford/nurb"
+Issues = "https://github.com/Shpigford/nurb/issues"
+
 [project.optional-dependencies]
 # `nurb render` screenshots the viewer, which means a browser. Optional because it is
 # the only command that needs one and the download is larger than everything else here.

--- a/src/nurb/__init__.py
+++ b/src/nurb/__init__.py
@@ -9,6 +9,8 @@ A part file needs one import:
         return Box(width, height, wall)
 """
 
+import importlib.metadata as _metadata
+
 import build123d as _b3d
 from build123d import *  # noqa: F401,F403  -- geometry vocabulary
 
@@ -33,4 +35,8 @@ __all__ = [
     "measured",
     "polish",
 ]
-__version__ = "0.1.0"
+# The version lives in pyproject.toml and nowhere else; a second copy here would drift.
+try:
+    __version__ = _metadata.version("nurb")
+except _metadata.PackageNotFoundError:  # a source tree on PYTHONPATH, never installed
+    __version__ = "0.0.0"

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -9,6 +9,7 @@ import collections
 import json
 import pathlib
 import secrets
+import threading
 import traceback
 
 from watchdog.events import FileSystemEventHandler
@@ -17,10 +18,55 @@ from websockets.asyncio.server import serve
 from websockets.http11 import Response
 from websockets.datastructures import Headers
 
-from . import builder
+from . import __version__, builder
 
 VIEWER = pathlib.Path(__file__).parent / "viewer.html"
 VENDOR = (pathlib.Path(__file__).parent / "vendor").resolve()
+
+
+def _newer(current, latest):
+    """Is `latest` a later X.Y.Z than `current`? Anything unparseable is not newer."""
+    try:
+        return tuple(map(int, latest.split("."))) > tuple(map(int, current.split(".")))
+    except ValueError:
+        return False
+
+
+def _latest_on_pypi():
+    """The newest nurb on PyPI, asked at most once a day, or None.
+
+    Offline, slow, or an odd response all mean None: the check is a nudge, never a
+    requirement.
+    """
+    import time
+    import urllib.request
+
+    cache = pathlib.Path.home() / ".cache" / "nurb" / "latest"
+    try:
+        stamp, cached = cache.read_text().split()
+        if time.time() - float(stamp) < 86400:
+            return cached
+    except (OSError, ValueError):
+        pass
+    try:
+        with urllib.request.urlopen("https://pypi.org/pypi/nurb/json", timeout=3) as resp:
+            latest = json.load(resp)["info"]["version"]
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        cache.write_text(f"{time.time()} {latest}")
+        return latest
+    except Exception:
+        return None
+
+
+def _update_nudge():
+    """One line on `nurb dev` stdout when PyPI has a newer release.
+
+    A thread because the primary user is an agent reading stdout, and startup must
+    never wait on the network to say so.
+    """
+    latest = _latest_on_pypi()
+    if latest and _newer(__version__, latest):
+        print(f"  nurb {__version__} ({latest} available: uv tool upgrade nurb)", flush=True)
 
 
 def _user_traceback(exc, path):
@@ -268,6 +314,7 @@ class Server:
                 {
                     "type": "sync",
                     "project": self.root.name,
+                    "version": __version__,
                     "parts": [self._wire(e) for e in self.state.values()],
                 }
             )
@@ -445,4 +492,5 @@ class Server:
             self.ws, "127.0.0.1", self.port, process_request=self.http, origins=self.origins
         ):
             print(f"\n  nurb  http://127.0.0.1:{self.port}\n", flush=True)
+            threading.Thread(target=_update_nudge, daemon=True).start()
             await asyncio.Future()

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -110,6 +110,15 @@
   #hud, #checks { transition: opacity .12s .25s; }
   body.stale #hud, body.stale #checks { opacity: .32; }
 
+  #foot { margin-top: auto; padding: 9px 12px; border-top: 1px solid var(--line);
+          display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px 10px;
+          color: var(--dim); font-size: 10px; }
+  #version { white-space: nowrap; }
+  #version.update { color: var(--accent); }
+  #links { margin-left: auto; display: flex; gap: 10px; }
+  #foot a { color: var(--dim); text-decoration: none; }
+  #foot a:hover { color: var(--text); }
+
   /* ---- parameters ---- */
   #params { flex: 1 1 auto; min-height: 0; overflow-y: auto; border-top: 1px solid var(--line); padding: 0 12px 12px; }
   #params.empty { display: none; }
@@ -183,6 +192,13 @@
   <h1><b>nurb</b><span id="project"></span><span id="conn">connecting</span></h1>
   <div id="list"></div>
   <div id="params" class="empty"></div>
+  <div id="foot">
+    <span id="version"></span>
+    <span id="links">
+      <a href="https://github.com/Shpigford/nurb" target="_blank" rel="noreferrer">github</a>
+      <a href="https://github.com/Shpigford/nurb/issues/new" target="_blank" rel="noreferrer">send feedback</a>
+    </span>
+  </div>
 </aside>
 <main>
   <div id="empty">no parts yet. nurb new &lt;name&gt;</div>
@@ -829,6 +845,44 @@ function flash(name) {
   setTimeout(() => dot.classList.remove('busy'), 400);
 }
 
+// ---- update check ----
+// The server says what is installed; PyPI says what is newest, asked at most once a
+// day (localStorage remembers) and never in a headless render. Offline, the fetch
+// fails silently and the badge is just the installed version.
+function versionBadge(installed, latest) {
+  const el = document.getElementById('version');
+  if (!installed) return;
+  if (latest && newerVersion(installed, latest)) {
+    el.textContent = `v${installed} → ${latest}`;
+    el.title = `${latest} is out: uv tool upgrade nurb`;
+    el.classList.add('update');
+  } else {
+    el.textContent = `v${installed}`;
+  }
+}
+
+function newerVersion(a, b) {
+  const pa = a.split('.').map(Number), pb = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pb[i] || 0) - (pa[i] || 0);
+    if (d) return d > 0;
+  }
+  return false;
+}
+
+async function checkUpdate(installed) {
+  versionBadge(installed, null);
+  if (bare) return;
+  const cached = JSON.parse(localStorage.getItem('nurb-latest') || 'null');
+  if (cached && Date.now() - cached.at < 86400e3) return versionBadge(installed, cached.version);
+  try {
+    const resp = await fetch('https://pypi.org/pypi/nurb/json');
+    const latest = (await resp.json()).info.version;
+    localStorage.setItem('nurb-latest', JSON.stringify({ at: Date.now(), version: latest }));
+    versionBadge(installed, latest);
+  } catch { /* offline; the badge already shows the installed version */ }
+}
+
 // ---- socket ----
 function connect() {
   const ws = new WebSocket(`ws://${location.host}/ws`);
@@ -848,6 +902,7 @@ function connect() {
     if (msg.type === 'sync') {
       project = msg.project || '';
       document.getElementById('project').textContent = project;
+      checkUpdate(msg.version);
       parts.clear();
       msg.parts.forEach(p => parts.set(p.name, p));
       if (!current && parts.has(want)) current = want;


### PR DESCRIPTION
The viewer sidebar gains a footer with the installed version and github/feedback links, and once a day (localStorage-cached) it asks pypi.org whether a newer nurb exists, turning the badge into an upgrade hint when one does. The dev server does the same check on startup in a daemon thread with a one-day disk cache and prints one stdout line, because the primary user is an agent that reads stdout. `__version__` now comes from `importlib.metadata`, so `pyproject.toml` is the only place the number lives, and it gains repository/issues URLs. Every failure path is silent, and `?bare=1` renders never fetch, so `nurb render` in CI stays off the network. CLAUDE.md's offline rule is reworded to allow nudges that degrade silently, and PROGRESS.md logs the session.