### PR TITLE
Bind the dev server port before the first build

### DIFF
--- a/src/nurb/cli.py
+++ b/src/nurb/cli.py
@@ -526,7 +526,6 @@ def cmd_dev(args):
     port = _pick_port(args.port)
     server = Server(root, port=port, draft=args.draft, open_browser=args.open)
     print(f"  building {root.name}/parts")
-    server.rebuild_all()
     try:
         asyncio.run(server.run())
     except KeyboardInterrupt:

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -198,17 +198,6 @@ class Server:
             ]
         return entry
 
-    def rebuild_all(self):
-        for path in builder.find_parts(self.root):
-            entry = self.rebuild(path)
-            self.check(path)
-            status = entry["error"] or f"{entry['ms']}ms"
-            note = ""
-            if entry.get("findings"):
-                bad = sum(1 for f in entry["findings"] if f["severity"] == "fail")
-                note = f"  {len(entry['findings'])} finding(s), {bad} to fix"
-            print(f"  {entry['name']}: {status}{note}", flush=True)
-
     # ---------- http ----------
 
     async def http(self, connection, request):
@@ -552,6 +541,11 @@ class Server:
         self.watch()
         # Held too: asyncio only keeps weak references to tasks.
         self.drain_task = asyncio.create_task(self.drain())
+        # The whole project goes through the same queue a save does, so the bind never
+        # waits on a build. An agent hands out the URL the moment it prints, and a
+        # project's worth of builds behind it was seconds of connection refused.
+        for path in builder.find_parts(self.root):
+            self.queue.put_nowait(str(path))
         async with serve(
             self.ws, "127.0.0.1", self.port, process_request=self.http, origins=self.origins
         ):


### PR DESCRIPTION
`nurb dev` built and checked every part before binding its socket, so the URL was connection refused for the whole initial build: 9.4s on the notch examples, 2.5s minimum. An agent backgrounds the server and hands out the URL immediately (skill.md says to), so a user clicking right away saw a dead page and had to refresh, which is exactly the quirk a Codex user reported on 0.4.1.

`run()` now enqueues every part onto the same queue a file save uses, right before binding, and `rebuild_all()` is deleted since `cmd_dev` was its only caller. The page loads immediately, parts stream in through the existing `rebuilt`/`checked` broadcasts, and the viewer already auto-selects the first part to land. Verified on notch: port accepts connections at 2.6s (down from 9.4s), an early websocket client has all 13 parts by 7.8s, and the suite passes (247 passed, 1 skipped).