### PR TITLE
Release 0.9.0: print orientation, diagonal variants, and generated support fins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,9 @@ parallel `PARAMS` dict; the two would drift.
 skip the polish pass. Worth 20% on a real part, not the 18x a cube suggested: chamfers
 are 23% of the gridfinity shelf's build.
 
-The build is now nearly all of the loop. Tessellation used to look like the larger half
-at 620ms, and Phase 4 found that almost all of it was one iterator in build123d rather
-than any geometry; `builder._triangulate` reads the same triangles by index in 30ms.
+The build is nearly all of the loop. Tessellation used to look like the larger half at
+620ms, and almost all of that was one pathological iterator in build123d rather than
+any geometry; `builder._triangulate` reads the same triangles by index in 30ms.
 Write a continuous dimension as a float (`chamfer_size=1.0`) and a count as an int
 (`bracket_count=4`): the viewer reads the type of the default to decide whether that
 parameter's slider steps by one.
@@ -71,6 +71,7 @@ src/nurb/registry.py      @part, signature introspection
 src/nurb/builder.py       load, build, tessellate, GLB
 src/nurb/checks.py        printability rules, convexity, Finding/Context, variants
 src/nurb/polish.py        the bisecting polish pass, and chamfer with real errors
+src/nurb/orient.py        stand(), the diagonal print stance with its bed facet
 src/nurb/probe.py         what `nurb inspect` measures, in the rules' own units
 src/nurb/api.py           the vocabulary, derived from __all__ so it cannot drift
 src/nurb/printers.toml    shipped printer profiles, named by a project's printer.toml
@@ -195,67 +196,3 @@ as though every file will be read by a stranger.
 - No em-dashes in user-facing copy, docs, or comments.
 - Commit messages describe what changed and why, in plain sentences.
 - **Never hard-wrap prose. Ever.** One paragraph is one line; editors soft-wrap. This applies to every markdown and text file, and it applies even when the surrounding file is already wrapped: fix the paragraph you touch instead of matching the wrapping. Code, tables, and fenced blocks keep their formatting.
-
-## Current state
-
-Phases 1 through 5 are done. The whole Notch catalog lives in `examples/notch/`:
-sixteen catalog entries out of thirteen part files and nineteen shipped configurations,
-every one a single solid matching its Fusion bounding box, clean under
-`nurb check --strict`, and watertight when exported.
-
-`tests/test_notch_fit.py` is the hanging interface, asserted rather than read: every
-channel floor on exact pitch, at full span, one per bracket and no more, for every
-configuration. Its numbers are literals rather than imports from `system.py`, because a
-fit test that reads the same constant the part built from agrees with the part however
-wrong the constant is. A deliberate 0.1mm per interval pitch error is in the suite so
-the assertion is known to be able to fail. 238 tests.
-
-**Thirteen parts found rule bugs that three parts could not.** `concave_cosmetic` was
-firing at the 2mm structural relief the doctrine prescribes for thin material, and
-`bed_bevel` at the 45 degree corbel it prescribes for a raised feature. Both were
-recalibrated against measurements, not opinions: a relief is wider than polish, and a
-bottom chamfer rises by exactly its size where a corbel rises farther. `polish_edges` also
-had a gap, allowing a sloped edge that reaches the bed. Every one was found by a part
-rather than by review, which is the argument for `examples/` being the calibration set.
-
-The agent surface is in: `nurb rules` prints the doctrine from `src/nurb/doctrine.md`,
-`nurb card` regenerates each card's AUTO block from a build, `nurb render` screenshots the
-viewer headlessly, and `measurements.toml` carries dimensions with their provenance.
-
-**What an agent cannot ask, it reverse-engineers, and that is the expensive path.** A
-recorded 40-minute session spent about 95% of its output tokens thinking, and twenty-two
-of its thirty-eight shell commands were reading nurb's own source in site-packages or
-writing throwaway scripts to print a face centre. `nurb api` answers the first (the
-vocabulary with signatures, derived from `__all__` and from the live functions, so it
-cannot drift) and `nurb inspect` answers the second (faces, normals, concave edges, and
-each finding resolved to the face it fired on, in the units the rules report). `chamfer`
-shadows build123d's to append the doctrine's room rule on failure, because the kernel's
-own "try a smaller length value(s)" points at the wrong cause. `fillet` is deliberately
-not wrapped: build123d's fillet error already names `max_fillet()` and a smaller radius
-really is the fix there, so the chamfer rule would have been wrong half the time.
-
-`nurb extract` finds duplication across sibling parts up to alpha-equivalence and
-reports it; it does not rewrite, because naming the thing is the judgement and noticing
-is the mechanical part. Run over the finished port it found `system.slab()` in six files
-at once.
-
-The viewer has a slider per numeric parameter, inferred from the signature and nothing
-else, a section view that caps its cut so a solid still reads as solid, and a button
-that writes an exploration back into the file's defaults. three.js is vendored, so the
-viewer and `nurb render` both work with no network.
-
-**The live loop got about 20x faster in Phase 4, and not for a reason anyone would
-guess.** `Shape.tessellate` reads its triangles with `for t in poly.Triangles()`, and
-OCP's iterator over that array is pathological: 7790 triangles cost 536ms to iterate
-and 6.8ms to read by index, against 10ms for the meshing itself. `builder._triangulate`
-reads them by index and returns bit-identical geometry. Phase 1's recorded conclusion
-that "tessellation is the loop" was measuring that iterator.
-
-The README's original "not built yet" list is built. Printer profiles ship in
-`src/nurb/printers.toml`, named once per project by `printer.toml` (`nurb check
---printer x` tries another machine). `min_wall` corrects its ray chords with an
-inscribed sphere on exact kernel distances, gated so the sphere is only paid for where
-it could change the verdict; the far contact gets the same 0.3 cosine floor as the
-ray's exit filter, or a dimple's bowl reads as a thin wall (it did: 1.07mm in a 2.3mm
-web on the scraper). And the viewer is the configurator: `stl`/`step` buttons build at
-the slider values, polished, and hand back the file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.8.0"
+version = "0.9.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.8.0"
+  version: "0.9.0"
 ---
 
 # nurb

--- a/src/nurb/__init__.py
+++ b/src/nurb/__init__.py
@@ -17,6 +17,7 @@ from build123d import *  # noqa: F401,F403  -- geometry vocabulary
 from .assembly import assembly, hinge, obstacle, use  # noqa: E402
 from .checks import concave_edges, is_convex  # noqa: E402
 from .measurements import measured  # noqa: E402
+from .orient import stand  # noqa: E402
 from .polish import chamfer, polish  # noqa: E402  -- must win, see below
 from .registry import part  # noqa: E402  -- must win over any build123d name
 
@@ -28,11 +29,17 @@ from .registry import part  # noqa: E402  -- must win over any build123d name
 # be written without it: chamfering an inside corner is the one polish mistake that looks
 # fine in code. `measured` is here because the alternative to asking for a dimension is
 # inventing one, and an invented one builds, checks clean and prints.
+# `stand` is here because a diagonal print variant cannot be written without it: the
+# rotation is trivial, but the bed facet it cuts is a doctrine rule (2mm of flat, or the
+# first layer is one extrusion line wide and peels), and a part file left to tilt by
+# hand ships the knife edge.
 # `chamfer` deliberately shadows build123d's. Same behaviour, same exception type;
 # what it adds is the doctrine's rule on the way out of a failure, because the kernel's
 # own advice is "try a smaller length value(s)" and following it is how a part ends up
 # with a 0.4mm chamfer that lands and prints as a defect. It is the most common way a
-# part stops building, so it is the one message worth owning.
+# part stops building, so it is the one message worth owning. `fillet` is deliberately
+# not wrapped: build123d's fillet error already names `max_fillet()` and a smaller
+# radius really is the fix there, so the chamfer rule would be wrong half the time.
 __all__ = [
     *getattr(_b3d, "__all__", [n for n in dir(_b3d) if not n.startswith("_")]),
     "part",
@@ -40,6 +47,7 @@ __all__ = [
     "concave_edges",
     "measured",
     "polish",
+    "stand",
     "assembly",
     "use",
     "hinge",

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -175,16 +175,33 @@ def sliver(shape, ctx):
 def build_volume(shape, ctx):
     """Does it fit on the printer at all."""
     size = shape.bounding_box().size
-    got = sorted([size.X, size.Y, size.Z], reverse=True)
-    fits = sorted(ctx.bed, reverse=True)
-    if all(g <= b for g, b in zip(got, fits)):
+    up = Vector(*ctx.up).normalized()
+    if _standing(shape, up) is None:
+        got = sorted([size.X, size.Y, size.Z], reverse=True)
+        fits = all(g <= b for g, b in zip(got, sorted(ctx.bed, reverse=True)))
+        orientation = "in any orientation"
+    else:
+        # A stance facet fixes the build direction. The part may turn on the plate,
+        # but rolling it onto another axis would put the facet in the air again.
+        bed, top = _span(shape, up)
+        footprint = sorted(
+            _span(shape, axis)[1] - _span(shape, axis)[0]
+            for axis in _bed_axes(up)
+        )
+        plate = sorted(ctx.bed[:2])
+        got = [top - bed, *footprint]
+        fits = top - bed <= ctx.bed[2] and all(
+            got <= available for got, available in zip(footprint, plate)
+        )
+        orientation = "in its fixed build orientation"
+    if fits:
         return []
     return [
         Finding(
             "build_volume",
             FAIL,
             f"{size.X:.0f} x {size.Y:.0f} x {size.Z:.0f}mm does not fit "
-            f"{ctx.bed[0]:.0f} x {ctx.bed[1]:.0f} x {ctx.bed[2]:.0f}mm in any orientation",
+            f"{ctx.bed[0]:.0f} x {ctx.bed[1]:.0f} x {ctx.bed[2]:.0f}mm {orientation}",
             value=round(max(got), 1),
         )
     ]
@@ -237,6 +254,13 @@ def _span(shape, up):
     return min(reach), max(reach)
 
 
+def _bed_axes(up):
+    """Two perpendicular directions across the build plate."""
+    guide = Vector(1, 0, 0) if abs(up.X) < 0.9 else Vector(0, 1, 0)
+    first = up.cross(guide).normalized()
+    return first, up.cross(first).normalized()
+
+
 def _reach(face, up):
     """How far a face protrudes, which is the smallest of its horizontal extents.
 
@@ -250,6 +274,97 @@ def _reach(face, up):
         if abs(axis.dot(up)) < 0.9
     ]
     return min(across) if across else 0.0
+
+
+# Height over stance width past which first-layer adhesion is holding a lever and a
+# part needs fins. Provisional, sitting between a 30mm bracket on a 2mm facet that
+# prints clean and a 60mm bar that does not survive without one. `stand()` grows its
+# fins at the same number, so the rule and the remedy cannot drift apart.
+LEVERAGE = 20
+
+
+def _standing(shape, up):
+    """The supported footprint width when a part stands rather than sits.
+
+    A part printed diagonally does not have a bottom face: it stands on a deliberate
+    narrow flat, the facet `stand()` cuts across its down corner, plus the pads of
+    any fins it grew. Several rules were calibrated on parts that sit, and a stance
+    is the case that breaks them: there is no bottom whose rim a bed bevel could
+    dress, and the centre of mass is always outside a 2mm strip.
+
+    Aspect ratio alone cannot identify it: a normally seated 4mm wall also has a long,
+    narrow bottom. The cut facet has two long edges against sloped body faces which
+    continue into other nonvertical faces; a bottom bevel instead ends at the vertical
+    wall it dresses. Once found, all real bed faces count toward support, so generated
+    fin pads widen the returned footprint. Returns None for a sitting part.
+    """
+    FACET = 5.0
+    bed, _ = _span(shape, up)
+    footing = [
+        f for f in shape.faces() if _span(f, up)[1] <= bed + 1e-4 and f.area >= 4.0
+    ]
+    if not footing:
+        return None
+    neighbours = None
+    facet = None
+    long_edge = None
+    for face in footing:
+        edges = list(face.edges())
+        if not edges:
+            continue
+        longest = max(edges, key=lambda edge: edge.length)
+        length = longest.length
+        if length <= 0:
+            continue
+        width = face.area / length
+        if width > FACET or length < 3 * width:
+            continue
+        if neighbours is None:
+            neighbours = edge_faces(shape)
+        stance_edges = 0
+        for edge in edges:
+            if edge.length < max(2 * width, 0.8 * length):
+                continue
+            pair = neighbours.get(edge, [])
+            if len(pair) != 2:
+                continue
+            other = pair[1] if pair[0] == face else pair[0]
+            tilt = abs(other.normal_at(edge.center()).dot(up))
+            if not 1e-4 < tilt < 0.9999:
+                continue
+            continues = False
+            for far_edge in other.edges():
+                if far_edge == edge or far_edge.length < 0.8 * edge.length:
+                    continue
+                far_pair = neighbours.get(far_edge, [])
+                if len(far_pair) != 2:
+                    continue
+                beyond = far_pair[1] if far_pair[0] == other else far_pair[0]
+                if beyond == face:
+                    continue
+                beyond_tilt = abs(beyond.normal_at(far_edge.center()).dot(up))
+                if 1e-4 < beyond_tilt < 0.9999:
+                    continues = True
+                    break
+            if continues:
+                stance_edges += 1
+        if stance_edges >= 2:
+            facet, long_edge = face, longest
+            break
+    if facet is None:
+        return None
+
+    along = long_edge.tangent_at(0)
+    along = (along - up * along.dot(up)).normalized()
+    across = up.cross(along).normalized()
+
+    def footprint(axis):
+        spans = [_span(face, axis) for face in footing]
+        return max(high for _, high in spans) - min(low for low, _ in spans)
+
+    # Leverage acts across the facet, in the direction of the lean. Its length along
+    # the corner already carries the first layer; fins extend support across it.
+    return footprint(across)
 
 
 def _bridged(solid, face, up, ctx):
@@ -305,7 +420,12 @@ def overhang(shape, ctx):
         crossing = _bridged(solid, face, up, ctx) if solid else None
         if crossing is not None and crossing <= ctx.bridge_limit:
             continue  # a bridge this printer walks across
-        if crossing is None and _reach(face, up) <= ctx.overhang_reach:
+        # A polish chamfer that a diagonal stand turns to face the bed is a strip
+        # `size * 1.42` wide, the same figure concave_cosmetic uses, and it prints:
+        # the flanks close over it at 45 degrees. Measured at 1.32mm on a stood
+        # bracket whose flat print is clean.
+        droop = max(ctx.overhang_reach, 1.42 * 1.15 * ctx.cosmetic_chamfer)
+        if crossing is None and _reach(face, up) <= droop:
             continue  # a ledge too shallow to droop, whatever its angle or length
         if crossing is not None:
             found.append(
@@ -332,14 +452,115 @@ def overhang(shape, ctx):
     return found
 
 
+@rule("floating")
+def floating(shape, ctx):
+    """A region whose first layer would be laid on air.
+
+    The overhang rule judges faces one at a time by angle, and a floating region can
+    present nothing steeper than the limit: stand an L on the end of one leg and the
+    other leg's tip hangs in space with every face at exactly 45 degrees. What gives
+    it away is the shape of the low point: a vertex above the bed with every edge
+    rising away from it. Somewhere to sit is what a first layer needs, and angle
+    cannot measure it.
+
+    Supported means one of two things, and both are needed. An edge running further
+    down: the second-lowest corner of a stood slab has air straight below it, but its
+    silhouette descends to the facet and every layer rests on the one before. Or
+    material straight below: the calipers holder's corbel corner has every edge
+    rising away from it and sits directly on the body underneath, which is what
+    flagged the edge test as insufficient when this rule first ran on the catalog.
+    The face gate mirrors the overhang rule's: a low point whose downward faces are
+    all chamfer-band strips is a polish artifact, not a region.
+    """
+    up = Vector(*ctx.up).normalized()
+    bed, _ = _span(shape, up)
+    droop = max(ctx.overhang_reach, 1.42 * 1.15 * ctx.cosmetic_chamfer)
+
+    def key(p):
+        return (round(p.X, 4), round(p.Y, 4), round(p.Z, 4))
+
+    # Directions leaving each vertex, off the edge tangents rather than the chords,
+    # keyed by position: the kernel hands back fresh objects on every call, so
+    # identity would never match anything.
+    leaving = {}
+    for edge in shape.edges():
+        try:
+            ends = (edge.position_at(0), edge.position_at(1))
+            tangents = (edge.tangent_at(0), -edge.tangent_at(1))
+        except Exception:
+            continue
+        for point, tangent in zip(ends, tangents):
+            leaving.setdefault(key(point), []).append(tangent)
+    faces_at = {}
+    for face in shape.faces():
+        for v in face.vertices():
+            faces_at.setdefault(key(Vector(v.X, v.Y, v.Z)), []).append(face)
+    solid = shape.solids()[0] if shape.solids() else None
+    found = []
+    for spot, directions in leaving.items():
+        here = Vector(*spot)
+        rise = here.dot(up) - bed
+        if rise <= 1e-4:
+            continue  # on the bed, which is the one place a low point belongs
+        if any(d.dot(up) < -1e-6 for d in directions):
+            continue  # material runs further down, so this is not the low point
+        below = here - up * 0.5
+        if solid and solid.is_inside((below.X, below.Y, below.Z)):
+            continue  # sitting on material, which is support however the edges run
+        # A bead anchored on both sides at its own layer is a bridge, and a fin's
+        # tine is exactly one: it starts in air and prints anyway, walked across
+        # from the part to the fin. Probed a bead out each way, just above the low
+        # point, so a floating tip, anchored on one side at best, stays a finding.
+        level = here + up * 0.15
+        horiz = [a for a in (Vector(1, 0, 0), Vector(0, 1, 0), Vector(0, 0, 1)) if abs(a.dot(up)) < 0.9]
+        def held(p):
+            return solid.is_inside((p.X, p.Y, p.Z))
+
+        if solid and any(held(level + d * 1.2) and held(level - d * 1.2) for d in horiz):
+            continue
+        wide = [
+            f
+            for f in faces_at.get(spot, [])
+            if min(n.dot(up) for n in _sample_normals(f)) < -0.03 and _reach(f, up) > droop
+        ]
+        if not wide:
+            continue
+        found.append(
+            Finding(
+                "floating",
+                FAIL,
+                f"a region's first layer sits on air, {rise:.1f}mm up with nothing below",
+                value=round(rise, 1),
+                where=tuple(round(v, 2) for v in here),
+            )
+        )
+    return found
+
+
 @rule("stability")
 def stability(shape, ctx):
     """Will it stand on the bed, or tip while printing."""
     up = Vector(*ctx.up).normalized()
-    bed, _ = _span(shape, up)
+    bed, top = _span(shape, up)
     footing = [f for f in shape.faces() if _span(f, up)[1] <= bed + 1e-4]
     if not footing:
         return [Finding("stability", FAIL, "nothing flat to stand on")]
+    stance = _standing(shape, up)
+    if stance is not None:
+        # Standing on a facet, the centre of mass is always outside it and the part
+        # is held by first-layer adhesion, not balance. What adhesion cannot hold is
+        # leverage; fins widen the stance, which is how growing them clears this.
+        if top - bed > LEVERAGE * stance:
+            return [
+                Finding(
+                    "stability",
+                    WARN,
+                    f"stands {top - bed:.0f}mm tall on a {stance:.1f}mm facet, "
+                    "more than adhesion holds; a support fin is the fix",
+                    value=round((top - bed) / stance, 1),
+                )
+            ]
+        return []
     com = shape.center(CenterOf.MASS)
     axes = [a for a in (Vector(1, 0, 0), Vector(0, 1, 0), Vector(0, 0, 1)) if abs(a.dot(up)) < 0.9]
     for axis in axes:
@@ -482,7 +703,7 @@ def configurations(part_path, base=None):
 
     out = [(stem, {}, fresh())]
     for name, variant in block.get("variants", {}).items():
-        extra = set(variant) - {"params", "accepted", "part", "printer"}
+        extra = set(variant) - {"params", "accepted", "part", "printer", "note"}
         if extra:
             raise ValueError(
                 f"{card.name}: variant {name} has {', '.join(sorted(extra))} at the top "
@@ -558,6 +779,12 @@ def bed_bevel(shape, ctx):
     """
     up = Vector(*ctx.up).normalized()
     bed, _ = _span(shape, up)
+    if _standing(shape, up) is not None:
+        # Standing on a facet, so every face at the plate is deliberately tilted and
+        # there is no bottom whose rim a bevel could dress. A 4mm wall stood at 45
+        # rises 2.83mm, square in the chamfer band, and prints fine: rise cannot tell
+        # it from a bevel, but the stance can.
+        return []
     found = []
     for face in shape.faces():
         low, high = _span(face, up)

--- a/src/nurb/doctrine.md
+++ b/src/nurb/doctrine.md
@@ -60,6 +60,17 @@ bounding box and still exports, so nothing downstream catches it.
   structural or corbel, has to read as one system.
 - **Elephant's foot is a slicer setting**, not a CAD problem. Do not model around it.
 
+## Print orientation
+
+Parts print the way they are modelled, +z up, and for most parts that is the end of it. Orientation becomes a decision in exactly two situations: an overhang a corbel cannot carry without disfiguring the part, and a load that wraps a corner, where no flat orientation keeps every member strong.
+
+- **The two remedies for an overhang finding are a corbel and a tilt.** Reach for the corbel first: it is local, it keeps the part on its natural face, and it disappears into the design. Reach for the tilt when the whole part fights the bed. An open box printed upright wants support inside; printed flat it has one huge first layer that warps and three finishes that do not match; stood on a corner at 45 degrees, nothing needs support and every face is printed as perimeters, one finish.
+- **Layer bonds are about half strength**, measured near 50% of in-plane tensile for PLA and worse for ASA. A part loaded around a corner, which is every bracket and every L, has no flat orientation that keeps both legs loading in-plane: one of them always pulls its layers apart. Stood at 45 degrees neither does, and the load path never lies in a single weld plane. A tilt moves the weak plane rather than deleting it, so it is not automatic: a hook printed at an angle fails at the same load with the break somewhere else. It earns its keep on corners, not on straight pulls.
+- **`stand(part, tilt, axis, facet)` is the verb.** It rotates the part about a horizontal axis, seats it, and shaves the down corner flat, because a part standing on an unshaved corner meets the bed along a single extrusion line, and that line peels. The facet is 2mm minimum, measured across the flat. 45 degrees is the usual tilt and is not sacred: a shallow part stands at whatever angle brings everything inside the limit. Run the polish pass before standing, in the functional orientation.
+- **Stand a part on the corner that grounds every region, and prefer the lowest stance that does.** For an L that is the outside of its elbow, legs up in a V. The sign of the roll depends on which way the model faces, so check rather than reason: the same L rolled the other way stands on the end of one leg as a chevron, still grounded, still legal, but 60% taller on the same facet, and height on a facet is what spends the adhesion margin. The stance to refuse is the tent, elbow up, one leg's tip hanging in air, and it is easy to miss by eye because nothing about it looks steep: every face of the floating tip can sit at exactly 45 degrees, silent to the overhang rule. The `floating` rule fails any region whose first layer has nothing to sit on and `stability` judges the height, so `nurb check` on the stood variant settles the corner choice. Past grounded, inside the limit, and low, the tilt is taste: what remains is where the facet scar lands, which is the user's call.
+- **A diagonal print is a variant, and it is offered, never imposed.** The facet is cut from visible geometry, and whether that corner may go is not a printability question: only the user knows whether it shows. The pattern is a bool parameter, `diagonal=False`, that applies `stand()` when true, and a card variant that sets it, so it builds, checks against its own baselines, exports its own STL and shows in the viewer like any variant. Give the variant a `note` saying what the tilt buys and costs in plain words, "prints tilted on a flattened corner: no supports, and stronger across the corner", never in the doctrine's. Build it speculatively and link it, `?part=x&variant=x_diagonal`; the user judges by looking, and two lines delete it if they pass.
+- **Past about twenty times the facet width in height, adhesion is holding a lever, and `stand()` grows fins.** A compact part holds its facet by first-layer adhesion; a tall one needs support fins modelled into the part, never slicer supports, whose loose grip lets warp tension spring the part free mid-print. The recipe is print-farm practice with fixed numbers, so it is generated rather than judged: a thin blade at each side of the part hugging the lean across a small gap, each on a 1mm pad for its own adhesion, joined to the part only by horizontal tines a single layer tall and a bead wide, about 0.5 x 0.5mm, five or so, biased toward the bottom where the young print is least stable. After printing the fins lift off whole and the tine stubs rub off with a fingernail. The tines cost a handful of sub-millimetre faces, declared on the card like any other earned sliver. The stability warning remains the referee for what `stand()` did not build: pass `fins=False` to see it, and a part tilted by hand still gets it.
+
 ## Load path
 
 Work out where the weight sits and what it does at the mount before drawing anything.
@@ -249,6 +260,9 @@ exactly as they walk the part's own defaults, so it gets its own STL, its own ba
 and its own line in the AUTO block.
 
 ```toml
+[variants.shelf_gridfinity_3x2]
+note = "The same shelf sized for the wide bin: three columns instead of two."
+
 [variants.shelf_gridfinity_3x2.params]
 grid_x = 3
 bracket_count = 6
@@ -259,6 +273,8 @@ sliver = 26
 
 The test is whether it is the same geometry. A wider cradle on the same J is a variant.
 A different mechanism is a part, however similar the slab looks.
+
+`note` is one sentence saying why the variant exists, written in the user's words rather than the doctrine's, because the viewer shows it next to the variant and its reader is whoever is about to print the thing. The params are the how and never the why: `diagonal = true` explains nothing to someone who has not read the doctrine, and "prints tilted so it needs no supports" does.
 
 ## Measurements
 

--- a/src/nurb/orient.py
+++ b/src/nurb/orient.py
@@ -1,0 +1,160 @@
+"""Diagonal print orientation: stand a part on a corner, on a flat it can grip.
+
+Every check judges a solid the way it sits, building up in +z. So orientation is not
+metadata to carry around; it is geometry. A part that should print tilted gets tilted,
+seated on the bed, and handed to the same rules as any other solid, and they all stay
+right without knowing anything happened.
+
+The one piece of new physics is the facet. A tilted part meets the bed along an edge,
+and an edge is a single extrusion line on the first layer: it peels, and the print tips.
+The corner gets shaved flat so the part stands on a real face. The doctrine's number is
+2mm minimum, measured across the flat.
+
+Past about twenty times the facet in height, adhesion is holding a lever, and the fix is
+fins: break-away triangular walls behind the lean, grown here because the recipe is
+print-farm practice with fixed numbers, not a judgement. The fin body stays clear of the
+part; only the tines touch, each a single-layer bead that rubs off with a fingernail.
+"""
+
+from math import radians, sin
+
+from build123d import Axis, Box, CenterOf, Keep, Plane, Polygon, Pos, Vector, extrude, split
+
+from .checks import LEVERAGE
+
+FIN_THICK = 1.0  # a couple of beads of wall: stiff enough to hold, thin enough to lift
+                 # off whole, and exactly the printer's min_wall so the checker does
+                 # not read a deliberate sacrificial blade as a defect
+FIN_RISE = 0.7  # how far up the part a fin reaches, as a fraction of its height
+GAP = 0.7  # horizontal clearance between fin and part, about half a millimetre square-on
+TINE = 0.3  # a tine is one layer tall, so it prints as a single continuous bead
+TINE_WIDE = 0.5  # and a bead or so wide, so it rubs off without a scar
+BITE = 0.6  # how far a tine reaches into each body, so both ends actually fuse
+PAD_THICK = 1.0  # the doctrine's base pad: thick enough to peel without leaving veneer
+PAD_MARGIN = 1.9  # pad width beyond the fin blade, kept clear of the 5mm stance strip
+
+
+def stand(shape, tilt=45.0, axis=Axis.Y, facet=2.0, fins=True):
+    """Tilt a part for diagonal printing and shave a flat for it to stand on.
+
+    Rotates `tilt` degrees about the horizontal `axis`, seats the part on the bed, and
+    cuts the corner below the bed plane away so the part stands on a flat `facet` wide
+    instead of a knife edge. The result is real geometry in print orientation: every
+    check, the viewer, and export judge it exactly as it will build.
+
+    `facet` is the width of the flat across the down corner, exact when that corner is
+    square. A wider corner gives a wider flat, which is fine: the doctrine's 2mm is a
+    minimum. The sign and size of `tilt` pick which corner goes down, and past 90 is
+    often the point: an L stands on the outside of its elbow, legs up, which is its
+    model rolled about 135 degrees with the sign set by which way it faces. Check the
+    result rather than reasoning about the sign. Stand a part on the corner that
+    grounds all of it, the lowest such stance by preference; a corner that leaves some
+    region hanging in air is the `floating` finding.
+
+    A part standing taller than the adhesion rule allows grows break-away support fins
+    behind its lean, one at each side, tined on and rubbed off after printing. `fins`
+    is on by default and only builds them when the stance earns them; pass False to
+    see the raw stability finding instead. Fins currently understand the default Y
+    tilt axis only.
+
+    Run the polish pass before this, in the functional orientation. The facet's own
+    edges stay unpolished, the same as any bed-contact face.
+    """
+    if abs(sin(radians(2 * tilt))) < 0.05:
+        raise ValueError(
+            f"stand() needs a tilt away from 0, 90 and 180 degrees, got {tilt:g}. "
+            "At those angles a flat face is already down and there is no corner to "
+            "stand on; this is for diagonal prints."
+        )
+    if facet <= 0:
+        raise ValueError(f"facet is the width of the bed flat in mm, got {facet:g}")
+    if abs(axis.direction.normalized().dot(Vector(0, 0, 1))) > 1e-6:
+        raise ValueError(
+            "stand() needs a horizontal rotation axis; an axis with a Z component "
+            "does not tilt the part cleanly toward the bed."
+        )
+    tilted = shape.rotate(axis, tilt)
+    # For a square corner tilted t, a cut d deep makes a flat 2*d/|sin(2t)| wide, so
+    # d = facet * |sin(2t)| / 2. At 45 or 135 degrees that is half the facet.
+    depth = facet * abs(sin(radians(2 * tilt))) / 2
+    seated = Pos(0, 0, -tilted.bounding_box().min.Z - depth) * tilted
+    seated = split(seated, bisect_by=Plane.XY, keep=Keep.TOP)
+    height = seated.bounding_box().max.Z
+    if not fins or height <= LEVERAGE * facet:
+        return seated
+    if abs(axis.direction.dot(Vector(0, 1, 0))) < 0.999:
+        raise ValueError(
+            "stand() grows fins for the default Y tilt axis only; rotate the model "
+            "so its tilt is about Y, or pass fins=False and model the fin by hand."
+        )
+    return seated + _fins(seated, height)
+
+
+def _underside(seated, s, z):
+    """Where the lean-side surface sits at height `z`, in lean coordinates.
+
+    Lean coordinates put outward positive whichever way the part leans: u = s * x.
+    Measured off a thin slice rather than derived from the tilt, because the fin has
+    to hug the face that is actually there, whatever cut it.
+    """
+    slab = seated & Pos(0, 0, z) * Box(10000, 10000, 0.05)
+    box = slab.bounding_box()
+    return s * (box.max.X if s > 0 else box.min.X)
+
+
+def _fins(seated, height):
+    """Two break-away fins behind the lean, with their pads and tines.
+
+    The recipe is print-farm practice: a thin wall whose top edge parallels the
+    part's leaning underside across a small gap, standing on a 1mm pad for its own
+    adhesion, joined to the part by a handful of single-layer tines biased toward
+    the bottom, where the young print is least stable. One fin at each side of the
+    part, because scars hide at corners and two fins also stop twist.
+    """
+    bb = seated.bounding_box()
+    bed = [f for f in seated.faces() if abs(f.bounding_box().max.Z) < 1e-6]
+    footing = sum(f.center().X * f.area for f in bed) / sum(f.area for f in bed)
+    s = 1.0 if seated.center(CenterOf.MASS).X >= footing else -1.0
+
+    # The lean line u(z) = c + m*z, fitted mid-part where the silhouette is the lean
+    # face itself rather than whatever bulk sits near the bed.
+    z1, z2 = 0.45 * height, 0.65 * height
+    u1, u2 = _underside(seated, s, z1), _underside(seated, s, z2)
+    m = max((u2 - u1) / (z2 - z1), 0.0)
+    c = u1 - m * z1
+    # The fin foot starts beyond whatever the part puts near the bed, grip lumps
+    # included, so the blade breaks away instead of fusing into them.
+    start = max(c + GAP, _underside(seated, s, PAD_THICK) + GAP)
+    rise = FIN_RISE * height
+    lip = min((start - c - GAP) / m if m > 0 else 0.0, rise * 0.5)
+
+    def at(u, z):
+        return (s * u, z)
+
+    outer = c + GAP + m * rise
+    points = [at(start, 0), at(outer, 0), at(outer, rise)]
+    if lip > 0:
+        points.append(at(start, lip))
+    blade = extrude(Plane.XZ * Polygon(*points, align=None), FIN_THICK)
+    pad_u = (min(start, outer), max(start, outer) + PAD_MARGIN)
+    pad = Box(pad_u[1] - pad_u[0], FIN_THICK + 2 * PAD_MARGIN, PAD_THICK)
+    pad = Pos(s * (pad_u[0] + pad_u[1]) / 2, 0, PAD_THICK / 2) * pad
+
+    # Tines every so often up the blade, geometrically spaced so most sit low.
+    heights, z = [], lip + 2.0
+    while z < rise and len(heights) < 6:
+        heights.append(z)
+        z = lip + 2.0 + (z - lip) * 1.8
+    grown = []
+    for edge in (bb.min.Y, bb.max.Y - FIN_THICK):
+        y = edge - blade.bounding_box().min.Y
+        grown.append(Pos(0, y, 0) * blade)
+        grown.append(Pos(0, edge + FIN_THICK / 2 - pad.center().Y, 0) * pad)
+        for z in heights:
+            u0, u1t = c + m * z - BITE, c + GAP + m * z + BITE
+            tine = Box(u1t - u0, TINE_WIDE, TINE)
+            grown.append(Pos(s * (u0 + u1t) / 2, edge + FIN_THICK / 2, z + TINE / 2) * tine)
+    body = grown[0]
+    for piece in grown[1:]:
+        body = body + piece
+    return body

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -241,16 +241,24 @@ class Server:
 
     @staticmethod
     def _variants(path):
-        """The card's variants, as the viewer shows them: a name and its overrides.
+        """The card's variants, as the viewer shows them: a name, its overrides, and
+        the card's note saying why it exists.
 
         A variant is one part flexed, which is exactly what the sliders do, so the
-        viewer treats picking one as loading its params. A card that will not parse
-        means no variants, not a broken part: the build itself never read the card.
+        viewer treats picking one as loading its params. The note rides along because
+        the params are the how and never the why: `diagonal = true` explains nothing
+        to someone who has not read the doctrine, and the card sentence does. A card
+        that will not parse means no variants, not a broken part: the build itself
+        never read the card.
         """
         from . import checks
 
         try:
-            return [{"name": n, "params": p} for n, p, _ in checks.configurations(path)[1:]]
+            notes = checks.settings(path).get("variants", {})
+            return [
+                {"name": n, "params": p, "note": notes.get(n, {}).get("note")}
+                for n, p, _ in checks.configurations(path)[1:]
+            ]
         except Exception:
             return []
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.8.0"
+  version: "0.9.0"
 ---
 
 # nurb

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -56,6 +56,9 @@
   .item.var { padding: 4px 10px 4px 24px; font-size: 12px; }
   .item.var .name { color: var(--dim); }
   .item.var.active .name { color: var(--text); }
+  /* The sliders glyph says what a variant is: the same part at other values. */
+  .item.var .vic { width: 10px; height: 10px; flex: none; color: var(--dim); }
+  .item.var.active .vic { color: var(--accent); }
   .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); flex: none; }
   .dot.bad { background: var(--bad); }
   /* An assembly's status light is the cubes icon itself: same slot, same colors.
@@ -78,6 +81,7 @@
     text-shadow: 0 1px 2px rgba(0,0,0,.5);
   }
   #hud b { color: var(--text); font-weight: 600; }
+  #hud .note { display: inline-block; max-width: 340px; }
   #err {
     position: absolute; inset: auto 16px 14px 16px; max-height: 42%; overflow: auto;
     background: rgba(42,22,24,.94); border: 1px solid #5b2b2f; color: #ffb4b4;
@@ -288,6 +292,7 @@
   <symbol id="i-warn" viewBox="0 0 12 12"><path d="M6 11.25C8.899 11.25 11.25 8.899 11.25 6C11.25 3.101 8.899 0.75 6 0.75C3.101 0.75 0.75 3.101 0.75 6C0.75 8.899 3.101 11.25 6 11.25Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M6 9.5C6.483 9.5 6.875 9.108 6.875 8.625C6.875 8.142 6.483 7.75 6 7.75C5.517 7.75 5.125 8.142 5.125 8.625C5.125 9.108 5.517 9.5 6 9.5Z" fill="currentColor"/><path d="M6 3.5V6.25" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
   <symbol id="i-ok" viewBox="0 0 12 12"><circle cx="6" cy="6" r="5.25" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><polyline points="3.747 6.5 5.25 8 8.253 4" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
   <symbol id="i-cube" viewBox="0 0 18 18"><path d="m7.997,2.332l-4.25,2.465c-.617.358-.997,1.017-.997,1.73v4.946c0,.713.38,1.372.997,1.73l4.25,2.465c.621.36,1.386.36,2.007,0l4.25-2.465c.617-.358.997-1.017.997-1.73v-4.946c0-.713-.38-1.372-.997-1.73l-4.25-2.465c-.621-.36-1.386-.36-2.007,0Z" fill="currentColor" opacity=".3" stroke-width="0"/><path d="m7.997,2.332l-4.25,2.465c-.617.358-.997,1.017-.997,1.73v4.946c0,.713.38,1.372.997,1.73l4.25,2.465c.621.36,1.386.36,2.007,0l4.25-2.465c.617-.358.997-1.017.997-1.73v-4.946c0-.713-.38-1.372-.997-1.73l-4.25-2.465c-.621-.36-1.386-.36-2.007,0Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><polyline points="12.251 7.1035 9 9 5.75 7.1035" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><line x1="9.0005" y1="12.7817" x2="9" y2="9" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
+  <symbol id="i-variant" viewBox="0 0 12 12"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><line x1="11.25" y1="8.75" x2="6.25" y2="8.75"/><circle cx="4.25" cy="8.75" r="2"/><line x1="2.25" y1="8.75" x2=".75" y2="8.75"/><line x1=".75" y1="3.25" x2="5.75" y2="3.25"/><circle cx="7.75" cy="3.25" r="2"/><line x1="9.75" y1="3.25" x2="11.25" y2="3.25"/></g></symbol>
   <symbol id="i-cubes" viewBox="0 0 18 18"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><path d="M4.648,8.086l-2.55,1.479c-.37,.215-.598,.61-.598,1.038v2.968c0,.428,.228,.823,.598,1.038l2.55,1.479c.372,.216,.832,.216,1.204,0l2.55-1.479c.37-.215,.598-.61,.598-1.038v-2.968c0-.428-.228-.823-.598-1.038l-2.55-1.479c-.372-.216-.832-.216-1.204,0Z"/><polyline points="8.84 10.005 5.25 12.087 1.66 10.005"/><line x1="5.25" y1="16.25" x2="5.25" y2="12.087"/><path d="M12.148,8.086l-2.55,1.479c-.37,.215-.598,.61-.598,1.038v2.968c0,.428,.228,.823,.598,1.038l2.55,1.479c.372,.216,.832,.216,1.204,0l2.55-1.479c.37-.215,.598-.61,.598-1.038v-2.968c0-.428-.228-.823-.598-1.038l-2.55-1.479c-.372-.216-.832-.216-1.204,0Z"/><polyline points="16.34 10.005 12.75 12.087 9.16 10.005"/><line x1="12.75" y1="16.25" x2="12.75" y2="12.087"/><path d="M8.398,1.586l-2.55,1.479c-.37,.215-.598,.61-.598,1.038v2.968c0,.428,.228,.823,.598,1.038l2.55,1.479c.372,.216,.832,.216,1.204,0l2.55-1.479c.37-.215,.598-.61,.598-1.038v-2.968c0-.428-.228-.823-.598-1.038l-2.55-1.479c-.372-.216-.832-.216-1.204,0Z"/><polyline points="12.59 3.505 9 5.587 5.41 3.505"/><line x1="9" y1="9.75" x2="9" y2="5.587"/></g></symbol>
   <symbol id="i-reset" viewBox="0 0 18 18"><path d="M5.25 9.5L3 7.25L0.75 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13.495 13.345C12.3587 14.5226 10.7641 15.25 9 15.25C5.548 15.25 2.75 12.45 2.75 9C2.75 8.4 2.834 7.83003 2.99 7.28003" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M12.75 8.5L15 10.75L17.25 8.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M4.50629 4.65564C5.64249 3.48544 7.23658 2.75 8.99998 2.75C12.452 2.75 15.25 5.55 15.25 9C15.25 9.58 15.171 10.14 15.024 10.67" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
 </svg>
@@ -886,9 +891,14 @@ function checks(name) {
 }
 
 function hud(e) {
+  // With a variant on screen the HUD carries its card note, because the sidebar can
+  // say which variant but never why it exists, and the why is the point of it.
+  const v = e.error ? null : activeVariant(e);
   document.getElementById('hud').innerHTML = e.error
     ? `<b>${e.name}</b><br>build failed`
-    : `<b>${e.name}</b><br>${e.bbox.join(' &times; ')} mm<br>${e.ms} ms`;
+    : `<b>${v ? v.name : e.name}</b>`
+      + (v && v.note ? `<br><span class="note">${v.note}</span>` : '')
+      + `<br>${e.bbox.join(' &times; ')} mm<br>${e.ms} ms`;
   // An assembly is placed parts, not one printable solid, so its buttons download
   // one zip with a file per placed part. Only an assembly that places nothing goes
   // dark: geometry built inline has no part file, and a part file is what a print is.
@@ -1231,13 +1241,22 @@ function render() {
         : `<span class="dot ${e.error ? 'bad' : ''}"></span>`)
       + `<span class="name">${e.name}</span>`
       + `<span class="ms">${e.error ? 'err' : e.ms + 'ms'}</span>`;
-    row.onclick = () => { current = e.name; render(); show(e.name, { keepCamera: false }); setURL(); };
+    row.onclick = () => {
+      current = e.name;
+      // The part row is the defaults configuration. With a variant active it is also
+      // the only way back: a variant that flips a bool has no slider to drag home.
+      if (activeVariant(e)) applyVariant(e.name, { params: {} });
+      render(); show(e.name, { keepCamera: false }); setURL();
+    };
     list.appendChild(row);
     for (const v of e.variants || []) {
       const vr = document.createElement('div');
       vr.className = 'item var' + (e.name === current && variantActive(e, v) ? ' active' : '');
-      vr.innerHTML = `<span class="name">${v.name}</span>`;
-      vr.title = Object.entries(v.params).map(([k, val]) => `${k} = ${val}`).join('\n');
+      vr.innerHTML = `<svg class="vic"><title>variant</title><use href="#i-variant"/></svg>`
+        + `<span class="name">${v.name}</span>`;
+      // The note is the why, the params are the how; a hover gets both, why first.
+      const how = Object.entries(v.params).map(([k, val]) => `${k} = ${val}`).join('\n');
+      vr.title = v.note ? `${v.note}\n\n${how}` : how;
       vr.onclick = () => {
         if (current !== e.name) { current = e.name; show(e.name, { keepCamera: false }); }
         applyVariant(e.name, v);

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,6 +28,7 @@ def test_the_documented_vocabulary_is_the_exported_one():
         "is_convex",
         "concave_edges",
         "measured",
+        "stand",
         "assembly",
         "use",
         "hinge",

--- a/tests/test_orient.py
+++ b/tests/test_orient.py
@@ -1,0 +1,89 @@
+"""stand() turns orientation into geometry, so every rule judges it unchanged.
+
+The facet width is asserted against hand geometry: a square corner tilted 45 degrees
+and sunk `facet * sin(90) / 2` deep cuts a flat exactly `facet` wide.
+"""
+
+from build123d import Align, Axis, Box, Pos
+import pytest
+
+from nurb import stand
+from nurb.checks import run
+
+
+CORNER = (Align.MIN, Align.MIN, Align.MIN)
+
+
+def bracket():
+    """An L: vertical back, horizontal arm at the top. Flat, the arm's underside is a
+    90 degree cantilever; stood on the outside of its elbow at 135 about Y, legs up,
+    every face is at or under the limit and every region is grounded."""
+    back = Box(4, 30, 40, align=CORNER)
+    arm = Pos(4, 0, 36) * Box(26, 30, 4, align=CORNER)
+    return back + arm
+
+
+def bed_faces(shape):
+    return [f for f in shape.faces() if abs(f.bounding_box().max.Z) < 1e-6]
+
+
+def test_the_facet_is_exactly_as_wide_as_asked_on_a_square_corner():
+    stood = stand(Box(10, 10, 40, align=CORNER), tilt=45, facet=2.0)
+    flats = bed_faces(stood)
+    assert len(flats) == 1
+    assert flats[0].bounding_box().size.X == pytest.approx(2.0, abs=1e-6)
+    assert flats[0].bounding_box().size.Y == pytest.approx(10.0, abs=1e-6)
+
+
+def test_the_result_is_seated_on_the_bed_as_one_solid():
+    stood = stand(bracket(), tilt=45, facet=2.0)
+    assert len(stood.solids()) == 1
+    assert stood.bounding_box().min.Z == pytest.approx(0.0, abs=1e-6)
+
+
+def test_the_tilt_sign_picks_which_corner_goes_down():
+    plus = stand(bracket(), tilt=45, facet=2.0)
+    minus = stand(bracket(), tilt=-45, facet=2.0)
+    # One stands on the back-bottom corner and leans forward, the other the reverse,
+    # so their silhouettes swap which way is long.
+    assert plus.bounding_box().size.X > plus.bounding_box().size.Z
+    assert minus.bounding_box().size.Z > minus.bounding_box().size.X
+
+
+def test_a_bracket_that_fails_flat_checks_clean_stood_on_its_elbow():
+    """The whole point: the overhang finding is the prompt, stand() is the remedy."""
+    flat = [f for f in run(bracket(), only={"overhang"})]
+    assert flat and flat[0].value == pytest.approx(90.0)
+    # The sign matters and is not guessable from "135": +135 stands this model on the
+    # end of its arm, a taller chevron. The V, elbow down, is the negative roll.
+    stood = stand(bracket(), tilt=-135, facet=2.0)
+    assert run(stood, only={"overhang", "bed_bevel", "stability", "floating"}) == []
+
+
+def test_standing_on_a_leg_end_leaves_the_other_tip_in_air():
+    """The wrong corner: tent pose, elbow up. The tips' faces are all at 45 so the
+    overhang rule is silent, and the floating rule is what catches it. Photographed
+    before it was a rule: the part built, checked clean and could not print."""
+    stood = stand(bracket(), tilt=45, facet=2.0)
+    found = [f for f in run(stood, only={"floating"})]
+    assert found and all(f.severity == "fail" for f in found)
+
+
+def test_fins_grow_only_when_the_stance_earns_them():
+    """Short on its facet, a part stands alone; past the leverage rule it sprouts a
+    fin pad at each side, so its bed contact goes from one strip to three."""
+    def strips(shape):
+        return [f for f in shape.faces() if abs(f.bounding_box().max.Z) < 1e-6 and f.area >= 4]
+
+    assert len(strips(stand(Box(4, 30, 40, align=CORNER), tilt=45))) == 1
+    assert len(strips(stand(Box(4, 30, 80, align=CORNER), tilt=45))) == 3
+
+
+def test_degenerate_tilts_are_refused():
+    for tilt in (0, 90, 180):
+        with pytest.raises(ValueError):
+            stand(Box(10, 10, 10), tilt=tilt)
+    with pytest.raises(ValueError):
+        stand(Box(10, 10, 10), facet=0)
+    with pytest.raises(ValueError, match="horizontal rotation axis"):
+        stand(Box(10, 10, 10), axis=Axis.Z)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -6,7 +6,7 @@ finding is obvious from the geometry: a known angle, a known count, a known tip.
 
 from math import tan, radians
 
-from build123d import Box, Cylinder, Plane, Pos, Rot, extrude, Polygon
+from build123d import Align, Box, Cylinder, Plane, Pos, Rot, extrude, Polygon
 import pytest
 
 from nurb.checks import FAIL, WARN, Context, run
@@ -87,6 +87,60 @@ def test_top_heavy_lean_tips():
     assert found[0].severity == WARN
 
 
+def test_a_narrow_flat_foot_still_uses_its_center_of_mass():
+    """A slim rectangular foot is ordinary bed contact, not a diagonal facet."""
+    corner = (Align.MIN, Align.CENTER, Align.MIN)
+    shape = Box(4, 30, 20, align=corner) + Pos(2, 0, 16) * Box(
+        20, 30, 4, align=corner
+    )
+    assert len(shape.solids()) == 1
+    found = only(shape, "stability")
+    assert len(found) == 1
+    assert found[0].severity == WARN
+
+
+def test_standing_on_a_facet_holds_by_adhesion_not_balance():
+    """A part stood at 45 always has its centre of mass outside the facet, so the
+    centre-of-mass test would warn on every diagonal print, including the bracket
+    this was calibrated against, which printed clean."""
+    from nurb import stand
+
+    assert only(stand(Box(4, 30, 30), tilt=45, facet=2.0), "stability") == []
+
+
+def test_standing_too_tall_on_a_facet_is_the_fin_signal():
+    """With fins declined, the rule is the referee for hand-tilted geometry."""
+    from nurb import stand
+
+    found = only(stand(Box(4, 30, 80), tilt=45, facet=2.0, fins=False), "stability")
+    assert len(found) == 1
+    assert found[0].severity == WARN
+    assert "fin" in found[0].message
+
+
+def test_grown_fins_satisfy_every_rule_but_their_declared_slivers():
+    """The generated fin is one solid with the part, grounded, bridged at its tines,
+    thick enough for min_wall, and standing on pad strips that widen the stance past
+    the leverage rule. The tines' tiny faces are the one honest cost, and those are
+    declared on a card like any other earned sliver."""
+    from nurb import stand
+
+    finned = stand(Box(4, 30, 80), tilt=45, facet=2.0)
+    assert len(finned.solids()) == 1
+    assert only(finned, "stability") == []
+    assert only(finned, "floating") == []
+    assert only(finned, "overhang") == []
+    assert only(finned, "min_wall") == []
+
+
+def test_grown_fins_clear_the_stability_rule_on_a_tall_part():
+    """The fin pads widen the whole footprint; their own short edge is not the stance."""
+    from nurb import stand
+
+    finned = stand(Box(4, 30, 160), tilt=45, facet=2.0)
+    assert only(finned, "stability") == []
+
+
 # --- sliver ------------------------------------------------------------------
 
 
@@ -112,6 +166,16 @@ def test_build_volume_uses_the_best_orientation():
     assert only(tall, "build_volume", Context(bed=(256, 256, 300))) == [], "stands up"
     assert only(tall, "build_volume", Context(bed=(256, 256, 256))) != [], "260 > 256"
     assert only(tall, "build_volume", Context(bed=(100, 100, 100)))[0].severity == FAIL
+
+
+def test_build_volume_keeps_a_stood_parts_facet_on_the_bed():
+    """Once stand() cuts the bed facet, the check may rotate only around build-up."""
+    from nurb import stand
+
+    stood = stand(Box(4, 30, 160), tilt=45, facet=2.0, fins=False)
+    found = only(stood, "build_volume", Context(bed=(256, 256, 100)))
+    assert len(found) == 1
+    assert found[0].severity == FAIL
 
 
 # --- bridges vs cantilevers --------------------------------------------------
@@ -157,6 +221,15 @@ def test_bed_bevel_catches_a_chamfer_on_the_first_layer():
     assert len(only(bottom, "bed_bevel")) == 4
 
 
+def test_bed_bevel_catches_a_chamfer_beneath_a_narrow_wall():
+    """A long, narrow bottom face is not enough to call a normally seated wall stood."""
+    from build123d import Axis, chamfer
+
+    wall = Box(4, 30, 20)
+    bottom = chamfer(wall.edges().group_by(Axis.Z)[0], 1)
+    assert len(only(bottom, "bed_bevel")) == 4
+
+
 def test_bed_bevel_catches_a_circular_chamfer_on_the_first_layer():
     """The band is 1mm deep even though its plan-view bounding box is 20mm wide."""
     from build123d import chamfer
@@ -193,6 +266,41 @@ def test_bed_bevel_leaves_a_corbel_landing_on_the_plate_alone():
     # The same face against a part whose polish is 4mm, where 10mm of rise is back
     # inside chamfer territory. The rule is about scale, so it has to move with it.
     assert len(only(post, "bed_bevel", Context(cosmetic_chamfer=4.0))) == 1
+
+
+def test_floating_ignores_a_vertex_resting_on_material_below():
+    """The calipers-holder case, distilled: a corbel corner with every edge rising
+    away from it, sitting directly on the body underneath. The edge test alone called
+    it floating; the probe below is what clears it."""
+    shape = Box(20, 20, 10) + Pos(0, 0, 10) * Box(12, 12, 10)
+    assert only(shape, "floating") == []
+
+
+def test_floating_catches_a_tip_hanging_in_air():
+    """A leg tip whose faces all sit at 45 degrees: silent to the overhang rule,
+    unprintable anyway, because its first layer has nothing to sit on."""
+    from nurb import stand
+
+    bracket = Pos(2, 15, 20) * Box(4, 30, 40) + Pos(17, 15, 38) * Box(26, 30, 4)
+    found = only(stand(bracket, tilt=45, facet=2.0), "floating")
+    assert found and all(f.severity == FAIL for f in found)
+
+
+def test_floating_ignores_the_stairstep_corner_of_a_stood_slab():
+    """The second-lowest corner of a tilted slab has air straight below it and prints
+    fine: its silhouette descends to the facet, one layer resting on the next."""
+    from nurb import stand
+
+    assert only(stand(Box(4, 30, 40), tilt=45, facet=2.0), "floating") == []
+
+
+def test_bed_bevel_leaves_a_standing_part_alone():
+    """A 4mm wall stood at 45 rises 2.83mm off the plate, square in the chamfer band,
+    and rise cannot tell it from a bevel. The stance can: the part has no bottom face
+    whose rim a bevel could dress, only the facet it stands on."""
+    from nurb import stand
+
+    assert only(stand(Box(4, 30, 40), tilt=45, facet=2.0), "bed_bevel") == []
 
 
 def test_concave_cosmetic_catches_polish_in_an_inside_corner():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -32,6 +32,9 @@ CARD = """# thing
 [part]
 min_wall = 10.0
 
+[variants.slim]
+note = "Half width for the narrow rail."
+
 [variants.slim.params]
 width = 15.0
 
@@ -64,7 +67,9 @@ def test_rebuild_carries_the_cards_variants(tmp_path):
     part = tmp_path / "parts" / "thing.py"
     (tmp_path / "parts" / "thing.md").write_text(CARD)
     entry = server.rebuild(part)
-    assert entry["variants"] == [{"name": "slim", "params": {"width": 15.0}}]
+    assert entry["variants"] == [
+        {"name": "slim", "params": {"width": 15.0}, "note": "Half width for the narrow rail."}
+    ]
     assert server._wire(entry)["variants"] == entry["variants"]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
A part that should print tilted now gets tilted as geometry, not metadata. `stand(part, tilt, axis, facet)` rotates the part, seats it, and shaves a flat across the down corner, so every existing check, the viewer, and export judge the print orientation unchanged. The diagonal print is a card variant, offered rather than imposed, with a plain-language `note` the viewer now shows for whoever is about to print the thing.

## Checks

- **New `floating` rule**: fails any region whose first layer sits on air. The overhang rule cannot see this case, because every face of a floating tip can sit at exactly 45 degrees; what gives it away is a low point above the bed that material only rises away from. Calibrated against the notch catalog, which immediately taught it two support cases: a corbel corner resting on the body below, and a tine bridging two bodies at its own layer.
- **`bed_bevel` and `stability` learned what a stance is.** A stood part has no bottom face whose rim a bevel could dress, and its centre of mass is always outside a 2mm facet; both rules previously fired on parts that print (photographed). Stability in a stance now judges leverage instead: past 20x the facet width in height, adhesion is holding a lever, and the finding names the fix.
- **`build_volume`** knows a stance fixes the build direction, so a stood part is judged in its orientation rather than "in any orientation".

## Fins

When the stance is past the leverage rule, `stand()` grows break-away support fins to the print-farm recipe: a blade at each side hugging the measured lean across a small gap, each on a 1mm pad for its own adhesion, joined only by single-layer tines that rub off with a fingernail. The rule and the remedy share one constant, so they cannot drift. The stability warning remains the referee for hand-tilted geometry and `fins=False`. Exported fins are part of one watertight solid.

## Viewer

- Variants get a sliders glyph (what a variant is: the same part at other values), dim when inactive, accent when on screen.
- The active variant's card `note` shows in the HUD, and hover on the row gives the why before the params.
- Clicking the part row while a variant is active returns to the defaults. Previously that was a one-way door for a variant flipping a bool, which has no slider to drag back.

## Doctrine

New "Print orientation" section: the two remedies for an overhang finding, the strength argument with its honest caveat, which corner to stand on and why the checks referee the choice, the offer-never-impose variant pattern, and the fin recipe. Ships in the package via `nurb rules`; the skill files needed no change, which is the thin-shim architecture working as intended.

CLAUDE.md's stale "Current state" section is gone; its two load-bearing notes moved to where they belong (the fillet non-wrapping decision to `__init__.py`, beside chamfer's).

294 tests pass. Version bumped to 0.9.0 in pyproject and both skill mirrors.