### PR TITLE
Scrub the three.js placeholder domain that Snyk flags as suspicious

### DIFF
--- a/src/nurb/vendor/three/README.md
+++ b/src/nurb/vendor/three/README.md
@@ -6,7 +6,7 @@ Here rather than on a CDN because a CAD tool that needs the network is broken on
 plane, and because `nurb render` drives this same page: without the network it used to
 serve the viewer, load the canvas, and then draw nothing at all, forever.
 
-Copied verbatim from the npm tarball:
+Copied verbatim from the npm tarball, with one comment-only exception noted below:
 
 | here | from `three@0.169.0` |
 |---|---|
@@ -18,6 +18,8 @@ Copied verbatim from the npm tarball:
 
 `BufferGeometryUtils` is not imported by the viewer. `GLTFLoader` imports it, and
 leaving it out is a 404 that only shows up when a model loads.
+
+The one deviation: four upstream comments in `GLTFLoader.js` (near `resourcePath`, around line 199) used a made-up personal-CDN domain as a placeholder URL, and security scanners auditing the repo flagged that unregistered domain as a suspicious download source (Snyk marked the nurb skill CRITICAL on skills.sh over it, GitHub issue #34). The comments here say `example.com` instead. Re-apply this when vendoring a new version if upstream still has its own placeholder.
 
 The build is minified and the addons are not, because that is how the package ships
 them. The `@license` header at the top of the minified build is part of the licence

--- a/src/nurb/vendor/three/addons/loaders/GLTFLoader.js
+++ b/src/nurb/vendor/three/addons/loaders/GLTFLoader.js
@@ -196,10 +196,10 @@ class GLTFLoader extends Loader {
 		} else if ( this.path !== '' ) {
 
 			// If a base path is set, resources will be relative paths from that plus the relative path of the gltf file
-			// Example  path = 'https://my-cnd-server.com/', url = 'assets/models/model.gltf'
-			// resourcePath = 'https://my-cnd-server.com/assets/models/'
-			// referenced resource 'model.bin' will be loaded from 'https://my-cnd-server.com/assets/models/model.bin'
-			// referenced resource '../textures/texture.png' will be loaded from 'https://my-cnd-server.com/assets/textures/texture.png'
+			// Example  path = 'https://example.com/', url = 'assets/models/model.gltf'
+			// resourcePath = 'https://example.com/assets/models/'
+			// referenced resource 'model.bin' will be loaded from 'https://example.com/assets/models/model.bin'
+			// referenced resource '../textures/texture.png' will be loaded from 'https://example.com/assets/textures/texture.png'
 			const relativeUrl = LoaderUtils.extractUrlBase( url );
 			resourcePath = LoaderUtils.resolveURL( relativeUrl, this.path );
 


### PR DESCRIPTION
Fixes #34.

The Snyk audit on the skill's skills.sh page marks it CRITICAL over a "suspicious download URL": a made-up personal-CDN placeholder domain that lives in four code comments in upstream three.js r169's GLTFLoader.js, vendored here for the offline viewer. The comments are byte-identical to upstream, so nothing malicious is present, but the red badge is what anyone vetting the skill sees. This replaces the placeholder with example.com in the vendored copy (comment-only, no behavior change) and records the single deviation from verbatim in the vendor README so the next vendoring pass re-applies it. The audit is pinned to a commit on skills.sh's side, so the badge clears on their next re-audit. Socket's low-severity warning from the same screenshot is inherent to nurb executing part files and needs no change.