### PR TITLE
Fix Chrome's hanging websocket handshake and make the viewer degrade gracefully (#17)

### DIFF
--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -278,6 +278,11 @@ class Server:
                 "Content-Type": content_type,
                 "Content-Length": str(len(body)),
                 "Cache-Control": "no-store",
+                # websockets tears the connection down after a process_request
+                # response. Without this header the response reads as keep-alive,
+                # Chrome pools the socket, and its next request on it, including
+                # the /ws upgrade, dies silently (#17).
+                "Connection": "close",
             }
         )
         if attach:

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -291,8 +291,8 @@
   <div id="empty">
     <div>
       <svg><use href="#i-cube"/></svg>
-      <div>no parts yet</div>
-      <code>nurb new &lt;name&gt;</code>
+      <div id="emptymsg">no parts yet</div>
+      <code id="emptycmd">nurb new &lt;name&gt;</code>
     </div>
   </div>
   <div id="tools">
@@ -979,6 +979,7 @@ function render() {
   // Here rather than on the sync message, so the first part written into an empty
   // project brings the tools back without a reload.
   document.body.classList.toggle('noparts', parts.size === 0);
+  emptyState();
   for (const e of parts.values()) {
     const row = document.createElement('div');
     row.className = 'item' + (e.name === current ? ' active' : '');
@@ -1088,17 +1089,48 @@ async function checkUpdate(installed) {
 }
 
 // ---- socket ----
+
+// "This project has no parts" and "the socket is down" must not read the same:
+// the first prescribes `nurb new`, the second means the viewer is blind.
+function emptyState() {
+  const live = sock && sock.readyState === WebSocket.OPEN;
+  document.getElementById('emptymsg').textContent = live ? 'no parts yet' : 'not connected';
+  document.getElementById('emptycmd').textContent = live ? 'nurb new <name>' : 'nurb dev';
+}
+
+// The socket is the only live channel, but /api/parts serves the same rows a sync
+// carries, so a viewer whose socket is down degrades to a static-but-correct view
+// instead of asserting an empty project.
+async function fallback() {
+  if (parts.size) return;
+  try {
+    const rows = await (await fetch('/api/parts')).json();
+    if (parts.size || !rows.length) return;  // a sync won the race, or truly empty
+    rows.forEach(p => parts.set(p.name, p));
+    current = parts.has(want) ? want : rows[0].name;
+    render();
+    show(current, { keepCamera: false });
+  } catch { /* server gone entirely; the empty state already says so */ }
+}
+
 function connect() {
   const ws = new WebSocket(`ws://${location.host}/ws`);
   sock = ws;
   const conn = document.getElementById('conn');
-  ws.onopen = () => conn.textContent = '';
+  // A handshake that hangs fires neither onopen nor onclose (#17 saw Chrome do
+  // exactly that on a pooled connection), which would leave "connecting" up forever
+  // with no retry. Give up and go around again on a fresh socket.
+  const stuck = setTimeout(() => ws.close(), 4000);
+  ws.onopen = () => { clearTimeout(stuck); conn.textContent = ''; emptyState(); };
   ws.onclose = () => {
+    clearTimeout(stuck);
     conn.textContent = 'reconnecting';
     // Nothing is coming back, so the in-flight rebuild has to be forgotten or the
     // sliders go dead for good.
     inflight = null;
     document.body.classList.remove('stale');
+    emptyState();
+    fallback();
     setTimeout(connect, 1000);
   };
   ws.onmessage = ev => {


### PR DESCRIPTION
The viewer's HTTP responses read as keep-alive, but websockets tears the connection down after a `process_request` response, so Chrome pooled the socket and its next request on it, including the /ws upgrade, died silently, and the handshake hung in CONNECTING forever. The server now sends `Connection: close` on those responses. The viewer also stops trusting a handshake that never resolves: a 4-second timeout closes a stuck socket and retries on a fresh one, since a hung handshake fires neither `onopen` nor `onclose`. The empty state now distinguishes "no parts yet" (run `nurb new`) from "not connected" (run `nurb dev`), and when the socket is down the viewer falls back to `/api/parts` so a project with parts still renders them instead of claiming to be empty.

Fixes #17.