### PR TITLE
Explain what nurb is in the installer's closing message

### DIFF
--- a/site/install.sh
+++ b/site/install.sh
@@ -53,9 +53,10 @@ main() {
   fi
 
   say ""
-  say "  done."
+  say "  done. nurb is installed and your AI now knows how to use it."
   say ""
-  say "  open your AI (Claude, Cursor, Codex...) in a fresh folder and say:"
+  say "  there is no app to open: nurb works through the AI you already talk to."
+  say "  open Claude, Cursor, Codex... in a fresh folder and ask for a part:"
   say ""
   say "      \"design me a phone stand\""
   say ""


### PR DESCRIPTION
User feedback on install: the closing "done. open your AI (Claude, Cursor, Codex...) in a fresh folder and say..." read as a non sequitur, because the message never said nurb has no app of its own. The closing block now leads with what was installed ("nurb is installed and your AI now knows how to use it") and states that the AI is the interface ("there is no app to open") before giving the next step. "Fresh folder" stays, since opening the AI inside an existing codebase buries the request under that project's context.