### PR TITLE
Assembly export downloads one zip of its placed parts

### DIFF
--- a/src/nurb/cli.py
+++ b/src/nurb/cli.py
@@ -245,20 +245,24 @@ def cmd_export(args):
     configs = _collect_exports(_resolve(root, args.part))
     out = root / "build"
     out.mkdir(exist_ok=True)
-    for path, name, overrides, _ in configs:
+    queue = [(path, name, overrides) for path, name, overrides, _ in configs]
+    while queue:
+        path, name, overrides = queue.pop(0)
         shape, _, _ = builder.build(path, overrides=overrides or None, draft=False)
         scene = getattr(shape, "_nurb_scene", None)
         if scene is not None:
             # A merged scene is a weld, not a part, and its obstacles were never
-            # going to be printed. Named explicitly it is an error that says what
-            # to do instead; in a project sweep it just steps aside.
-            placed = ", ".join(sorted(pathlib.Path(u).stem for u in scene.uses))
-            if args.part:
-                sys.exit(
-                    f"  {name} is an assembly: placed parts, not one printable solid."
-                    + (f" Export the parts it places: {placed}." if placed else "")
-                )
-            print(f"  {name}: assembly, skipped (export the parts it places)")
+            # going to be printed. Named explicitly, an assembly exports the parts
+            # it places instead; in a project sweep those export as themselves, so
+            # it just steps aside.
+            if not args.part:
+                print(f"  {name}: assembly, skipped (its parts export as themselves)")
+                continue
+            placed = sorted(pathlib.Path(u) for u in scene.uses)
+            if not placed:
+                sys.exit(f"  {name} is an assembly that places no parts; nothing to print")
+            print(f"  {name}: exporting the {len(placed)} part(s) it places")
+            queue = [(p, p.stem, None) for p in placed] + queue
             continue
         for fmt in formats:
             target = out / f"{name}.{fmt}"

--- a/src/nurb/cli.py
+++ b/src/nurb/cli.py
@@ -247,6 +247,19 @@ def cmd_export(args):
     out.mkdir(exist_ok=True)
     for path, name, overrides, _ in configs:
         shape, _, _ = builder.build(path, overrides=overrides or None, draft=False)
+        scene = getattr(shape, "_nurb_scene", None)
+        if scene is not None:
+            # A merged scene is a weld, not a part, and its obstacles were never
+            # going to be printed. Named explicitly it is an error that says what
+            # to do instead; in a project sweep it just steps aside.
+            placed = ", ".join(sorted(pathlib.Path(u).stem for u in scene.uses))
+            if args.part:
+                sys.exit(
+                    f"  {name} is an assembly: placed parts, not one printable solid."
+                    + (f" Export the parts it places: {placed}." if placed else "")
+                )
+            print(f"  {name}: assembly, skipped (export the parts it places)")
+            continue
         for fmt in formats:
             target = out / f"{name}.{fmt}"
             if fmt == "stl":

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -185,6 +185,8 @@ class Server:
                 from .assembly import wire
 
                 entry["joints"] = wire(scene)
+                # What the stl button downloads instead of the merged scene.
+                entry["uses"] = sorted(pathlib.Path(u).stem for u in scene.uses)
         except Exception as exc:
             entry["glb"] = None
             entry["shape"] = None
@@ -322,41 +324,62 @@ class Server:
             return self._resp(404, b"not found", "text/plain")
         try:
             async with self.building:
-                body = await asyncio.to_thread(self._export, name, fmt)
+                body, attach, mime = await asyncio.to_thread(self._export, name, fmt)
         except Exception as exc:
             message = f"{type(exc).__name__}: {exc}"
             return self._resp(500, message.encode(), "text/plain")
-        return self._resp(200, body, self.EXPORTS[fmt], attach=f"{name}.{fmt}")
+        return self._resp(200, body, mime, attach=attach)
 
     def _export(self, name, fmt):
-        """Build at the values the sliders hold and export that.
+        """Build at the values the sliders hold and export that, as (body, filename, mime).
 
         Always the polished build, whatever the viewer is showing: draft is a preview
-        economy, and a file somebody downloads is on its way to a slicer.
+        economy, and a file somebody downloads is on its way to a slicer. An assembly
+        downloads one zip of the parts it places, each exported exactly as its own
+        entry would be: the merged scene is a weld, its obstacles were never going to
+        be printed, and one file per part as separate downloads dies silently on the
+        browser's multiple-download permission.
         """
+        import io
         import tempfile
+        import zipfile
 
         from build123d import export_step, export_stl
+
+        def solid(path, stem):
+            """(bytes, None) for a part, (None, scene) for an assembly."""
+            built, _, _ = builder.build(path, overrides=self.overrides.get(stem), draft=False)
+            scene = getattr(built, "_nurb_scene", None)
+            if scene is not None:
+                return None, scene
+            with tempfile.TemporaryDirectory() as scratch:
+                target = pathlib.Path(scratch) / f"{stem}.{fmt}"
+                (export_stl if fmt == "stl" else export_step)(built, str(target))
+                return target.read_bytes(), None
 
         path = next((p for p in builder.find_parts(self.root) if p.stem == name), None)
         if path is None:  # deleted between the click and the build
             raise builder.BuildError(f"{name} is no longer on disk")
-        shape, _, _ = builder.build(path, overrides=self.overrides.get(name), draft=False)
-        # The viewer already disables its buttons on an assembly; this catches the
-        # request anything else makes. A merged scene is a weld, and the obstacles
-        # in it were never going to be printed at all.
-        if getattr(shape, "_nurb_scene", None) is not None:
-            raise builder.BuildError(
-                f"{name} is an assembly: placed parts, not one printable solid. "
-                f"Export the parts it places."
-            )
-        with tempfile.TemporaryDirectory() as scratch:
-            target = pathlib.Path(scratch) / f"{name}.{fmt}"
-            if fmt == "stl":
-                export_stl(shape, str(target))
-            else:
-                export_step(shape, str(target))
-            return target.read_bytes()
+        body, scene = solid(path, name)
+        if scene is None:
+            return body, f"{name}.{fmt}", self.EXPORTS[fmt]
+        queue = sorted(pathlib.Path(u) for u in scene.uses)
+        if not queue:
+            raise builder.BuildError(f"{name} places no parts; nothing to print")
+        buf = io.BytesIO()
+        seen = set()
+        with zipfile.ZipFile(buf, "w") as bundle:
+            while queue:
+                placed = queue.pop(0)
+                if placed in seen:
+                    continue
+                seen.add(placed)
+                body, nested = solid(placed, placed.stem)
+                if nested is not None:  # an assembly placing an assembly
+                    queue += sorted(pathlib.Path(u) for u in nested.uses)
+                    continue
+                bundle.writestr(f"{placed.stem}.{fmt}", body)
+        return buf.getvalue(), f"{name}-{fmt}.zip", "application/zip"
 
     @staticmethod
     def _meta(entry):

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -342,6 +342,14 @@ class Server:
         if path is None:  # deleted between the click and the build
             raise builder.BuildError(f"{name} is no longer on disk")
         shape, _, _ = builder.build(path, overrides=self.overrides.get(name), draft=False)
+        # The viewer already disables its buttons on an assembly; this catches the
+        # request anything else makes. A merged scene is a weld, and the obstacles
+        # in it were never going to be printed at all.
+        if getattr(shape, "_nurb_scene", None) is not None:
+            raise builder.BuildError(
+                f"{name} is an assembly: placed parts, not one printable solid. "
+                f"Export the parts it places."
+            )
         with tempfile.TemporaryDirectory() as scratch:
             target = pathlib.Path(scratch) / f"{name}.{fmt}"
             if fmt == "stl":

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -519,6 +519,7 @@ function sectionUpdate() {
 // Fetched rather than navigated, so a failed build lands in the note instead of
 // replacing the viewer with a traceback.
 for (const b of document.querySelectorAll('#download button')) {
+  b.dataset.title = b.title;  // restored when an assembly stops being on screen
   b.onclick = async () => {
     if (!current) return;
     // The label lives in a span so swapping it leaves the icon alone.
@@ -812,6 +813,13 @@ function hud(e) {
   document.getElementById('hud').innerHTML = e.error
     ? `<b>${e.name}</b><br>build failed`
     : `<b>${e.name}</b><br>${e.bbox.join(' &times; ')} mm<br>${e.ms} ms`;
+  // An assembly is placed parts, not one printable solid, so the manufacturing
+  // formats go dark on it; each placed part exports from its own entry.
+  const asm = Array.isArray(e.joints);
+  for (const b of document.querySelectorAll('#download button')) {
+    b.disabled = asm;
+    b.title = asm ? 'an assembly is placed parts; export each part instead' : b.dataset.title;
+  }
 }
 
 // ---- parameters ----

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -531,9 +531,13 @@ for (const b of document.querySelectorAll('#download button')) {
       const url = URL.createObjectURL(await r.blob());
       // A variant is a catalog entry, so its file carries the catalog name: sliders
       // sitting on hook_utility download hook_utility.stl, not hook_scissors.stl.
+      // An assembly comes back as one zip of its placed parts, named by the server;
+      // one download, because a second file dies silently on the browser's
+      // multiple-download permission.
+      const zip = (r.headers.get('Content-Disposition') || '').match(/filename="([^"]+\.zip)"/);
       const v = activeVariant(parts.get(current));
       const a = Object.assign(document.createElement('a'),
-                              { href: url, download: `${v ? v.name : current}.${fmt}` });
+                              { href: url, download: zip ? zip[1] : `${v ? v.name : current}.${fmt}` });
       a.click();
       URL.revokeObjectURL(url);
     } catch (e) {
@@ -813,12 +817,16 @@ function hud(e) {
   document.getElementById('hud').innerHTML = e.error
     ? `<b>${e.name}</b><br>build failed`
     : `<b>${e.name}</b><br>${e.bbox.join(' &times; ')} mm<br>${e.ms} ms`;
-  // An assembly is placed parts, not one printable solid, so the manufacturing
-  // formats go dark on it; each placed part exports from its own entry.
+  // An assembly is placed parts, not one printable solid, so its buttons download
+  // one zip with a file per placed part. Only an assembly that places nothing goes
+  // dark: geometry built inline has no part file, and a part file is what a print is.
   const asm = Array.isArray(e.joints);
+  const placed = asm ? (e.uses || []) : null;
   for (const b of document.querySelectorAll('#download button')) {
-    b.disabled = asm;
-    b.title = asm ? 'an assembly is placed parts; export each part instead' : b.dataset.title;
+    b.disabled = asm && !placed.length;
+    b.title = !asm ? b.dataset.title
+      : placed.length ? `downloads the placed parts, zipped: ${placed.join(', ')}`
+      : 'this assembly places no parts; nothing to print';
   }
 }
 

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -201,10 +201,10 @@ def test_the_watcher_learns_dependents_from_the_scenes_already_built(project):
     assert srv._dependents({str(path)}) == set()  # nothing uses the assembly
 
 
-def test_export_refuses_an_assembly_by_name_and_steps_around_it_in_a_sweep(project, monkeypatch, capsys):
+def test_export_of_an_assembly_writes_its_placed_parts_and_never_the_weld(project, monkeypatch, capsys):
     """A merged scene is a weld, and its obstacles were never going to be printed.
-    Named explicitly the refusal says which parts to export instead; a project
-    sweep skips it and still writes the real parts."""
+    Named explicitly, an assembly exports the parts it places; a project sweep
+    skips it because those parts already export as themselves."""
     import argparse
 
     from nurb import cli
@@ -213,19 +213,24 @@ def test_export_refuses_an_assembly_by_name_and_steps_around_it_in_a_sweep(proje
     write(project, "carrier", USE_ASM)
     monkeypatch.chdir(project)
 
-    with pytest.raises(SystemExit) as exc:
-        cli.cmd_export(argparse.Namespace(part="carrier", formats=["stl"]))
-    assert "assembly" in str(exc.value.code)
-    assert "plate" in str(exc.value.code)
+    cli.cmd_export(argparse.Namespace(part="carrier", formats=["stl"]))
+    assert (project / "build" / "plate.stl").exists()
     assert not (project / "build" / "carrier.stl").exists()
+    assert "exporting the 1 part(s) it places" in capsys.readouterr().out
 
+    (project / "build" / "plate.stl").unlink()
     cli.cmd_export(argparse.Namespace(part=None, formats=["stl"]))
     assert (project / "build" / "plate.stl").exists()
     assert not (project / "build" / "carrier.stl").exists()
     assert "skipped" in capsys.readouterr().out
 
 
-def test_the_viewer_export_route_refuses_an_assembly(project):
+def test_the_viewer_export_route_zips_an_assemblys_placed_parts(project):
+    """One download: separate files die silently on the browser's
+    multiple-download permission, and the merged scene is a weld."""
+    import io
+    import zipfile
+
     from nurb.server import Server
 
     write(project, "plate", PLATE)
@@ -233,8 +238,14 @@ def test_the_viewer_export_route_refuses_an_assembly(project):
     srv = Server.__new__(Server)
     srv.root = project
     srv.overrides = {}
-    with pytest.raises(Exception, match="assembly"):
-        srv._export("carrier", "stl")
+
+    body, attach, mime = srv._export("carrier", "stl")
+    assert (attach, mime) == ("carrier-stl.zip", "application/zip")
+    assert zipfile.ZipFile(io.BytesIO(body)).namelist() == ["plate.stl"]
+
+    body, attach, mime = srv._export("plate", "stl")
+    assert (attach, mime) == ("plate.stl", "model/stl")
+    assert body[:80]  # a real file, not a wrapper
 
 
 def test_an_assembly_glb_keeps_its_movers_as_named_nodes(project):

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -201,6 +201,42 @@ def test_the_watcher_learns_dependents_from_the_scenes_already_built(project):
     assert srv._dependents({str(path)}) == set()  # nothing uses the assembly
 
 
+def test_export_refuses_an_assembly_by_name_and_steps_around_it_in_a_sweep(project, monkeypatch, capsys):
+    """A merged scene is a weld, and its obstacles were never going to be printed.
+    Named explicitly the refusal says which parts to export instead; a project
+    sweep skips it and still writes the real parts."""
+    import argparse
+
+    from nurb import cli
+
+    write(project, "plate", PLATE)
+    write(project, "carrier", USE_ASM)
+    monkeypatch.chdir(project)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.cmd_export(argparse.Namespace(part="carrier", formats=["stl"]))
+    assert "assembly" in str(exc.value.code)
+    assert "plate" in str(exc.value.code)
+    assert not (project / "build" / "carrier.stl").exists()
+
+    cli.cmd_export(argparse.Namespace(part=None, formats=["stl"]))
+    assert (project / "build" / "plate.stl").exists()
+    assert not (project / "build" / "carrier.stl").exists()
+    assert "skipped" in capsys.readouterr().out
+
+
+def test_the_viewer_export_route_refuses_an_assembly(project):
+    from nurb.server import Server
+
+    write(project, "plate", PLATE)
+    write(project, "carrier", USE_ASM)
+    srv = Server.__new__(Server)
+    srv.root = project
+    srv.overrides = {}
+    with pytest.raises(Exception, match="assembly"):
+        srv._export("carrier", "stl")
+
+
 def test_an_assembly_glb_keeps_its_movers_as_named_nodes(project):
     """The node names are the viewer's contract for posing a joint client-side."""
     import io


### PR DESCRIPTION
Follow-up to #32, from its review: the viewer's stl button on an assembly exported the whole scene merged, obstacles included, while the assembly module's own docstring says an assembly is never exported as one STL.

Clicking stl or step on an assembly now downloads one zip (`<name>-stl.zip`) containing each placed part, exported exactly as its own entry would be, at its own slider values. The tooltip names the parts. One zip rather than one download per file, because Chrome's multiple-download permission kills the second file silently, and it resets per origin every time the dev server lands on a new port (verified live: two `a.click()` downloads lost one or both files; the zip always lands).

- `nurb export <assembly>` writes the placed parts as separate files into `build/` (no browser in the way there), recursing when an assembly places an assembly. A project-wide sweep still skips assemblies since their parts export as themselves.
- An assembly that places no parts (inline geometry only) is the one refusal left: no part file, nothing to print.
- GLB is untouched: it is the viewing format and carries the joint nodes.

Three new tests; full suite green (269 passed). Verified in the browser: assembly click delivers a zip with both parts byte-identical to their individual exports, plain part still downloads a bare STL.