### PR TITLE
Release 0.7.0: an installed skill knows when it is stale

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.6.1"
+version = "0.7.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.6.1"
+  version: "0.7.0"
 ---
 
 # nurb

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.6.1"
+  version: "0.7.0"
 ---
 
 # nurb

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Version bump to 0.7.0 in pyproject.toml, uv.lock, and both skill file copies.

Since v0.6.1:
- The skill frontmatter carries the package version and nurb dev nudges stale installed copies (#44)
- The skill teaches the viewer one affordance at a time (#42)
- The suite runs in parallel with the strict check beside it (#43)
- The viewer survives WebGL being unavailable (#38)

Merging this triggers publish.yml: PyPI upload, the v0.7.0 tag, and the GitHub release.