### PR TITLE
Assemblies: check the motion between parts

### DIFF
--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -15,6 +15,8 @@ A part is a Python function and its keyword defaults are its parameters. A proje
 
 **Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch, up front, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
 
+**When parts have to work together, assemble them before printing either.** A part that mounts to another, or moves against one, gets an `@assembly`: a function in `parts/` that returns placed solids, with `use()` building the siblings, `hinge()` declaring how one moves, and `obstacle()` standing in for the machine or wall they mount into. `nurb check` then sweeps each joint through its declared range and reports the angle where it jams and where the contact is, which is the one failure no per-part check can see: a door that builds clean, checks clean, prints beautifully and will not open. The joint angle is a keyword default, so the viewer's slider swings the assembly live for the user. Model obstacles from the user's measurements, and say on the assembly's card how rough they are.
+
 **Finish with the polish pass.** Chamfered edges are what make a print feel designed rather than extruded, so the doctrine's last step (`polish`, 1mm on exposed edges) stays in the part through every edit; the template `nurb new` emits already ends with it. Say so when you hand the part over, because the user can only ask for sharp edges if they know the chamfers are there on purpose. The viewer builds polished by default, and its polish button flips to the faster draft build.
 
 **Write the card before you hand the part over, even for a single part.** A part gets printed, used, and then revisited weeks later to adjust something, and by then the session that built it is gone. `## Don't` is the only record of what was tried and rejected, so without it the next agent helpfully re-adds the lead-in chamfer that was retired on purpose. There is no one-off: there is the first session and the ones after it, and the card is what you are leaving for them.
@@ -24,7 +26,7 @@ nurb rules            the doctrine, read this before designing
 nurb api              the vocabulary a part file gets, with signatures
 nurb new <name>       create parts/<name>.py and its card
 nurb build [part]     build once, report size and timing
-nurb check [part]     the printability rules, --strict for CI
+nurb check [part]     the printability rules; on an assembly, the motion sweep. --strict for CI
 nurb inspect [part]   faces, normals, concave edges, each finding on its face
 nurb card [part]      regenerate a card's AUTO block
 nurb verify [part]    the doctrine's verification list: solids, flex, checks, card

--- a/src/nurb/__init__.py
+++ b/src/nurb/__init__.py
@@ -14,6 +14,7 @@ import importlib.metadata as _metadata
 import build123d as _b3d
 from build123d import *  # noqa: F401,F403  -- geometry vocabulary
 
+from .assembly import assembly, hinge, obstacle, use  # noqa: E402
 from .checks import concave_edges, is_convex  # noqa: E402
 from .measurements import measured  # noqa: E402
 from .polish import chamfer, polish  # noqa: E402  -- must win, see below
@@ -39,6 +40,10 @@ __all__ = [
     "concave_edges",
     "measured",
     "polish",
+    "assembly",
+    "use",
+    "hinge",
+    "obstacle",
 ]
 # The version lives in pyproject.toml and nowhere else; a second copy here would drift.
 try:

--- a/src/nurb/agents.md
+++ b/src/nurb/agents.md
@@ -10,6 +10,8 @@ A part is a Python function and its keyword defaults are its parameters. A proje
 
 **Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch, up front, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
 
+**When parts have to work together, assemble them before printing either.** A part that mounts to another, or moves against one, gets an `@assembly`: a function in `parts/` that returns placed solids, with `use()` building the siblings, `hinge()` declaring how one moves, and `obstacle()` standing in for the machine or wall they mount into. `nurb check` then sweeps each joint through its declared range and reports the angle where it jams and where the contact is, which is the one failure no per-part check can see: a door that builds clean, checks clean, prints beautifully and will not open. The joint angle is a keyword default, so the viewer's slider swings the assembly live for the user. Model obstacles from the user's measurements, and say on the assembly's card how rough they are.
+
 **Finish with the polish pass.** Chamfered edges are what make a print feel designed rather than extruded, so the doctrine's last step (`polish`, 1mm on exposed edges) stays in the part through every edit; the template `nurb new` emits already ends with it. Say so when you hand the part over, because the user can only ask for sharp edges if they know the chamfers are there on purpose. The viewer builds polished by default, and its polish button flips to the faster draft build.
 
 **Write the card before you hand the part over, even for a single part.** A part gets printed, used, and then revisited weeks later to adjust something, and by then the session that built it is gone. `## Don't` is the only record of what was tried and rejected, so without it the next agent helpfully re-adds the lead-in chamfer that was retired on purpose. There is no one-off: there is the first session and the ones after it, and the card is what you are leaving for them.
@@ -19,7 +21,7 @@ nurb rules            the doctrine, read this before designing
 nurb api              the vocabulary a part file gets, with signatures
 nurb new <name>       create parts/<name>.py and its card
 nurb build [part]     build once, report size and timing
-nurb check [part]     the printability rules, --strict for CI
+nurb check [part]     the printability rules; on an assembly, the motion sweep. --strict for CI
 nurb inspect [part]   faces, normals, concave edges, each finding on its face
 nurb card [part]      regenerate a card's AUTO block
 nurb verify [part]    the doctrine's verification list: solids, flex, checks, card

--- a/src/nurb/assembly.py
+++ b/src/nurb/assembly.py
@@ -237,6 +237,17 @@ def assembly(fn):
 _EPS = 1e-4  # mm3; below this an intersection is numerical noise, not a collision
 
 
+def _inside(bb, outer, slack=0.5):
+    return (
+        bb.min.X >= outer.min.X - slack
+        and bb.min.Y >= outer.min.Y - slack
+        and bb.min.Z >= outer.min.Z - slack
+        and bb.max.X <= outer.max.X + slack
+        and bb.max.Y <= outer.max.Y + slack
+        and bb.max.Z <= outer.max.Z + slack
+    )
+
+
 def _hits(moved, others):
     """The overlap volume and where it is, or (0, None)."""
     worst, where = 0.0, None
@@ -248,12 +259,23 @@ def _hits(moved, others):
             vol = 0.0
         if vol > max(_EPS, worst):
             bb = common.bounding_box()
+            # A real intersection is a subset of both inputs. OCCT handed a
+            # degenerate solid can return chunks of the other operand instead,
+            # which would read as a huge phantom collision; refusing it loudly
+            # names the solid to fix, where a silent zero would hide it and a
+            # phantom finding would send someone redesigning a working hinge.
+            label = getattr(other, "label", "") or "a fixed part"
+            if not _inside(bb, other.bounding_box()):
+                raise ValueError(
+                    f"intersecting with {label} returned geometry outside it "
+                    f"({vol:.0f}mm3) -- that solid is likely degenerate"
+                )
             worst = vol
             where = (
                 (bb.min.X + bb.max.X) / 2,
                 (bb.min.Y + bb.max.Y) / 2,
                 (bb.min.Z + bb.max.Z) / 2,
-                getattr(other, "label", "") or "a fixed part",
+                label,
             )
     return worst, where
 

--- a/src/nurb/assembly.py
+++ b/src/nurb/assembly.py
@@ -56,6 +56,27 @@ class Hinge:
     at: float
     name: str
     step: float
+    param: str | None = None  # the keyword that drove `at`, when one did
+
+
+class _Named(float):
+    """A float that remembers which parameter it was.
+
+    The viewer wants to drive a joint without a rebuild, and for that it has to know
+    which slider is which hinge. Nothing in `hinge(at=open_deg)` says so -- by the
+    time the value arrives it is just 0.0. So the runtime hands the assembly function
+    its float arguments wrapped in these, and `hinge` reads the name straight off its
+    `at`. Passed through arithmetic the name is lost, which is the right behaviour:
+    `at=open_deg / 2` is no longer the slider's own value, and a rebuild is the only
+    honest way to pose it.
+    """
+
+    __slots__ = ("param",)
+
+    def __new__(cls, value, param):
+        self = float.__new__(cls, value)
+        self.param = param
+        return self
 
 
 @dataclass
@@ -150,6 +171,7 @@ def hinge(solid, axis, through, at=0.0, name=None, step=3.0):
         at=float(at),
         name=name or getattr(solid, "label", "") or "the moving part",
         step=float(step),
+        param=getattr(at, "param", None),
     )
     return posed
 
@@ -200,7 +222,11 @@ def assembly(fn):
         rec = _Recorder(draft=draft)
         _active.append(rec)
         try:
-            call = dict(kwargs)
+            # Floats go in knowing their own names, so `hinge(at=open_deg)` can tie
+            # the joint to the slider that drives it. Bools are ints; leave both.
+            call = {
+                k: _Named(v, k) if type(v) is float else v for k, v in kwargs.items()
+            }
             if takes_draft:
                 call["draft"] = draft
             result = fn(**call)

--- a/src/nurb/assembly.py
+++ b/src/nurb/assembly.py
@@ -35,12 +35,11 @@ carries about width.
 
 import copy
 import functools
-import inspect
 import pathlib
 import sys
 from dataclasses import dataclass, field
 
-from .registry import PartDef
+from .registry import PartDef, declared
 
 # Findings come from checks.py's vocabulary so an assembly's report reads exactly like
 # a part's: same severities, same line format, same sorting.
@@ -89,6 +88,32 @@ class Scene:
     uses: tuple = ()  # the part files use() built, so a watcher can rebuild dependents
 
 
+NODE = "joint{}"  # the GLB node for scene.hinges[i]; the exporter and the payload both speak it
+
+
+def wire(scene):
+    """The joints as the part payload carries them: which GLB node each hinge is,
+    about what axis it turns, and which slider drives it.
+
+    This is the viewer's half of the client-side posing contract. With it a joint
+    drag is a transform at whatever rate the screen paints, not a rebuild
+    round-trip per tick.
+    """
+    return [
+        {
+            "node": NODE.format(i),
+            "param": h.param,
+            "name": h.name,
+            "origin": [h.axis.position.X, h.axis.position.Y, h.axis.position.Z],
+            "dir": [h.axis.direction.X, h.axis.direction.Y, h.axis.direction.Z],
+            "lo": h.lo,
+            "hi": h.hi,
+            "at": h.at,
+        }
+        for i, h in enumerate(scene.hinges)
+    ]
+
+
 @dataclass
 class _Recorder:
     draft: bool = False
@@ -110,14 +135,12 @@ def _recorder(who):
 
 
 def _caller_root():
-    """The project of the file that called, found the way measurements finds it."""
+    """The project of the file that called, found the way the CLI finds it."""
+    from .cli import project_root
+
     frame = sys._getframe(2)
     here = frame.f_globals.get("__file__")
-    start = pathlib.Path(here).resolve().parent if here else pathlib.Path.cwd()
-    for d in [start, *start.parents]:
-        if (d / "parts").is_dir():
-            return d
-    return start
+    return project_root(pathlib.Path(here).resolve().parent if here else None)
 
 
 _built = {}  # (path, stamp, overrides, draft) -> shape
@@ -227,13 +250,7 @@ def assembly(fn):
     compounds them for display and carries the recorded joints on the compound, which
     is how `nurb check` knows to sweep instead of running the printability rules.
     """
-    sig = inspect.signature(fn)
-    params = {
-        n: (None if p.default is inspect.Parameter.empty else p.default)
-        for n, p in sig.parameters.items()
-        if n != "draft"
-    }
-    takes_draft = "draft" in sig.parameters
+    params, takes_draft = declared(fn)
 
     @functools.wraps(fn)
     def wrapped(**kwargs):

--- a/src/nurb/assembly.py
+++ b/src/nurb/assembly.py
@@ -86,6 +86,7 @@ class Scene:
     hinges: list = field(default_factory=list)
     statics: list = field(default_factory=list)  # placed parts that do not move
     obstacles: list = field(default_factory=list)  # context geometry, never printed
+    uses: tuple = ()  # the part files use() built, so a watcher can rebuild dependents
 
 
 @dataclass
@@ -93,6 +94,7 @@ class _Recorder:
     draft: bool = False
     hinges: dict = field(default_factory=dict)  # id(solid) -> Hinge
     obstacles: dict = field(default_factory=dict)  # id(solid) -> name
+    uses: set = field(default_factory=set)  # resolved paths use() has built
 
 
 _active = []  # the recorder for the @assembly call currently executing, if any
@@ -118,27 +120,46 @@ def _caller_root():
     return start
 
 
-_built = {}  # (path, mtime, overrides, draft) -> shape
+_built = {}  # (path, stamp, overrides, draft) -> shape
+
+# Geometry can come from outside the part file: measured() reads measurements.toml
+# and any part can import from system.py. A cache keyed on the part's mtime alone
+# would keep serving the old solid after either of those changed -- silently, which
+# is the exact failure measurements.toml exists to prevent.
+_SHARED = ("system.py", "measurements.toml")
+
+
+def _stamp(root, path):
+    times = [path.stat().st_mtime_ns]
+    for name in _SHARED:
+        shared = root / name
+        if shared.is_file():
+            times.append(shared.stat().st_mtime_ns)
+    return max(times)
 
 
 def use(name, **overrides):
     """Build a sibling part by name and return its solid, placed where it was modelled.
 
-    Cached on the file's mtime, so dragging an assembly slider in the viewer does not
-    pay for a rebuild of every part it places. Each call returns a fresh wrapper around
-    the cached geometry, because the caller is about to move it and two assemblies
-    sharing one Python object would move each other.
+    Cached, so dragging an assembly slider in the viewer does not pay for a rebuild of
+    every part it places. The cache stamp covers the part file and the shared files
+    that can feed its geometry, so a save to any of them lands on the next build. Each
+    call returns a fresh wrapper around the cached geometry, because the caller is
+    about to move it and two assemblies sharing one Python object would move each
+    other.
     """
     from . import builder
 
     rec = _recorder("use()")
-    path = _caller_root() / "parts" / f"{name.replace('-', '_')}.py"
+    root = _caller_root()
+    path = root / "parts" / f"{name.replace('-', '_')}.py"
     if not path.is_file():
         raise FileNotFoundError(f"no part named {name!r} ({path} does not exist)")
-    key = (str(path), path.stat().st_mtime_ns, tuple(sorted(overrides.items())), rec.draft)
+    rec.uses.add(str(path))
+    key = (str(path), _stamp(root, path), tuple(sorted(overrides.items())), rec.draft)
     if key not in _built:
         _built[key] = builder.build(path, overrides=overrides or None, draft=rec.draft)[0]
-        # One mtime per file: a save invalidates, history does not accumulate.
+        # One stamp per file: a save invalidates, history does not accumulate.
         stale = [k for k in _built if k[0] == key[0] and k[1] != key[1]]
         for k in stale:
             del _built[k]
@@ -241,7 +262,7 @@ def assembly(fn):
                     f"hinge({h.name!r}) was declared but the hinged solid was not "
                     f"returned. Return what hinge() returned, not what went in."
                 )
-        scene = Scene()
+        scene = Scene(uses=tuple(sorted(rec.uses)))
         for s in solids:
             if id(s) in rec.hinges:
                 scene.hinges.append(rec.hinges[id(s)])

--- a/src/nurb/assembly.py
+++ b/src/nurb/assembly.py
@@ -1,0 +1,338 @@
+"""Assemblies: placed parts, a joint, and the sweep that catches a jam before a print.
+
+Every rule in checks.py judges one solid being manufactured. Nothing judges two solids
+being *used*: a door that cannot open past 45 degrees builds clean, checks clean,
+exports watertight and prints beautifully, because no check anywhere holds the door and
+its mount in the same hand. The failure is only visible in the motion, and the motion
+was in nobody's model. This module puts it in the model.
+
+An assembly is a part file whose function returns placed solids instead of one solid:
+
+    from nurb import *
+
+    @assembly
+    def privacy_cover(open_deg=0.0):
+        mount = use("prompter_mount")
+        door = Pos(0, 30, 24) * Rot(0, 0, 180) * use("prompter_door")
+        door = hinge(door, Axis((0, 38, 24), (1, 0, 0)), through=(0, 180), at=open_deg)
+        machine = obstacle(Pos(0, -100, -110) * Box(224, 230, 219), "the prompter")
+        return mount, door, machine
+
+The joint parameter is an ordinary keyword default, so the viewer's existing slider
+already animates it: drag `open_deg` and the door swings in the browser. Nothing in the
+viewer knows assemblies exist.
+
+`nurb check` on an assembly runs the sweep instead of the printability rules: each
+hinged solid is rotated through its declared range and intersected against everything
+else, and the finding reports the angle where it jams and the coordinates of the
+contact. The printability rules still run where they belong, on the individual parts.
+
+Collision is measured as intersection volume, so two faces that merely kiss at zero
+volume are reported clear; in plastic a zero-clearance pass is already a bind, and the
+declared range should carry the same honesty about clearance that a tongue's `fit`
+carries about width.
+"""
+
+import copy
+import functools
+import inspect
+import pathlib
+import sys
+from dataclasses import dataclass, field
+
+from .registry import PartDef
+
+# Findings come from checks.py's vocabulary so an assembly's report reads exactly like
+# a part's: same severities, same line format, same sorting.
+RULE = "motion"
+
+
+@dataclass
+class Hinge:
+    solid: object
+    axis: object  # build123d Axis
+    lo: float
+    hi: float
+    at: float
+    name: str
+    step: float
+
+
+@dataclass
+class Scene:
+    """What the sweep needs: who moves, about what, and what is in the way."""
+
+    hinges: list = field(default_factory=list)
+    statics: list = field(default_factory=list)  # placed parts that do not move
+    obstacles: list = field(default_factory=list)  # context geometry, never printed
+
+
+@dataclass
+class _Recorder:
+    draft: bool = False
+    hinges: dict = field(default_factory=dict)  # id(solid) -> Hinge
+    obstacles: dict = field(default_factory=dict)  # id(solid) -> name
+
+
+_active = []  # the recorder for the @assembly call currently executing, if any
+
+
+def _recorder(who):
+    if not _active:
+        raise RuntimeError(f"{who} only means something inside an @assembly function")
+    return _active[-1]
+
+
+# --- the vocabulary an assembly file gets ------------------------------------
+
+
+def _caller_root():
+    """The project of the file that called, found the way measurements finds it."""
+    frame = sys._getframe(2)
+    here = frame.f_globals.get("__file__")
+    start = pathlib.Path(here).resolve().parent if here else pathlib.Path.cwd()
+    for d in [start, *start.parents]:
+        if (d / "parts").is_dir():
+            return d
+    return start
+
+
+_built = {}  # (path, mtime, overrides, draft) -> shape
+
+
+def use(name, **overrides):
+    """Build a sibling part by name and return its solid, placed where it was modelled.
+
+    Cached on the file's mtime, so dragging an assembly slider in the viewer does not
+    pay for a rebuild of every part it places. Each call returns a fresh wrapper around
+    the cached geometry, because the caller is about to move it and two assemblies
+    sharing one Python object would move each other.
+    """
+    from . import builder
+
+    rec = _recorder("use()")
+    path = _caller_root() / "parts" / f"{name.replace('-', '_')}.py"
+    if not path.is_file():
+        raise FileNotFoundError(f"no part named {name!r} ({path} does not exist)")
+    key = (str(path), path.stat().st_mtime_ns, tuple(sorted(overrides.items())), rec.draft)
+    if key not in _built:
+        _built[key] = builder.build(path, overrides=overrides or None, draft=rec.draft)[0]
+        # One mtime per file: a save invalidates, history does not accumulate.
+        stale = [k for k in _built if k[0] == key[0] and k[1] != key[1]]
+        for k in stale:
+            del _built[k]
+    shape = copy.copy(_built[key])
+    shape.label = name
+    return shape
+
+
+def hinge(solid, axis, through, at=0.0, name=None, step=3.0):
+    """Declare that this solid rotates about `axis`, and pose it at `at` degrees.
+
+    `through` is the range the assembly claims to reach, and the claim is what the
+    sweep tests: motion is checked against the declaration the same way min_wall is
+    checked against the card. Positive angles follow the right hand rule about the
+    axis direction, so the axis is also how you pick which way is opening.
+
+    `step` is the coarse sweep resolution; the jam angle itself is bisected to a tenth
+    of a degree regardless.
+    """
+    rec = _recorder("hinge()")
+    lo, hi = float(through[0]), float(through[1])
+    if not lo <= at <= hi:
+        raise ValueError(f"hinge posed at {at} degrees, outside its declared ({lo}, {hi})")
+    posed = solid.rotate(axis, at) if at else solid
+    rec.hinges[id(posed)] = Hinge(
+        solid=posed,
+        axis=axis,
+        lo=lo,
+        hi=hi,
+        at=float(at),
+        name=name or getattr(solid, "label", "") or "the moving part",
+        step=float(step),
+    )
+    return posed
+
+
+def obstacle(solid, name="an obstacle"):
+    """Context geometry: the wall, the machine, the shelf above.
+
+    It collides like anything else and is displayed like anything else. What it is
+    not is printed -- an assembly is never exported as one STL anyway, but the name
+    keeps the intent readable in the file.
+    """
+    rec = _recorder("obstacle()")
+    rec.obstacles[id(solid)] = name
+    solid.label = name
+    return solid
+
+
+def _flatten(result):
+    if isinstance(result, (tuple, list)):
+        out = []
+        for item in result:
+            out.extend(_flatten(item))
+        return out
+    return [result]
+
+
+def assembly(fn):
+    """Mark a function as an assembly. Its keyword defaults are parameters, exactly
+    like a part's, so the viewer's sliders drive the pose.
+
+    The function returns its placed solids (a tuple, or one solid); the runtime
+    compounds them for display and carries the recorded joints on the compound, which
+    is how `nurb check` knows to sweep instead of running the printability rules.
+    """
+    sig = inspect.signature(fn)
+    params = {
+        n: (None if p.default is inspect.Parameter.empty else p.default)
+        for n, p in sig.parameters.items()
+        if n != "draft"
+    }
+    takes_draft = "draft" in sig.parameters
+
+    @functools.wraps(fn)
+    def wrapped(**kwargs):
+        from build123d import Compound
+
+        draft = bool(kwargs.pop("draft", False))
+        rec = _Recorder(draft=draft)
+        _active.append(rec)
+        try:
+            call = dict(kwargs)
+            if takes_draft:
+                call["draft"] = draft
+            result = fn(**call)
+        finally:
+            _active.pop()
+
+        solids = _flatten(result)
+        returned = {id(s) for s in solids}
+        for h in rec.hinges.values():
+            if id(h.solid) not in returned:
+                raise ValueError(
+                    f"hinge({h.name!r}) was declared but the hinged solid was not "
+                    f"returned. Return what hinge() returned, not what went in."
+                )
+        scene = Scene()
+        for s in solids:
+            if id(s) in rec.hinges:
+                scene.hinges.append(rec.hinges[id(s)])
+            elif id(s) in rec.obstacles:
+                scene.obstacles.append(s)
+            else:
+                scene.statics.append(s)
+        comp = Compound(children=[copy.copy(s) for s in solids])
+        comp._nurb_scene = scene
+        return comp
+
+    wrapped._nurb = PartDef(fn=wrapped, name=fn.__name__, params=params, accepts_draft=True)
+    return wrapped
+
+
+# --- the sweep ---------------------------------------------------------------
+
+
+_EPS = 1e-4  # mm3; below this an intersection is numerical noise, not a collision
+
+
+def _hits(moved, others):
+    """The overlap volume and where it is, or (0, None)."""
+    worst, where = 0.0, None
+    for other in others:
+        try:
+            common = moved & other
+            vol = common.volume if common else 0.0
+        except Exception:  # an empty boolean, depending on kernel mood
+            vol = 0.0
+        if vol > max(_EPS, worst):
+            bb = common.bounding_box()
+            worst = vol
+            where = (
+                (bb.min.X + bb.max.X) / 2,
+                (bb.min.Y + bb.max.Y) / 2,
+                (bb.min.Z + bb.max.Z) / 2,
+                getattr(other, "label", "") or "a fixed part",
+            )
+    return worst, where
+
+
+def _limit(h, others, direction):
+    """The last clear angle sweeping from the pose toward one end of the range.
+
+    Coarse steps find the first collision, bisection then pins the boundary to under
+    a tenth of a degree. Angles are absolute joint angles, not offsets from the pose.
+    """
+    end = h.hi if direction > 0 else h.lo
+    span = abs(end - h.at)
+    if span < 1e-9:
+        return end, None
+    clear, hit, contact = h.at, None, None
+    steps = int(span // h.step) + 1
+    for i in range(1, steps + 1):
+        t = h.at + direction * min(i * h.step, span)
+        moved = h.solid.rotate(h.axis, t - h.at)
+        vol, where = _hits(moved, others)
+        if vol:
+            hit, contact = t, where
+            break
+        clear = t
+    if hit is None:
+        return end, None
+    while abs(hit - clear) > 0.1:
+        mid = (hit + clear) / 2
+        moved = h.solid.rotate(h.axis, mid - h.at)
+        vol, where = _hits(moved, others)
+        if vol:
+            hit, contact = mid, where
+        else:
+            clear = mid
+    return clear, contact
+
+
+def sweep(scene):
+    """Findings for every declared joint, in checks.py's own vocabulary.
+
+    Each hinge sweeps alone; other hinged solids stand frozen at their pose, which is
+    the conservative reading of a mechanism you can only move one hand at a time.
+    """
+    from .checks import FAIL, Finding
+
+    found = []
+    for h in scene.hinges:
+        others = (
+            scene.statics
+            + scene.obstacles
+            + [o.solid for o in scene.hinges if o is not h]
+        )
+        if not others:
+            continue
+        vol, where = _hits(h.solid, others)
+        if vol:
+            found.append(
+                Finding(
+                    RULE,
+                    FAIL,
+                    f"{h.name} collides before it moves, posed at {h.at:.0f} deg "
+                    f"against {where[3]}",
+                    value=h.at,
+                    where=where[:3],
+                )
+            )
+            continue
+        for direction, end in ((+1, h.hi), (-1, h.lo)):
+            reached, contact = _limit(h, others, direction)
+            if contact is None:
+                continue
+            found.append(
+                Finding(
+                    RULE,
+                    FAIL,
+                    f"{h.name} jams at {reached:.1f} deg of the "
+                    f"({h.lo:.0f}, {h.hi:.0f}) declared, striking {contact[3]}",
+                    value=reached,
+                    where=contact[:3],
+                )
+            )
+    return found

--- a/src/nurb/builder.py
+++ b/src/nurb/builder.py
@@ -197,7 +197,26 @@ def to_mesh(shape, tolerance=0.1):
 
 
 def to_glb(shape, tolerance=0.1):
-    return trimesh.Scene([to_mesh(shape, tolerance)]).export(file_type="glb")
+    """One GLB. A part is one blob; an assembly keeps its movers as named nodes.
+
+    The scene rides on the compound the same way checks.run reads it: an attribute,
+    not an import, so this file stays ignorant of how assemblies work. The node
+    names are the contract with the viewer -- `joint<i>` for each hinged solid in
+    declaration order, `fixed` for everything static, `context` for obstacles --
+    which is what lets a slider pose a joint client-side without a rebuild.
+    """
+    scene = getattr(shape, "_nurb_scene", None)
+    if scene is None:
+        return trimesh.Scene([to_mesh(shape, tolerance)]).export(file_type="glb")
+    out = trimesh.Scene()
+    for i, h in enumerate(scene.hinges):
+        name = f"joint{i}"
+        out.add_geometry(to_mesh(h.solid, tolerance), node_name=name, geom_name=name)
+    for name, group in (("fixed", scene.statics), ("context", scene.obstacles)):
+        if group:
+            merged = trimesh.util.concatenate([to_mesh(s, tolerance) for s in group])
+            out.add_geometry(merged, node_name=name, geom_name=name)
+    return out.export(file_type="glb")
 
 
 def stats(shape):

--- a/src/nurb/builder.py
+++ b/src/nurb/builder.py
@@ -208,9 +208,11 @@ def to_glb(shape, tolerance=0.1):
     scene = getattr(shape, "_nurb_scene", None)
     if scene is None:
         return trimesh.Scene([to_mesh(shape, tolerance)]).export(file_type="glb")
+    from .assembly import NODE
+
     out = trimesh.Scene()
     for i, h in enumerate(scene.hinges):
-        name = f"joint{i}"
+        name = NODE.format(i)
         out.add_geometry(to_mesh(h.solid, tolerance), node_name=name, geom_name=name)
     for name, group in (("fixed", scene.statics), ("context", scene.obstacles)):
         if group:

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -65,6 +65,14 @@ def rule(name):
 
 
 def run(shape, ctx=None, only=None):
+    # An assembly's compound carries its recorded joints, and motion is the only
+    # thing worth judging about it: overhang and min_wall on an assembled scene
+    # would report confident nonsense about parts that each checked clean alone.
+    scene = getattr(shape, "_nurb_scene", None)
+    if scene is not None:
+        from .assembly import sweep
+
+        return sweep(scene)
     ctx = ctx or Context()
     found = []
     for name, fn in RULES.items():

--- a/src/nurb/doctrine.md
+++ b/src/nurb/doctrine.md
@@ -295,6 +295,64 @@ somebody picks up a caliper.
 A measured value pays for itself across a family. Notch measured one bracket pitch and
 amortized it over sixteen parts.
 
+## Assemblies
+
+Every rule above judges one solid being manufactured. An assembly judges solids being
+used together: a door on its mount, a lid over the machine it covers. The failure it
+exists for built clean, checked clean, exported watertight and printed beautifully,
+then jammed at 45 degrees of its swing, because the collision between two correct
+parts existed only in the physical world. No per-solid rule can have an opinion about
+motion.
+
+The contract mirrors a part's. An assembly is a function in `parts/` whose keyword
+defaults are its parameters; what it returns is placed solids rather than one solid.
+`use(name)` builds a sibling part where it was modelled, `hinge(solid, axis, through,
+at)` declares a revolute joint and poses it, and `obstacle(solid, name)` adds what the
+parts mount into: the machine, the wall, the shelf above. The joint angle is an
+ordinary keyword default, so the viewer's slider swings it live, and the slider ends
+exactly where the declared range does.
+
+**The declared range is a claim, and `nurb check` audits it** the way min_wall audits
+a wall: each hinge sweeps through it against everything else in the scene, and a
+finding is the angle where it jams plus the coordinates of the contact. Declare what
+the design needs, never what happens to pass. A door that must stay open by gravity
+needs past 90 degrees; declaring (0, 90) because that sweeps clean is writing the test
+to match the bug.
+
+**Nothing full width may cross the pivot line.** The mount that carries a hinge has to
+reach the pin from somewhere, so some of it always lives above or behind the pin, and
+any full-width material on the moving part that reaches past the pivot sweeps straight
+into it. The door that jammed at 45 did so against its own top edge, carried past the
+pin to support the knuckles; the knuckles got narrow tabs instead, sized to pass
+beside the mount, and the panel now starts at the pivot line.
+
+**Obstacles are boxes and prisms, never thin hand-drawn profiles.** Three nearly
+collinear points make a razor sliver, and OCCT answers a boolean against a degenerate
+solid with chunks of the other operand: measured once as a 152,000mm3 phantom
+collision at a pose that was actually clear. The sweep refuses any intersection that
+is not a subset of its inputs and names the solid to fix, but the fix is to model the
+obstacle as something with honest volume in the first place.
+
+**Tangent is clear, and clear is not clearance.** Collision is intersection volume, so
+two faces that kiss at zero volume pass, the closed door resting on its stop included.
+In plastic a zero-clearance pass is already a bind. The declared range should carry
+the same honesty about clearance that a tongue's `fit` carries about width.
+
+**The stop the sweep finds can be the detent the design wants.** The door that
+motivated all of this rests open at 240 degrees against the back of its own mount,
+held there by gravity, and that contact is a feature with a card entry, not a finding
+to engineer away. Read a jam before redesigning around it.
+
+**Never trust a swing worked out by hand.** The same hinge was hand-modelled three
+times and gave three answers, one of them "impossible"; the wrong one ran a convex
+test against a non-convex profile, which is exactly the kind of quiet modelling error
+a kernel boolean cannot make. The sweep is the authority, and it is cheap.
+
+One hinge sweeps at a time; the others hold their pose, which is the conservative
+reading of a mechanism you can only move one hand at a time. Printability rules stay
+off assemblies entirely: each part already answered them alone, and overhang measured
+on an assembled scene reports confident nonsense.
+
 ## Verification
 
 "It built" is not verification. `nurb verify` runs the machine-checkable part of

--- a/src/nurb/registry.py
+++ b/src/nurb/registry.py
@@ -12,6 +12,23 @@ class PartDef:
     accepts_draft: bool
 
 
+def declared(fn):
+    """The parameters a function declares, and whether it takes `draft`.
+
+    This is the one place the keyword-defaults-are-parameters convention is read
+    off a signature. Parts and assemblies both register through it, so they cannot
+    drift on what counts as a parameter.
+    """
+    params = {}
+    accepts_draft = False
+    for name, p in inspect.signature(fn).parameters.items():
+        if name == "draft":
+            accepts_draft = True
+            continue
+        params[name] = None if p.default is inspect.Parameter.empty else p.default
+    return params, accepts_draft
+
+
 def part(fn):
     """Mark a function as a part.
 
@@ -22,12 +39,6 @@ def part(fn):
     it's True the part should skip its polish pass (chamfers, fillets) so the
     live rebuild stays fast.
     """
-    params = {}
-    accepts_draft = False
-    for name, p in inspect.signature(fn).parameters.items():
-        if name == "draft":
-            accepts_draft = True
-            continue
-        params[name] = None if p.default is inspect.Parameter.empty else p.default
+    params, accepts_draft = declared(fn)
     fn._nurb = PartDef(fn=fn, name=fn.__name__, params=params, accepts_draft=accepts_draft)
     return fn

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -585,6 +585,29 @@ class Server:
         self.observer.daemon = True
         self.observer.start()
 
+    def _dependents(self, paths):
+        """Assemblies whose use() placed any of these files.
+
+        Editing a part while watching the assembly it sits in is the whole editing
+        loop for an assembly, and without this the scene on screen would be the one
+        part stale. Read off the scenes already built, so it costs nothing and there
+        is no dependency file to keep in sync. Fixpoint, not one pass: an assembly
+        can place an assembly.
+        """
+        found = set(paths)
+        grew = True
+        while grew:
+            grew = False
+            for entry in self.state.values():
+                scene = getattr(entry.get("shape"), "_nurb_scene", None)
+                if scene is None:
+                    continue
+                mine = str(self.root / "parts" / f"{entry['name']}.py")
+                if mine not in found and any(u in found for u in scene.uses):
+                    found.add(mine)
+                    grew = True
+        return found - set(paths)
+
     async def drain(self):
         """Rebuild on file change, coalescing the burst an editor save produces."""
         while True:
@@ -592,6 +615,7 @@ class Server:
             await asyncio.sleep(0.05)
             while not self.queue.empty():
                 paths.add(self.queue.get_nowait())  # collect, don't discard:
+            paths |= self._dependents(paths)
             for path in sorted(paths):              # two parts can change at once
                 if not pathlib.Path(path).exists():
                     # Deleted, or renamed away. Dropping it is the whole handling: a

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -182,23 +182,9 @@ class Server:
             entry["shape"] = shape  # kept for the check pass, never serialized
             scene = getattr(shape, "_nurb_scene", None)
             if scene is not None:
-                # The viewer's half of the joint contract: which GLB node each
-                # hinge is, about what axis it turns, and which slider drives it.
-                # With this a joint drag is a client-side transform at whatever
-                # rate the screen paints, not a rebuild round-trip per tick.
-                entry["joints"] = [
-                    {
-                        "node": f"joint{i}",
-                        "param": h.param,
-                        "name": h.name,
-                        "origin": [h.axis.position.X, h.axis.position.Y, h.axis.position.Z],
-                        "dir": [h.axis.direction.X, h.axis.direction.Y, h.axis.direction.Z],
-                        "lo": h.lo,
-                        "hi": h.hi,
-                        "at": h.at,
-                    }
-                    for i, h in enumerate(scene.hinges)
-                ]
+                from .assembly import wire
+
+                entry["joints"] = wire(scene)
         except Exception as exc:
             entry["glb"] = None
             entry["shape"] = None

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -180,6 +180,25 @@ class Server:
             entry["ms"] = round(ms, 1)
             entry["error"] = None
             entry["shape"] = shape  # kept for the check pass, never serialized
+            scene = getattr(shape, "_nurb_scene", None)
+            if scene is not None:
+                # The viewer's half of the joint contract: which GLB node each
+                # hinge is, about what axis it turns, and which slider drives it.
+                # With this a joint drag is a client-side transform at whatever
+                # rate the screen paints, not a rebuild round-trip per tick.
+                entry["joints"] = [
+                    {
+                        "node": f"joint{i}",
+                        "param": h.param,
+                        "name": h.name,
+                        "origin": [h.axis.position.X, h.axis.position.Y, h.axis.position.Z],
+                        "dir": [h.axis.direction.X, h.axis.direction.Y, h.axis.direction.Z],
+                        "lo": h.lo,
+                        "hi": h.hi,
+                        "at": h.at,
+                    }
+                    for i, h in enumerate(scene.hinges)
+                ]
         except Exception as exc:
             entry["glb"] = None
             entry["shape"] = None

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -15,6 +15,8 @@ A part is a Python function and its keyword defaults are its parameters. A proje
 
 **Ask before you model.** Anything the part has to fit (an opening, a bracket, the object it holds) is a question for the user: ask for those measurements in one batch, up front, using your harness's question tool if it has one, and record the answers in `measurements.toml` the way the doctrine describes. Anything that is taste rather than fit becomes a parameter instead of a question, because the viewer's sliders are how the user answers those. A guessed proportion costs one slider drag; a guessed clearance prints the wrong part.
 
+**When parts have to work together, assemble them before printing either.** A part that mounts to another, or moves against one, gets an `@assembly`: a function in `parts/` that returns placed solids, with `use()` building the siblings, `hinge()` declaring how one moves, and `obstacle()` standing in for the machine or wall they mount into. `nurb check` then sweeps each joint through its declared range and reports the angle where it jams and where the contact is, which is the one failure no per-part check can see: a door that builds clean, checks clean, prints beautifully and will not open. The joint angle is a keyword default, so the viewer's slider swings the assembly live for the user. Model obstacles from the user's measurements, and say on the assembly's card how rough they are.
+
 **Finish with the polish pass.** Chamfered edges are what make a print feel designed rather than extruded, so the doctrine's last step (`polish`, 1mm on exposed edges) stays in the part through every edit; the template `nurb new` emits already ends with it. Say so when you hand the part over, because the user can only ask for sharp edges if they know the chamfers are there on purpose. The viewer builds polished by default, and its polish button flips to the faster draft build.
 
 **Write the card before you hand the part over, even for a single part.** A part gets printed, used, and then revisited weeks later to adjust something, and by then the session that built it is gone. `## Don't` is the only record of what was tried and rejected, so without it the next agent helpfully re-adds the lead-in chamfer that was retired on purpose. There is no one-off: there is the first session and the ones after it, and the card is what you are leaving for them.
@@ -24,7 +26,7 @@ nurb rules            the doctrine, read this before designing
 nurb api              the vocabulary a part file gets, with signatures
 nurb new <name>       create parts/<name>.py and its card
 nurb build [part]     build once, report size and timing
-nurb check [part]     the printability rules, --strict for CI
+nurb check [part]     the printability rules; on an assembly, the motion sweep. --strict for CI
 nurb inspect [part]   faces, normals, concave edges, each finding on its face
 nurb card [part]      regenerate a card's AUTO block
 nurb verify [part]    the doctrine's verification list: solids, flex, checks, card

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -465,12 +465,20 @@ function sectionAttach() {
   for (const w of writers) scene.remove(w);
   writers = [];
   if (!mesh) return;
-  for (const mat of [stencilBack, stencilFront]) {
-    const w = new THREE.Mesh(mesh.geometry, mat);
-    w.position.copy(mesh.position);
-    w.renderOrder = 1;
-    scene.add(w);
-    writers.push(w);
+  mesh.updateMatrixWorld(true);
+  for (const child of mesh.children) {
+    if (!child.isMesh || child.name === 'context') continue;  // never cap the scenery
+    for (const mat of [stencilBack, stencilFront]) {
+      const w = new THREE.Mesh(child.geometry, mat);
+      // The writer's local matrix IS the child's world matrix -- the same object,
+      // not a copy -- so a joint posing the child mid-section drags its stencil
+      // writer along without anyone having to remember to re-attach.
+      w.matrixAutoUpdate = false;
+      w.matrix = child.matrixWorld;
+      w.renderOrder = 1;
+      scene.add(w);
+      writers.push(w);
+    }
   }
   sectionUpdate();
 }
@@ -630,6 +638,34 @@ function frame(box, from) {
 // ---- loading ----
 const loader = new GLTFLoader();
 
+// ---- joints ----
+// A hinged node poses on the GPU: T(origin) * R(axis, delta) * T(-origin) on top of
+// the matrix it loaded with. This is the whole reason assemblies export named nodes:
+// a slider drag becomes a transform at whatever rate the screen paints, instead of a
+// rebuild, a tessellation and a websocket push per tick.
+const jointNodes = new Map();  // param (or node name) -> { node, base, j }
+
+function poseJoint(param, deg) {
+  const rec = jointNodes.get(param);
+  if (!rec) return false;
+  const { node, base, j } = rec;
+  const o = new THREE.Vector3(...j.origin);
+  const d = new THREE.Vector3(...j.dir).normalize();
+  const M = new THREE.Matrix4().makeTranslation(o.x, o.y, o.z)
+    .multiply(new THREE.Matrix4().makeRotationAxis(d, THREE.MathUtils.degToRad(deg - j.at)))
+    .multiply(new THREE.Matrix4().makeTranslation(-o.x, -o.y, -o.z))
+    .multiply(base);
+  node.matrix.copy(M);
+  node.matrixWorldNeedsUpdate = true;
+  return true;
+}
+
+function applyJointPoses() {
+  for (const [param, rec] of jointNodes) {
+    poseJoint(param, values.has(param) ? values.get(param) : rec.j.at);
+  }
+}
+
 // `ready` is what a headless render waits on. Two frames after the geometry lands,
 // because one only guarantees the mesh is in the scene, not that it has been painted.
 // Set on every exit path including a failed build, or a render of a broken part hangs.
@@ -651,9 +687,12 @@ async function paint(name, { keepCamera }) {
     err.style.display = 'block';
     err.textContent = entry.traceback || entry.error;
     if (mesh) {                              // last good geometry stays, visibly stale
-      mesh.material.transparent = true;
-      mesh.material.opacity = 0.22;
-      mesh.material.needsUpdate = true;
+      mesh.traverse(o => {
+        if (!o.isMesh) return;
+        o.material.transparent = true;
+        o.material.opacity = 0.22;
+        o.material.needsUpdate = true;
+      });
     }
     hud(entry);
     checks(name);
@@ -663,22 +702,47 @@ async function paint(name, { keepCamera }) {
   err.style.display = 'none';
 
   const gltf = await loader.loadAsync(`/glb/${name}.glb?v=${entry.token}`);
-  const geo = [];
-  gltf.scene.traverse(o => { if (o.isMesh) geo.push(o.geometry); });
-  if (!geo.length) return;
+  const found = [];
+  gltf.scene.traverse(o => { if (o.isMesh) found.push(o); });
+  if (!found.length) return;
 
-  if (mesh) { scene.remove(mesh); mesh.geometry.dispose(); }
-  if (!geo[0].attributes.normal) geo[0].computeVertexNormals();  // never render unlit
-  mesh = new THREE.Mesh(geo[0], material.clone());
-  mesh.material.clippingPlanes = [plane];   // parked unless the section view is on
+  if (mesh) { scene.remove(mesh); mesh.traverse(o => { if (o.isMesh) o.geometry.dispose(); }); }
+  // Always a group, even for one blob: a part is a group of one, an assembly is a
+  // group whose named children the joints move, and nothing downstream branches.
+  mesh = new THREE.Group();
+  for (const src of found) {
+    if (!src.geometry.attributes.normal) src.geometry.computeVertexNormals();  // never render unlit
+    const m = new THREE.Mesh(src.geometry, material.clone());
+    m.material.clippingPlanes = [plane];   // parked unless the section view is on
+    // The exporter names the node; the loader sometimes hangs the mesh under it.
+    m.name = src.name || (src.parent && src.parent.name) || '';
+    if (m.name === 'context') {
+      // Obstacles are scenery: the machine a part mounts to, the wall behind it.
+      // Ghosted, so the printed parts stay the subject of the picture.
+      m.material.transparent = true;
+      m.material.opacity = 0.3;
+    }
+    mesh.add(m);
+  }
   scene.add(mesh);
 
-  mesh.geometry.computeBoundingBox();
+  jointNodes.clear();
+  for (const j of (entry.joints || [])) {
+    const node = mesh.getObjectByName(j.node);
+    if (!node) continue;
+    node.matrixAutoUpdate = false;
+    jointNodes.set(j.param || j.node, { node, base: node.matrix.clone(), j });
+  }
+  // The GLB arrives posed at each joint's `at`; the sliders may have moved since a
+  // drag never rebuilds. Reposing here is what keeps a save from snapping the door.
+  applyJointPoses();
+
+  const bb = new THREE.Box3().setFromObject(mesh);
   // The grid is the build plate, so a part sits on it. Where a part's own origin
   // falls is a modeling datum and nothing to do with printing: Notch hangs
   // everything below z=0, which would put every part underneath the plate.
-  mesh.position.z = -mesh.geometry.boundingBox.min.z;
-  const box = mesh.geometry.boundingBox.clone().translate(mesh.position);
+  mesh.position.z = -bb.min.z;
+  const box = bb.clone().translate(new THREE.Vector3(0, 0, mesh.position.z));
   const size = box.getSize(new THREE.Vector3()).length();
   sectionAttach();
 
@@ -817,7 +881,8 @@ function params(e) {
   // to be draggable back. The panel is only cleared if it belongs to another part.
   if (e.error && panelSig && panelSig.startsWith(e.name + '|')) return;
   const rows = (e.params || []).filter(adjustable);
-  const sig = e.name + '|' + rows.map(p => `${p.name}:${p.default}:${p.family ? 1 : 0}`).join(',');
+  const sig = e.name + '|' + rows.map(p => `${p.name}:${p.default}:${p.family ? 1 : 0}`).join(',')
+    + '|' + (e.joints || []).map(j => `${j.param}:${j.lo}:${j.hi}`).join(',');
   if (sig === panelSig) { sync(rows); return; }
   panelSig = sig;
 
@@ -840,6 +905,7 @@ function params(e) {
       + `family (${shared.length})</summary>`;
   }
   for (const p of rows) {
+    const joint = (e.joints || []).find(j => j.param === p.name);
     const r = infer(p.default, p.kind === 'int');
     values.set(p.name, p.value); defaults.set(p.name, p.default);
     const row = document.createElement('div');
@@ -850,8 +916,15 @@ function params(e) {
       + `<input class="v" type="number" step="any"></div>`
       + `<input type="range">`;
     const num = row.querySelector('.v'), slide = row.querySelector('[type=range]');
-    slide.min = Math.min(r.lo, p.value); slide.max = Math.max(r.hi, p.value);
-    slide.step = r.step; slide.value = p.value;
+    if (joint) {
+      // A joint's range is declared, not guessed: the slider ends exactly where the
+      // sweep proved the motion does.
+      slide.min = joint.lo; slide.max = joint.hi; slide.step = 0.5;
+    } else {
+      slide.min = Math.min(r.lo, p.value); slide.max = Math.max(r.hi, p.value);
+      slide.step = r.step;
+    }
+    slide.value = p.value;
     slide.title = p.name;
     num.value = p.value;
 
@@ -868,6 +941,9 @@ function params(e) {
       if (v < +slide.min) slide.min = v;
       if (v > +slide.max) slide.max = v;
       slide.value = v;
+      // A pose is not an edit: the joint turns on the GPU and the geometry is
+      // untouched, so there is nothing to rebuild and nothing to mark stale.
+      if (joint && poseJoint(p.name, v)) return;
       markDirty();
       push(commit);
     };
@@ -906,6 +982,10 @@ function params(e) {
 function sync(rows) {
   for (const p of rows) {
     defaults.set(p.name, p.default);
+    // A joint's slider is client-authoritative: drags never pushed, so the server's
+    // value is always behind, and syncing to it would snap the door shut on every
+    // unrelated rebuild. The pose survives; `paint` re-applies it to fresh geometry.
+    if (jointNodes.has(p.name)) continue;
     const row = document.querySelector(`.p[data-name="${p.name}"]`);
     if (!row) continue;
     const num = row.querySelector('.v'), slide = row.querySelector('[type=range]');

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -58,6 +58,11 @@
   .item.var.active .name { color: var(--text); }
   .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); flex: none; }
   .dot.bad { background: var(--bad); }
+  /* An assembly's status light is the cubes icon itself: same slot, same colors.
+     The negative margins keep its flex footprint at the dot's 6px, so part and
+     assembly names stay in one column. */
+  .dot.asm { width: 13px; height: 13px; margin: 0 -3.5px; background: none; border-radius: 0; color: var(--accent); }
+  .dot.asm.bad { color: var(--bad); }
   .dot.busy { animation: pulse .6s ease-in-out infinite; }
   @keyframes pulse { 50% { opacity: .25; } }
   main { position: relative; overflow: hidden; }
@@ -265,6 +270,7 @@
   <symbol id="i-warn" viewBox="0 0 12 12"><path d="M6 11.25C8.899 11.25 11.25 8.899 11.25 6C11.25 3.101 8.899 0.75 6 0.75C3.101 0.75 0.75 3.101 0.75 6C0.75 8.899 3.101 11.25 6 11.25Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M6 9.5C6.483 9.5 6.875 9.108 6.875 8.625C6.875 8.142 6.483 7.75 6 7.75C5.517 7.75 5.125 8.142 5.125 8.625C5.125 9.108 5.517 9.5 6 9.5Z" fill="currentColor"/><path d="M6 3.5V6.25" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
   <symbol id="i-ok" viewBox="0 0 12 12"><circle cx="6" cy="6" r="5.25" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><polyline points="3.747 6.5 5.25 8 8.253 4" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
   <symbol id="i-cube" viewBox="0 0 18 18"><path d="m7.997,2.332l-4.25,2.465c-.617.358-.997,1.017-.997,1.73v4.946c0,.713.38,1.372.997,1.73l4.25,2.465c.621.36,1.386.36,2.007,0l4.25-2.465c.617-.358.997-1.017.997-1.73v-4.946c0-.713-.38-1.372-.997-1.73l-4.25-2.465c-.621-.36-1.386-.36-2.007,0Z" fill="currentColor" opacity=".3" stroke-width="0"/><path d="m7.997,2.332l-4.25,2.465c-.617.358-.997,1.017-.997,1.73v4.946c0,.713.38,1.372.997,1.73l4.25,2.465c.621.36,1.386.36,2.007,0l4.25-2.465c.617-.358.997-1.017.997-1.73v-4.946c0-.713-.38-1.372-.997-1.73l-4.25-2.465c-.621-.36-1.386-.36-2.007,0Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><polyline points="12.251 7.1035 9 9 5.75 7.1035" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><line x1="9.0005" y1="12.7817" x2="9" y2="9" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
+  <symbol id="i-cubes" viewBox="0 0 18 18"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><path d="M4.648,8.086l-2.55,1.479c-.37,.215-.598,.61-.598,1.038v2.968c0,.428,.228,.823,.598,1.038l2.55,1.479c.372,.216,.832,.216,1.204,0l2.55-1.479c.37-.215,.598-.61,.598-1.038v-2.968c0-.428-.228-.823-.598-1.038l-2.55-1.479c-.372-.216-.832-.216-1.204,0Z"/><polyline points="8.84 10.005 5.25 12.087 1.66 10.005"/><line x1="5.25" y1="16.25" x2="5.25" y2="12.087"/><path d="M12.148,8.086l-2.55,1.479c-.37,.215-.598,.61-.598,1.038v2.968c0,.428,.228,.823,.598,1.038l2.55,1.479c.372,.216,.832,.216,1.204,0l2.55-1.479c.37-.215,.598-.61,.598-1.038v-2.968c0-.428-.228-.823-.598-1.038l-2.55-1.479c-.372-.216-.832-.216-1.204,0Z"/><polyline points="16.34 10.005 12.75 12.087 9.16 10.005"/><line x1="12.75" y1="16.25" x2="12.75" y2="12.087"/><path d="M8.398,1.586l-2.55,1.479c-.37,.215-.598,.61-.598,1.038v2.968c0,.428,.228,.823,.598,1.038l2.55,1.479c.372,.216,.832,.216,1.204,0l2.55-1.479c.37-.215,.598-.61,.598-1.038v-2.968c0-.428-.228-.823-.598-1.038l-2.55-1.479c-.372-.216-.832-.216-1.204,0Z"/><polyline points="12.59 3.505 9 5.587 5.41 3.505"/><line x1="9" y1="9.75" x2="9" y2="5.587"/></g></symbol>
   <symbol id="i-reset" viewBox="0 0 18 18"><path d="M5.25 9.5L3 7.25L0.75 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13.495 13.345C12.3587 14.5226 10.7641 15.25 9 15.25C5.548 15.25 2.75 12.45 2.75 9C2.75 8.4 2.834 7.83003 2.99 7.28003" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M12.75 8.5L15 10.75L17.25 8.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M4.50629 4.65564C5.64249 3.48544 7.23658 2.75 8.99998 2.75C12.452 2.75 15.25 5.55 15.25 9C15.25 9.58 15.171 10.14 15.024 10.67" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
 </svg>
 <aside>
@@ -1089,7 +1095,10 @@ function render() {
   for (const e of parts.values()) {
     const row = document.createElement('div');
     row.className = 'item' + (e.name === current ? ' active' : '');
-    row.innerHTML = `<span class="dot ${e.error ? 'bad' : ''}"></span>`
+    // The joints payload is the marker: only an assembly carries one, even empty.
+    row.innerHTML = (Array.isArray(e.joints)
+        ? `<svg class="dot asm ${e.error ? 'bad' : ''}"><title>assembly</title><use href="#i-cubes"/></svg>`
+        : `<span class="dot ${e.error ? 'bad' : ''}"></span>`)
       + `<span class="name">${e.name}</span>`
       + `<span class="ms">${e.error ? 'err' : e.ms + 'ms'}</span>`;
     row.onclick = () => { current = e.name; render(); show(e.name, { keepCamera: false }); setURL(); };

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,13 +20,18 @@ def test_own_names_are_whatever_init_adds_to_build123d():
 
 
 def test_the_documented_vocabulary_is_the_exported_one():
-    """What the doctrine names in prose: part, polish, the convexity pair, measured."""
+    """What the doctrine names in prose: part, polish, the convexity pair, measured,
+    and the assembly four."""
     assert set(api.own_names()) == {
         "part",
         "polish",
         "is_convex",
         "concave_edges",
         "measured",
+        "assembly",
+        "use",
+        "hinge",
+        "obstacle",
     }
 
 

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -155,6 +155,52 @@ def test_a_hinge_knows_which_parameter_posed_it(project):
     assert shape._nurb_scene.hinges[0].param is None
 
 
+def test_a_shared_file_edit_reaches_through_the_use_cache(project):
+    """measurements.toml and system.py feed geometry without touching the part
+    file's mtime, so the cache stamp has to cover them or an assembly keeps
+    serving the old solid -- silently, which is the failure measured() exists
+    to prevent."""
+    import os
+
+    # The module, not the decorator `from nurb import assembly` would fetch.
+    from nurb import assembly as _decorator  # noqa: F401  -- documents the trap
+    from nurb.assembly import _built
+
+    shared = project / "system.py"
+    shared.write_text("# shared\n")
+    write(project, "plate", PLATE)
+    path = write(project, "carrier", USE_ASM)
+
+    _built.clear()
+    builder.build(path)
+    before = set(_built)
+    assert len(before) == 1
+
+    stat = shared.stat()
+    os.utime(shared, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000))
+    builder.build(path)
+    after = set(_built)
+    assert len(after) == 1
+    assert after != before  # the old entry was evicted, not joined
+
+
+def test_the_watcher_learns_dependents_from_the_scenes_already_built(project):
+    """Editing a part while watching its assembly is the whole editing loop, so a
+    changed part has to drag its assemblies into the rebuild."""
+    from nurb.server import Server
+
+    write(project, "plate", PLATE)
+    path = write(project, "carrier", USE_ASM)
+    shape, _, _ = builder.build(path)
+
+    srv = Server.__new__(Server)
+    srv.root = project
+    srv.state = {"carrier": {"name": "carrier", "shape": shape}}
+    plate = str(project / "parts" / "plate.py")
+    assert srv._dependents({plate}) == {str(path)}
+    assert srv._dependents({str(path)}) == set()  # nothing uses the assembly
+
+
 def test_an_assembly_glb_keeps_its_movers_as_named_nodes(project):
     """The node names are the viewer's contract for posing a joint client-side."""
     import io

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -140,3 +140,37 @@ def test_printability_rules_stay_off_assemblies(project):
     path = write(project, "rig", FLAP_ASM)
     shape, _, _ = builder.build(path)
     assert all(f.rule == "motion" for f in checks.run(shape))
+
+
+def test_a_hinge_knows_which_parameter_posed_it(project):
+    """`hinge(at=open_deg)` ties the joint to the slider without anyone saying so.
+    Arithmetic strips the link, correctly: `at=open_deg / 2` is not the slider's own
+    value, and a rebuild is then the only honest way to pose it."""
+    path = write(project, "rig", FLAP_ASM)
+    shape, _, _ = builder.build(path)
+    assert shape._nurb_scene.hinges[0].param == "open_deg"
+
+    halved = write(project, "rig2", FLAP_ASM.replace("at=open_deg,", "at=open_deg / 2,"))
+    shape, _, _ = builder.build(halved)
+    assert shape._nurb_scene.hinges[0].param is None
+
+
+def test_an_assembly_glb_keeps_its_movers_as_named_nodes(project):
+    """The node names are the viewer's contract for posing a joint client-side."""
+    import io
+
+    import trimesh
+
+    path = write(project, "rig", FLAP_ASM)
+    shape, _, _ = builder.build(path)
+    glb = builder.to_glb(shape)
+    scene = trimesh.load(io.BytesIO(glb), file_type="glb")
+    names = set(scene.geometry)
+    assert "joint0" in names
+    assert "fixed" in names
+    # A plain part stays one anonymous blob; nothing downstream should start
+    # depending on node names existing for everything.
+    write(project, "plate", PLATE)
+    solid, _, _ = builder.build(project / "parts" / "plate.py")
+    plain = trimesh.load(io.BytesIO(builder.to_glb(solid)), file_type="glb")
+    assert len(plain.geometry) == 1

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1,0 +1,142 @@
+"""Assemblies: the sweep must find the jam the printability rules cannot see.
+
+The fixture geometry is chosen so the jam angle is analytic, not observed: a flap
+hinged along the edge of a slab it lies flat against can rise and swing over its own
+hinge, and the first material interference is at exactly 180 degrees, when its
+trailing face crosses into the slab's quadrant. Downward it interferes immediately.
+No tolerance in these tests was tuned to make them pass.
+"""
+
+import pathlib
+
+import pytest
+
+from nurb import builder, checks
+
+FLAP_ASM = '''from nurb import *
+
+
+@assembly
+def rig(open_deg=0.0, wall=True):
+    slab = Pos(0, 15, -1) * Box(20, 30, 2)
+    flap = Pos(0, 15, 1) * Box(20, 30, 2)
+    flap = hinge(flap, Axis((0, 0, 0), (1, 0, 0)), through=(-90, 270), at=open_deg,
+                 name="flap")
+    if not wall:
+        return (flap,)
+    return slab, flap
+'''
+
+PLATE = '''from nurb import *
+
+
+@part
+def plate(width=10.0, draft=False):
+    return Box(width, 10, 2)
+'''
+
+USE_ASM = '''from nurb import *
+
+
+@assembly
+def carrier(open_deg=0.0):
+    base = Pos(0, 0, -5) * Box(40, 40, 2)
+    arm = use("plate")
+    arm = hinge(Pos(0, 10, 0) * arm, Axis((0, 5, 0), (1, 0, 0)), through=(0, 90),
+                at=open_deg, name="arm")
+    return base, arm
+'''
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / "parts").mkdir()
+    return tmp_path
+
+
+def write(project, name, text):
+    path = project / "parts" / f"{name}.py"
+    path.write_text(text)
+    return path
+
+
+def motion(shape):
+    return [f for f in checks.run(shape) if f.rule == "motion"]
+
+
+def test_an_assembly_builds_to_one_compound_the_existing_pipeline_can_carry(project):
+    path = write(project, "rig", FLAP_ASM)
+    shape, params, _ = builder.build(path)
+    assert shape.volume > 0
+    assert [p["name"] for p in params] == ["open_deg", "wall"]
+    # The whole point of returning a Compound: to_glb and stats need no new code.
+    assert builder.to_glb(shape)
+    assert builder.stats(shape)["bbox"][0] == pytest.approx(20, abs=0.1)
+
+
+def test_the_sweep_finds_the_analytic_jam_in_both_directions(project):
+    path = write(project, "rig", FLAP_ASM)
+    shape, _, _ = builder.build(path)
+    found = motion(shape)
+    assert len(found) == 2
+    up = max(f.value for f in found)
+    down = min(f.value for f in found)
+    # Rising, the flap swings over the hinge and its trailing face crosses into the
+    # slab's quadrant at exactly 180. Falling, it presses into the slab at once.
+    assert up == pytest.approx(180.0, abs=0.2)
+    assert down == pytest.approx(0.0, abs=0.2)
+    for f in found:
+        assert f.severity == checks.FAIL
+        assert f.where is not None
+        assert "flap" in f.message
+
+
+def test_lying_flat_against_the_slab_is_tangent_and_tangent_is_clear(project):
+    """Zero-volume contact is not a collision, the same way a fit is not a weld."""
+    path = write(project, "rig", FLAP_ASM)
+    shape, _, _ = builder.build(path)
+    found = motion(shape)
+    assert all("before it moves" not in f.message for f in found)
+
+
+def test_without_the_wall_the_whole_range_is_clear(project):
+    path = write(project, "rig", FLAP_ASM)
+    shape, _, _ = builder.build(path, overrides={"wall": False})
+    assert motion(shape) == []
+
+
+def test_a_pose_already_inside_the_wall_is_its_own_finding(project):
+    path = write(project, "rig", FLAP_ASM)
+    shape, _, _ = builder.build(path, overrides={"open_deg": -30.0})
+    found = motion(shape)
+    assert len(found) == 1
+    assert "before it moves" in found[0].message
+
+
+def test_use_builds_a_sibling_part_and_the_scene_carries_it(project):
+    write(project, "plate", PLATE)
+    path = write(project, "carrier", USE_ASM)
+    shape, _, _ = builder.build(path)
+    scene = shape._nurb_scene
+    assert [h.name for h in scene.hinges] == ["arm"]
+    assert len(scene.statics) == 1
+    # 0..90 with the base 5mm below the hinge: nothing in the way going up.
+    assert motion(shape) == []
+
+
+def test_a_hinged_solid_that_is_not_returned_is_an_error_not_a_silence(project):
+    path = write(
+        project,
+        "broken",
+        FLAP_ASM.replace("return slab, flap", "return (slab,)"),
+    )
+    with pytest.raises(Exception, match="not.*returned|returned.*not"):
+        builder.build(path)
+
+
+def test_printability_rules_stay_off_assemblies(project):
+    """An assembled scene would fail overhang and min_wall for reasons that mean
+    nothing: each part already answered those alone."""
+    path = write(project, "rig", FLAP_ASM)
+    shape, _, _ = builder.build(path)
+    assert all(f.rule == "motion" for f in checks.run(shape))


### PR DESCRIPTION
Implements #29.

An assembly is a part file whose function returns placed solids instead of one solid. `use()` builds sibling parts, `hinge()` declares a revolute joint and poses it, `obstacle()` stands in for what the parts mount into. `nurb check` sweeps each declared range with OCCT booleans, bisected to a tenth of a degree, and reports the jam angle and contact coordinates in the existing Finding format. The joint angle is an ordinary keyword default, so the viewer slider poses the moving GLB node client-side with no rebuild per tick, and the slider ends where the declared range does.

Beyond the sketch in #29:

- `registry.declared()`: parts and assemblies read parameters through one function, so they cannot drift on what counts as a parameter.
- The GLB node contract lives once, in `assembly.NODE`, with the payload serialization beside it in `assembly.wire()`.
- `use()` caches on a stamp covering the part file plus system.py and measurements.toml, so a shared-file edit reaches through the cache.
- The dev watcher rebuilds an assembly when a part it placed changes, read off the scenes already built. No dependency file.
- A doctrine section and a skill paragraph, written to be rewritten in your voice. Same for the README, which I left alone.

Evidence:

- 12 new tests. One fixture has an analytic jam at exactly 180.0 and the sweep reports 180.0. Full suite green on top of current main.
- On the project that motivated it: the sweep found the redesigned hinge's true stop at 240.0 degrees with the contact point on the mount, and caught a part deriving its length from a stale pivot height, both before printing.

Calls that are yours:

- The sweep runs in dev's existing deferred check pass. A real assembly costs a few seconds per save on my machine; throttle or gate it if you'd rather.
- Naming: `assembly`, `use`, `hinge`, `obstacle`. Rename freely.
- Revolute joints only. Slides waited until something needs one.
- Tangent contact reads as clear (collision is intersection volume). Deliberate, documented in the doctrine section, easy to tighten if you disagree.
