### PR TITLE
Document the release steps in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ nurb launcher        write viewer.command, a double-clickable `nurb dev`
 A project is any directory containing `parts/`. There is no init step, and there
 never should be.
 
+A release is a version bump merged to main: `uv version X.Y.Z`, plus the matching `version:` line in `src/nurb/skill.md` and `skills/nurb/SKILL.md` (a test enforces they agree). The publish workflow does the rest: PyPI upload, tag, GitHub release.
+
 ## Layout
 
 ```


### PR DESCRIPTION
The 0.8.0 release's first CI run went red because the skill frontmatter carries its own version line that uv version does not touch. One sentence in CLAUDE.md so the next release gets it right on the first commit.