### PR TITLE
nurb dev --open honors the macOS default browser

### DIFF
--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -76,6 +76,23 @@ def _upgrade_command():
     return None
 
 
+def _open_viewer(url):
+    """Open the viewer in the user's default browser.
+
+    On macOS the stdlib webbrowser module drives an AppleScript `open location`,
+    which lands in Safari regardless of the LaunchServices default. /usr/bin/open
+    consults LaunchServices, so it opens the browser the user actually set. A failed
+    open is not fatal either way; the URL is already on stdout.
+    """
+    import subprocess
+    import sys
+
+    if sys.platform == "darwin":
+        subprocess.run(["/usr/bin/open", url], check=False)
+    else:
+        webbrowser.open(url)
+
+
 def _update_nudge():
     """One line on `nurb dev` stdout when PyPI has a newer release.
 
@@ -598,6 +615,6 @@ class Server:
             print(f"\n  nurb  http://127.0.0.1:{self.port}\n", flush=True)
             if self.open_browser:
                 # After the bind, or the browser lands on a connection refused.
-                webbrowser.open(f"http://127.0.0.1:{self.port}")
+                _open_viewer(f"http://127.0.0.1:{self.port}")
             threading.Thread(target=_update_nudge, daemon=True).start()
             await asyncio.Future()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -229,7 +229,7 @@ def test_open_browser_fires_after_the_bind(tmp_path, monkeypatch):
     (tmp_path / "parts").mkdir()
     srv = Server(tmp_path, port=port, open_browser=True)
     opened = []
-    monkeypatch.setattr(server_mod.webbrowser, "open", lambda url: opened.append(url))
+    monkeypatch.setattr(server_mod, "_open_viewer", lambda url: opened.append(url))
     monkeypatch.setattr(server_mod, "_update_nudge", lambda: None)
 
     async def go():
@@ -246,3 +246,27 @@ def test_open_browser_fires_after_the_bind(tmp_path, monkeypatch):
     if srv.observer:
         srv.observer.stop()
     assert opened == [f"http://127.0.0.1:{port}"]
+
+
+def test_open_viewer_uses_launchservices_on_macos(monkeypatch):
+    """webbrowser's AppleScript path opens Safari regardless of the system default,
+    so on macOS the viewer goes through /usr/bin/open instead (issue #18)."""
+    import subprocess
+
+    from nurb import server as server_mod
+
+    ran = []
+    monkeypatch.setattr(subprocess, "run", lambda argv, **kw: ran.append(argv))
+    monkeypatch.setattr("sys.platform", "darwin")
+    server_mod._open_viewer("http://127.0.0.1:7373")
+    assert ran == [["/usr/bin/open", "http://127.0.0.1:7373"]]
+
+
+def test_open_viewer_uses_webbrowser_elsewhere(monkeypatch):
+    from nurb import server as server_mod
+
+    opened = []
+    monkeypatch.setattr(server_mod.webbrowser, "open", lambda url: opened.append(url))
+    monkeypatch.setattr("sys.platform", "linux")
+    server_mod._open_viewer("http://127.0.0.1:7373")
+    assert opened == ["http://127.0.0.1:7373"]


### PR DESCRIPTION
On macOS the stdlib webbrowser module drives an AppleScript `open location`, which lands in Safari regardless of the LaunchServices handler, so `nurb dev --open` ignored the browser set in System Settings. The server now opens the viewer through `/usr/bin/open` on macOS, which consults LaunchServices, and keeps `webbrowser.open()` on other platforms; `check=False` preserves the behavior that a failed open never takes the server down. Verified live on a machine whose default is Dia: the old path opened Safari, the new one opens Dia. Tests cover both platform branches, and the existing bind-ordering test now patches the helper so the suite no longer launches a real browser on macOS.

Fixes #18.