### PR TITLE
Release 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.1.0"
+version = "0.1.1"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -428,7 +428,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Bumps the version to 0.1.1. Merging this publishes to PyPI and creates the v0.1.1 GitHub release via publish.yml; the release carries #11's viewer version badge and daily update check.