### PR TITLE
Viewer design pass: pill toolbar, Nucleo icons, severity icons in checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.4.0"
+version = "0.4.1"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -28,7 +28,10 @@
      chrome. Two `nurb dev` on two directories look identical without it. */
   aside h1 #project { color: var(--text); overflow: hidden; text-overflow: ellipsis;
                       white-space: nowrap; }
-  aside h1 #conn { margin-left: auto; flex: none; font-size: 11px; }
+  aside h1 svg { width: 13px; height: 13px; color: var(--accent); align-self: center; flex: none; }
+  /* Amber while connecting or reconnecting, gone once the socket is up. */
+  aside h1 #conn { margin-left: auto; flex: none; font-size: 10px; color: #f0c274; }
+  aside h1 #conn:empty { display: none; }
   /* The list gives way to the parameters: three parts and fifteen sliders is the
      common case, not the other way round.
 
@@ -56,13 +59,15 @@
   #hud {
     position: absolute; left: 16px; bottom: 14px; color: var(--dim);
     font-size: 11px; pointer-events: none; line-height: 1.7;
+    text-shadow: 0 1px 2px rgba(0,0,0,.5);
   }
   #hud b { color: var(--text); font-weight: 600; }
   #err {
     position: absolute; inset: auto 16px 14px 16px; max-height: 42%; overflow: auto;
-    background: #2a1618; border: 1px solid #5b2b2f; color: #ffb4b4;
-    padding: 12px 14px; border-radius: 8px; white-space: pre-wrap;
+    background: rgba(42,22,24,.94); border: 1px solid #5b2b2f; color: #ffb4b4;
+    padding: 12px 14px; border-radius: 10px; white-space: pre-wrap;
     font-size: 11px; display: none;
+    box-shadow: 0 4px 16px rgba(0,0,0,.35); backdrop-filter: blur(10px);
   }
   #tools {
     position: absolute; top: 14px; right: 14px;
@@ -70,38 +75,68 @@
   }
   button {
     background: var(--panel); color: var(--text); border: 1px solid var(--line);
-    padding: 7px 12px; border-radius: 6px; cursor: pointer; font: inherit; font-size: 11px;
+    padding: 7px 12px; border-radius: 7px; cursor: pointer; font: inherit; font-size: 11px;
   }
   button:hover { border-color: var(--dim); }
   button:focus-visible { outline: none; border-color: var(--accent); }
-  #reframe { display: none; }
-  #download { display: flex; gap: 6px; }
+  button svg, a svg { width: 12px; height: 12px; flex: none; }
+  /* One pill: borderless icon buttons on a translucent bar, dividers between groups.
+     The pill carries the border and the shadow, so the toolbar reads as a single piece
+     of chrome floating above the geometry rather than four stray buttons. */
+  .pill {
+    display: flex; align-items: center; gap: 2px; padding: 3px;
+    background: rgba(29,32,39,.9); border: 1px solid var(--line); border-radius: 9px;
+    box-shadow: 0 4px 16px rgba(0,0,0,.35); backdrop-filter: blur(10px);
+  }
+  .pill .sep { width: 1px; height: 16px; background: var(--line); margin: 0 3px; flex: none; }
+  .pill button {
+    display: inline-flex; align-items: center; gap: 6px;
+    background: none; border: none; padding: 5px 9px; border-radius: 6px; color: var(--text);
+  }
+  .pill button:hover { background: #262b34; }
+  .pill button:focus-visible { box-shadow: 0 0 0 1px var(--accent) inset; }
+  .pill button svg { color: var(--dim); }
+  .pill button:hover svg { color: var(--text); }
+  .pill button.on { color: var(--accent); background: rgba(110,231,168,.1); }
+  .pill button.on svg { color: var(--accent); }
+  #download { display: contents; }
   #download button:disabled { color: var(--dim); cursor: default; }
-  #section { display: flex; align-items: center; gap: 6px; }
-  #section .on, #polishbtn.on { border-color: var(--accent); color: var(--accent); }
-  #cut { display: none; align-items: center; gap: 4px;
-         background: var(--panel); border: 1px solid var(--line); border-radius: 6px; padding: 4px 8px; }
+  #reframe { display: none; align-items: center; gap: 6px;
+             background: rgba(29,32,39,.9); box-shadow: 0 4px 16px rgba(0,0,0,.35);
+             backdrop-filter: blur(10px); }
+  #reframe svg { color: var(--dim); }
+  #cut { display: none; align-items: center; }
   #cut.open { display: flex; }
-  #cut button { padding: 3px 7px; border: 1px solid transparent; background: none; color: var(--dim); }
-  #cut button.on { color: var(--accent); }
-  #cut input { width: 90px; }
-  #empty { position: absolute; inset: 0; display: grid; place-items: center; color: var(--dim); }
+  #cut button { padding: 4px 9px; color: var(--dim); }
+  #cut button.on { color: var(--accent); background: rgba(110,231,168,.1); }
+  #cut input { width: 110px; margin: 0 6px 0 4px; }
+  #empty { position: absolute; inset: 0; display: grid; place-items: center;
+           color: var(--dim); text-align: center; }
+  #empty svg { width: 44px; height: 44px; opacity: .45; margin-bottom: 10px; }
+  #empty code {
+    display: inline-block; margin-top: 8px; padding: 4px 10px; font: inherit;
+    background: var(--panel); border: 1px solid var(--line); border-radius: 6px;
+    color: var(--text);
+  }
   #checks {
     position: absolute; top: 14px; left: 16px; max-width: 46%; max-height: 60%;
     overflow: auto; display: none; font-size: 11px; line-height: 1.6;
-    background: rgba(29,32,39,.92); border: 1px solid var(--line);
-    border-radius: 8px; padding: 9px 11px;
+    background: rgba(29,32,39,.9); border: 1px solid var(--line);
+    border-radius: 10px; padding: 10px 12px;
+    box-shadow: 0 4px 16px rgba(0,0,0,.35); backdrop-filter: blur(10px);
   }
-  #checks h2 { font-size: 11px; font-weight: 600; color: var(--dim); margin-bottom: 5px; letter-spacing: .04em; }
+  #checks h2 { display: flex; align-items: center; gap: 6px; font-size: 11px;
+               font-weight: 600; color: var(--dim); margin-bottom: 5px; letter-spacing: .04em; }
+  #checks h2 .n { background: #262b34; border-radius: 8px; padding: 0 7px; }
   #checks .f { display: flex; gap: 7px; padding: 2px 0; cursor: default; }
   #checks .f:hover { color: #fff; }
-  #checks .tag { flex: none; width: 30px; font-weight: 600; }
-  #checks .fail .tag { color: var(--bad); }
-  #checks .warn .tag { color: #f0c274; }
+  #checks .ic { flex: none; width: 12px; height: 12px; margin-top: 2.5px; }
+  #checks .fail .ic { color: var(--bad); }
+  #checks .warn .ic { color: #f0c274; }
   /* Wide enough for the longest rule name. At 92px `projection_ratio` overflowed its
      column and printed on top of its own message. */
   #checks .rule { flex: none; color: var(--dim); width: 118px; }
-  #checks .ok { color: var(--accent); }
+  #checks .ok { color: var(--accent); display: flex; align-items: center; gap: 7px; }
   /* What a slider makes stale is the numbers, not the shape: the bbox, the build time
      and the findings all describe the solid that is being replaced. The mesh is left
      alone because fading it already means "this build failed". The .25s delay is the
@@ -123,8 +158,9 @@
              place-items: center; background: rgba(0,0,0,.45); }
   #upgrade.open { display: grid; }
   #upgrade .card { background: var(--panel); border: 1px solid var(--line);
-                   border-radius: 8px; padding: 16px 18px; width: 320px;
-                   font-size: 12px; line-height: 1.7; }
+                   border-radius: 10px; padding: 16px 18px; width: 320px;
+                   font-size: 12px; line-height: 1.7;
+                   box-shadow: 0 12px 40px rgba(0,0,0,.5); }
   #upgrade .card b { color: var(--accent); font-weight: 600; }
   #upgrade code { display: block; background: var(--bg); border: 1px solid var(--line);
                   border-radius: 6px; padding: 6px 10px; margin: 10px 0;
@@ -144,9 +180,11 @@
     display: flex; align-items: center; padding: 10px 0 6px;
     font-size: 11px; font-weight: 600; color: var(--dim); letter-spacing: .04em;
   }
-  #params h2 a { margin-left: auto; color: var(--dim); cursor: pointer; text-decoration: none; display: none; }
+  #params h2 a { margin-left: auto; color: var(--dim); cursor: pointer; text-decoration: none;
+                 display: none; align-items: center; gap: 4px; }
+  #params h2 a svg { width: 11px; height: 11px; }
   #params h2 a:hover { color: var(--text); }
-  body.dirty #params h2 a { display: block; }
+  body.dirty #params h2 a { display: flex; }
   /* Parameters the rest of the project shares, folded away. They are adjustable, and
      adjusting one is a different act from adjusting a dimension: it makes this part
      disagree with its siblings rather than changing its shape. Collapsed by default,
@@ -205,8 +243,21 @@
 </style>
 </head>
 <body>
+<!-- Nucleo icons, inlined as symbols so the viewer stays offline. Strokes are
+     currentColor: an icon is tinted by the text color of whatever holds it. -->
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <symbol id="i-download" viewBox="0 0 12 12"><line x1="6" y1="7.75" x2="6" y2=".75" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><polyline points="3.75 5.75 6 8 8.25 5.75" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><path d="m8.69,2.75c1.028,0,1.888.779,1.99,1.801l.35,3.5c.118,1.177-.807,2.199-1.99,2.199H2.96c-1.183,0-2.108-1.022-1.99-2.199l.35-3.5c.102-1.022.963-1.801,1.99-1.801" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
+  <symbol id="i-wand" viewBox="0 0 18 18"><path d="M4.49298 4.74201L3.54698 4.42701L3.23098 3.47999C3.12898 3.17399 2.62198 3.17399 2.51998 3.47999L2.20398 4.42701L1.25798 4.74201C1.10498 4.79301 1.00098 4.93603 1.00098 5.09803C1.00098 5.26003 1.10498 5.40299 1.25798 5.45399L2.20398 5.76899L2.51998 6.71601C2.57098 6.86901 2.71398 6.97199 2.87498 6.97199C3.03598 6.97199 3.17998 6.86801 3.22998 6.71601L3.54598 5.76899L4.49198 5.45399C4.64498 5.40299 4.74898 5.26003 4.74898 5.09803C4.74898 4.93603 4.64598 4.79301 4.49298 4.74201Z" fill="currentColor"/><path d="M16.658 12.99L15.395 12.5689L14.974 11.3061C14.837 10.8981 14.162 10.8981 14.025 11.3061L13.604 12.5689L12.341 12.99C12.137 13.058 11.999 13.249 11.999 13.464C11.999 13.679 12.137 13.87 12.341 13.938L13.604 14.359L14.025 15.622C14.093 15.826 14.285 15.964 14.5 15.964C14.715 15.964 14.906 15.826 14.975 15.622L15.396 14.359L16.659 13.938C16.863 13.87 17.001 13.679 17.001 13.464C17.001 13.249 16.862 13.058 16.658 12.99Z" fill="currentColor"/><path d="M5.75 2.5C6.1642 2.5 6.5 2.164 6.5 1.75C6.5 1.336 6.1642 1 5.75 1C5.3358 1 5 1.336 5 1.75C5 2.164 5.3358 2.5 5.75 2.5Z" fill="currentColor"/><path d="M2.5 15.5L9.7545 8.24542" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M8.8428 2L11.6329 3.82147L14.7153 2.55713L13.8445 5.77307L16 8.31268L12.6731 8.47852L10.9231 11.314L9.7374 8.20062L6.5 7.41333L9.0945 5.32208L8.8428 2Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+  <symbol id="i-layers" viewBox="0 0 12 12"><path d="m6.405,1.362l4.087,2.437c.343.205.343.699,0,.904l-4.087,2.437c-.249.149-.561.149-.81,0L1.507,4.702c-.343-.205-.343-.699,0-.904L5.595,1.362c.249-.149.561-.149.81,0Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><path d="m10.493,7.298c.343.205.343.699,0,.904l-4.087,2.437c-.249.149-.561.149-.81,0l-4.087-2.437c-.343-.205-.343-.699,0-.904" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
+  <symbol id="i-focus" viewBox="0 0 24 24"><path d="M3 16L3 21L8 21" stroke="currentColor" stroke-width="2" stroke-miterlimit="10" stroke-linecap="square" fill="none"/><path d="M21 8L21 3L16 3" stroke="currentColor" stroke-width="2" stroke-miterlimit="10" stroke-linecap="square" fill="none"/><path d="M21 16L21 21L16 21" stroke="currentColor" stroke-width="2" stroke-miterlimit="10" stroke-linecap="square" fill="none"/><path d="M3 8L3 3L8 3" stroke="currentColor" stroke-width="2" stroke-miterlimit="10" stroke-linecap="square" fill="none"/><path d="M12 12.01L12 12" stroke="currentColor" stroke-width="2" stroke-linecap="square" fill="none"/><path d="M12 7.01L12 7" stroke="currentColor" stroke-width="2" stroke-linecap="square" fill="none"/><path d="M7 12.01L7 12" stroke="currentColor" stroke-width="2" stroke-linecap="square" fill="none"/><path d="M17 12.01L17 12" stroke="currentColor" stroke-width="2" stroke-linecap="square" fill="none"/><path d="M12 17.01L12 17" stroke="currentColor" stroke-width="2" stroke-linecap="square" fill="none"/></symbol>
+  <symbol id="i-fail" viewBox="0 0 12 12"><circle cx="6" cy="10.125" r=".875" fill="currentColor" stroke-width="0"/><line x1="6" y1="4.75" x2="6" y2="7.75" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><path d="m8.625,10.25h1.164c1.123,0,1.826-1.216,1.265-2.189L7.265,1.484c-.562-.975-1.969-.975-2.53,0L.946,8.061c-.561.973.142,2.189,1.265,2.189h1.164" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
+  <symbol id="i-warn" viewBox="0 0 12 12"><path d="M6 11.25C8.899 11.25 11.25 8.899 11.25 6C11.25 3.101 8.899 0.75 6 0.75C3.101 0.75 0.75 3.101 0.75 6C0.75 8.899 3.101 11.25 6 11.25Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M6 9.5C6.483 9.5 6.875 9.108 6.875 8.625C6.875 8.142 6.483 7.75 6 7.75C5.517 7.75 5.125 8.142 5.125 8.625C5.125 9.108 5.517 9.5 6 9.5Z" fill="currentColor"/><path d="M6 3.5V6.25" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+  <symbol id="i-ok" viewBox="0 0 12 12"><circle cx="6" cy="6" r="5.25" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><polyline points="3.747 6.5 5.25 8 8.253 4" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
+  <symbol id="i-cube" viewBox="0 0 18 18"><polyline points="14.983 5.53 9 9 3.017 5.53" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><line x1="9" y1="15.938" x2="9" y2="9" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><path d="M7.997,2.332L3.747,4.797c-.617,.358-.997,1.017-.997,1.73v4.946c0,.713,.38,1.372,.997,1.73l4.25,2.465c.621,.36,1.386,.36,2.007,0l4.25-2.465c.617-.358,.997-1.017,.997-1.73V6.527c0-.713-.38-1.372-.997-1.73l-4.25-2.465c-.621-.36-1.386-.36-2.007,0Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
+  <symbol id="i-reset" viewBox="0 0 18 18"><path d="M5.25 9.5L3 7.25L0.75 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13.495 13.345C12.3587 14.5226 10.7641 15.25 9 15.25C5.548 15.25 2.75 12.45 2.75 9C2.75 8.4 2.834 7.83003 2.99 7.28003" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M12.75 8.5L15 10.75L17.25 8.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M4.50629 4.65564C5.64249 3.48544 7.23658 2.75 8.99998 2.75C12.452 2.75 15.25 5.55 15.25 9C15.25 9.58 15.171 10.14 15.024 10.67" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+</svg>
 <aside>
-  <h1><b>nurb</b><span id="project"></span><span id="conn">connecting</span></h1>
+  <h1><svg><use href="#i-cube"/></svg><b>nurb</b><span id="project"></span><span id="conn">connecting</span></h1>
   <div id="list"></div>
   <div id="params" class="empty"></div>
   <div id="foot">
@@ -226,23 +277,31 @@
   </div>
 </div>
 <main>
-  <div id="empty">no parts yet. nurb new &lt;name&gt;</div>
+  <div id="empty">
+    <div>
+      <svg><use href="#i-cube"/></svg>
+      <div>no parts yet</div>
+      <code>nurb new &lt;name&gt;</code>
+    </div>
+  </div>
   <div id="tools">
-    <div id="download">
-      <button data-fmt="stl">stl</button>
-      <button data-fmt="step">step</button>
-    </div>
-    <button id="reframe">reframe</button>
-    <button id="polishbtn" title="chamfer the exposed edges; off is the faster draft build">polish</button>
-    <div id="section">
-      <div id="cut">
-        <button data-axis="x">x</button>
-        <button data-axis="y">y</button>
-        <button data-axis="z">z</button>
-        <input id="cutpos" type="range" min="0" max="1" step="0.002" value="0.5">
+    <div class="pill">
+      <div id="download">
+        <button data-fmt="stl" title="download an STL built at the current slider values"><svg><use href="#i-download"/></svg><span>stl</span></button>
+        <button data-fmt="step" title="download a STEP built at the current slider values"><svg><use href="#i-download"/></svg><span>step</span></button>
       </div>
-      <button id="sectionbtn">section</button>
+      <span class="sep"></span>
+      <button id="polishbtn" title="chamfer the exposed edges; off is the faster draft build"><svg><use href="#i-wand"/></svg><span>polish</span></button>
+      <span class="sep"></span>
+      <button id="sectionbtn" title="cut the part open along an axis"><svg><use href="#i-layers"/></svg><span>section</span></button>
     </div>
+    <div class="pill" id="cut">
+      <button data-axis="x">x</button>
+      <button data-axis="y">y</button>
+      <button data-axis="z">z</button>
+      <input id="cutpos" type="range" min="0" max="1" step="0.002" value="0.5">
+    </div>
+    <button id="reframe" title="refit the camera to the part"><svg><use href="#i-focus"/></svg><span>reframe</span></button>
   </div>
   <div id="hud"></div>
   <div id="checks"></div>
@@ -436,8 +495,9 @@ function sectionUpdate() {
 for (const b of document.querySelectorAll('#download button')) {
   b.onclick = async () => {
     if (!current) return;
-    const fmt = b.dataset.fmt, was = b.textContent;
-    b.disabled = true; b.textContent = 'building';
+    // The label lives in a span so swapping it leaves the icon alone.
+    const fmt = b.dataset.fmt, lab = b.querySelector('span'), was = lab.textContent;
+    b.disabled = true; lab.textContent = 'building';
     try {
       const r = await fetch(`/export/${current}.${fmt}`);
       if (!r.ok) throw new Error(await r.text());
@@ -450,7 +510,7 @@ for (const b of document.querySelectorAll('#download button')) {
       const note = document.getElementById('note');
       if (note) { note.classList.add('bad'); note.textContent = `export failed: ${e.message}`; }
     } finally {
-      b.disabled = false; b.textContent = was;
+      b.disabled = false; lab.textContent = was;
     }
   };
 }
@@ -596,7 +656,7 @@ async function paint(name, { keepCamera }) {
     if (!restoreCamera(name)) frame(box);
     reframe.style.display = 'none';
   } else {
-    reframe.style.display = jumped ? 'block' : 'none';
+    reframe.style.display = jumped ? 'inline-flex' : 'none';
   }
   reframe.onclick = () => { frame(box); reframe.style.display = 'none'; };
   lastSize = size;
@@ -616,13 +676,15 @@ function checks(name) {
   if (!e || e.error || found === null || found === undefined) { box.style.display = 'none'; return; }
   box.style.display = 'block';
   if (!found.length) {
-    box.innerHTML = '<h2>checks</h2><div class="ok">clean</div>';
+    box.innerHTML = '<h2>checks</h2><div class="ok"><svg class="ic"><use href="#i-ok"/></svg>clean</div>';
     return;
   }
+  // The icon is the severity tag: shape and color both carry it, the title spells it out.
   const rows = found.map(f =>
-    `<div class="f ${f.severity}"><span class="tag">${f.severity}</span>`
+    `<div class="f ${f.severity}" title="${f.severity}">`
+    + `<svg class="ic"><use href="#i-${f.severity === 'fail' ? 'fail' : 'warn'}"/></svg>`
     + `<span class="rule">${f.rule}</span><span>${f.message}</span></div>`).join('');
-  box.innerHTML = `<h2>checks (${found.length})</h2>${rows}`;
+  box.innerHTML = `<h2>checks <span class="n">${found.length}</span></h2>${rows}`;
   const lift = mesh ? mesh.position.z : 0;
   for (const f of found) {
     if (!f.where) continue;
@@ -722,7 +784,8 @@ function params(e) {
   box.classList.toggle('empty', !rows.length);
   if (!rows.length) { box.innerHTML = ''; document.body.classList.remove('dirty'); return; }
 
-  box.innerHTML = '<h2>parameters<a id="resetall" title="reset every parameter">reset</a></h2>';
+  box.innerHTML = '<h2>parameters<a id="resetall" title="reset every parameter">'
+    + '<svg><use href="#i-reset"/></svg>reset</a></h2>';
   // Split, not filtered: a family constant stays reachable, it just stops competing for
   // attention with the dimensions this part actually owns.
   const shared = rows.filter(p => p.family);

--- a/uv.lock
+++ b/uv.lock
@@ -428,7 +428,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
A UI pass on the viewer, patterned on Spline's viewport chrome: the four stray toolbar buttons become one translucent pill of borderless icon buttons with dividers, the section axis picker becomes a segmented control in its own pill, and floating panels (checks, error, upgrade modal) gain matching blur, radius, and shadow. Icons are Nucleo outlines inlined as SVG symbols with currentColor strokes, so the viewer stays offline and hover/on states tint them; they cover export, polish, section, reframe, checks severities, the brand mark, the empty state, and the reset link. The checks panel swaps its fail/warn words for colored icons with a count chip, and the export button's label moves into a span so the 'building' swap can't wipe its icon. Verified live in the browser across default, section, dirty-parameter, export, build-failure, and findings states; the 49 viewer-touching tests pass. Purely cosmetic, so the version bumps to 0.4.1.