### PR TITLE
Release 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.7.0"
+version = "0.8.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.7.0"
+  version: "0.8.0"
 ---
 
 # nurb

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.7.0"
+  version: "0.8.0"
 ---
 
 # nurb

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Bumps the version to 0.8.0. Merging publishes to PyPI, tags v0.8.0, and creates the GitHub release with generated notes.

Since v0.7.0:
- Fix three viewer bugs: section cut range, stale camera, checks panel blink (#50)
- Skill tells the agent to name parameters in the user's words (#49)
- Skill offers the permission allowlist before the prompts start (#48)
- Skill captions the placeholder block when the viewer URL is handed over (#47)
- Explain what nurb is in the installer's closing message (#46)