### PR TITLE
Run the test suite in parallel and the strict check beside it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,27 @@ jobs:
       # playwright without one. Without this the render tests do not skip, they fail.
       - run: uv run playwright install --with-deps chromium
 
-      - run: uv run pytest -q
+      # The suite is CPU-bound OCCT builds and parallelizes almost perfectly: -n auto
+      # cut it 3x on a laptop and the runner has four cores.
+      - run: uv run pytest -q -n auto
 
-      # The rules against the real library, on a machine that is not the one they were
-      # calibrated on. --strict is what makes a finding fail the build; the command
-      # reports and exits 0 without it, because a warning that blocks work gets switched
-      # off. Run from the project directory, since a project is any directory with parts/.
+  # The rules against the real library, on a machine that is not the one they were
+  # calibrated on. --strict is what makes a finding fail the build; the command
+  # reports and exits 0 without it, because a warning that blocks work gets switched
+  # off. Run from the project directory, since a project is any directory with parts/.
+  # A separate job because it needs no browser and its 13 serial builds would
+  # otherwise sit behind pytest instead of running beside it.
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - run: uv sync --locked --dev
+
       - name: nurb check --strict
         working-directory: examples/notch
         run: uv run --project ../.. nurb check --strict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,10 @@ Issues = "https://github.com/Shpigford/nurb/issues"
 render = ["playwright>=1.49"]
 
 [dependency-groups]
-dev = ["pytest>=8.0"]
+dev = [
+    "pytest>=8.0",
+    "pytest-xdist>=3.8.0",
+]
 
 [project.scripts]
 nurb = "nurb.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -152,6 +152,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -445,6 +454,7 @@ render = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -458,7 +468,10 @@ requires-dist = [
 provides-extras = ["render"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.0" }]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
+]
 
 [[package]]
 name = "ocp-gordon"
@@ -656,6 +669,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
CI was taking 3 to 5 minutes, and profiling showed the suite is CPU-bound OCCT part builds that parallelize almost perfectly: pytest-xdist with `-n auto` cut a local serial run from 100s to 34s with all 269 tests green across repeated runs. The workflow now passes `-n auto` to pytest, and `nurb check --strict` moves to its own job so its serial catalog builds (another 34s locally) run beside pytest instead of after it. The check job syncs without `--all-extras`, skipping a playwright install it never used; verified locally that it still exits 0. Adds pytest-xdist to the dev dependency group.