### PR TITLE
Print-scale STL meshing, diagonal bed fit, and viewer orientation aids

### DIFF
--- a/docs/rim-helper-research.md
+++ b/docs/rim-helper-research.md
@@ -1,0 +1,50 @@
+# Research: a crown() helper for variable-height rims
+
+Status: research only, nothing implemented. Written 2026-08-02 while triaging issue #55, so a future session can pick this up cold. The branch `issue-55` shipped the small fixes from that issue; this is the one big item deliberately left out.
+
+## The problem
+
+Issue #55 (https://github.com/Shpigford/nurb/issues/55), section 1. A user building a 145 x 364 x 102mm aircraft-floor tray wanted one conceptually simple thing: "round the top of this variable-height wall." A closed perimeter wall whose roofline rises and falls, capped with one consistently smooth rounded rim.
+
+Direct filleting and polish failed for them with, in their words: visible bumps where wall sections joined, missing roundovers on short corner segments, segmented or faceted transitions, spherical-looking patches at corners, thin-wall and overhang defects from a swept coping-bead experiment, and topology changes that made edge selection unreliable after booleans.
+
+Their eventual working recipe, which is the existence proof that this can be done on OCCT, took eight manual steps: (1) build one full-height perimeter ring, (2) cut the variable-height roofline from it, (3) create a separate 3D centreline, (4) sample curved edges manually, (5) convert sections into splines, (6) trim every path edge, (7) add tangent spline blends at every junction, (8) sweep a circular profile around the resulting closed wire. That occupied a substantial part of a 689-line part file. The ask is a robust high-level operation with tangent corner handling and selection that stays stable after booleans.
+
+## Current state of nurb (verified against 0.9.0 source)
+
+- There is no rim, crown, coping, pipe, or sweep helper anywhere in `src/`. `polish()` (`src/nurb/polish.py:98`) is the only edge-treatment helper and it is chamfer-only; it calls build123d's `chamfer` and vetoes any chamfer that would create a face smaller than `0.8 * size**2` slivers.
+- `fillet` is deliberately not wrapped; the reason is stated at `src/nurb/__init__.py:40-42`. The doctrine actively prefers chamfers: `src/nurb/doctrine.md:126-127`, "a consistent faceted look that prints reliably beats a fillet default."
+- The closest existing idiom is hand-rolled in `examples/notch/parts/bin_small_parts.py:135-184`: a bin rim with a front drop and two ramps, treated with face-normal predicates and a deliberate two-pass chamfer because one junction is the four-faces/three-edges vertex OCCT cannot cap. Roughly 50 careful lines for one rim on one part, i.e. the same shape of struggle as the issue, in our own examples.
+- The other relevant trick on file: `examples/notch/parts/holder_filament_spool.py:104` builds a smooth transition as `fillet(tops[0], r) & fillet(tops[-1], r)`, an intersection of two single-fillet variants, with a warning in its card (`holder_filament_spool.md:113-116`) about why `mirror` is not the way to get the second half.
+- Selection stability after booleans is a solved pattern here: `new_edges(before, combined=after)` (doctrine `src/nurb/doctrine.md:209-214`, repo rule in `CLAUDE.md`). Any crown() implementation should lean on it rather than on geometric selectors.
+
+## Known kernel constraints (hard-won, do not rediscover)
+
+- Two chamfered/filleted edges need more than `2 * size` of face between them or OCCT fails with `BRep_API: command not done`. The trap: each edge works alone, only the batch fails. Bisect the set (`CLAUDE.md`, and `src/nurb/polish.py:26-65` turns these kernel messages into doctrine-grade errors worth imitating).
+- Chamfer/fillet order changes topology, so anything resolved against pristine geometry drifts after the first operation lands.
+- OCCT's corner patches are exactly where the reporter saw "spherical-looking patches": ChFi3d corner capping at junctions of unequal-height edges is the fragile spot.
+
+## Candidate approaches, in the order I would try them
+
+**A. Baseline: plain fillet on the top-rim edge loop.** Select the roofline edges (everything on the top after the roofline cut, via `new_edges`), one `fillet` call. Known to fail on hard cases (that is the issue), but it must be the spike's control: measure exactly where and how it fails on the test parts, because if it works for 80% of real rims, crown() may only need to be the fallback.
+
+**B. Bead sweep along the wall centreline (the reporter's recipe, automated).** The insight that makes this tractable: for a wall of constant thickness `t`, a fully-round rim is exactly the union of the wall with a pipe of radius `t/2` swept along the wall's top centreline. If the path is G1-continuous, the pipe is inherently smooth and tangent everywhere, no corner patches involved. The entire difficulty collapses into constructing one smooth closed 3D path, which is what the reporter hand-built in steps 3-7. Automation sketch: take the top face(s) of the wall after the roofline cut, extract inner and outer top edge loops, pair points to compute the midline (or offset the outer loop inward by `t/2` in the wall's local frame), fit a periodic BSpline through sampled midline points, and `sweep` a circle of radius `t/2`. Fitting one periodic spline through samples sidesteps the trim-every-edge-and-blend-every-junction work entirely; the cost is that the bead follows the roofline approximately (within sampling tolerance) rather than exactly, which for a printed part is fine and worth saying out loud in the docstring.
+Failure modes to probe: tight inner corners with plan radius < `t/2` (self-intersecting sweep), walls of varying thickness (no single centreline), rooflines with sharp steps (a G1 spline will round the step, which may actually be the wanted behavior), and the seam where the periodic spline closes.
+
+**C. Ring-then-cut ordering.** Round the rim while the roofline is still flat (a constant-height rim is the easy case for either fillet or a torus-section sweep), then cut the variable roofline afterwards. Almost certainly wrong as stated, because the cut re-exposes sharp edges along the new roofline; noted because the reporter tried the reverse ordering and because a variant might work: cut the roofline into the *solid* wall first, then apply B.
+
+**D. OCP variable-radius fillet laws.** OCCT's `BRepFilletAPI_MakeFillet` supports radius evolution laws along an edge, which build123d does not expose. Dropping to OCP could handle rims where the wall thins toward the top. High effort, deep OCCT dependency, and the corner-capping fragility is the same machinery that already fails; I would only look here if B dies.
+
+## Spike plan
+
+Test parts, in ascending difficulty: (1) the `bin_small_parts` rim (front drop + two ramps, the known two-pass case), (2) a rectangular tray with one long sine-wave roofline, (3) an issue-#55-shaped tapered tray with mixed straight/curved plan and a multi-level roofline, (4) a torture case with a plan-radius corner tighter than `t/2`.
+
+Acceptance: one visually smooth bead with no tangency kinks at junctions; builds across a parameter sweep (the `_flex` idea in `src/nurb/cli.py`, grow counts and lengths and see what breaks); `nurb check` clean beyond declared slivers; rebuild-stable when upstream features move (the selection must be derived, not coordinate-frozen); and a doctrine-grade error, in the part's own vocabulary, when the geometry makes the bead impossible (thin wall, tight corner) rather than a raw `BRep_API` message.
+
+API sketch, holding to the vocabulary rules: `crown(wall, radius=None)` where radius defaults to half the measured wall thickness, returning the welded solid. It should refuse loudly when the wall is not a single closed loop of near-constant thickness, because that constraint is what makes approach B sound. Whether it lives in `polish.py` or its own `crown.py` is a judgement for whoever implements it; either way it joins `__all__` and therefore `nurb api` automatically.
+
+Doctrine consequences to settle if the spike succeeds: this would be the first sanctioned round-edge treatment, so the doctrine's chamfer-first stance needs a carve-out ("rims a hand wraps around are the fillet exception" or similar), and draft mode should skip the crown the same way it skips polish. The bead ends and seam will earn slivers that need the usual card accounting.
+
+## If the spike fails
+
+The honest fallback, already true today: chamfer the rim via `polish()` and say so in the issue. A crown() that works on demos and dies on real parts is worse than no crown(), because it fails at exactly the moment the doctrine promised reliability.

--- a/src/nurb/builder.py
+++ b/src/nurb/builder.py
@@ -222,6 +222,27 @@ def to_glb(shape, tolerance=0.1):
     return out.export(file_type="glb")
 
 
+def write_stl(shape, target):
+    """Write an STL meshed for printing rather than for archival.
+
+    build123d's export_stl defaults to 1e-3mm linear deflection, an order finer than
+    a nozzle reproduces: issue #55's 145x364mm tray meshed to 97k triangles and
+    4.7MB, and the slicer turned the micro-segments into constant braking along the
+    walls. A 0.01mm chord error is invisible at FDM scale and cuts the mesh to a
+    fraction.
+    """
+    from build123d import export_stl
+
+    export_stl(shape, str(target), tolerance=0.01, angular_tolerance=0.2)
+
+
+def stl_triangles(target):
+    """Triangle count of a binary STL, from the header."""
+    with open(target, "rb") as f:
+        f.seek(80)
+        return int.from_bytes(f.read(4), "little")
+
+
 def stats(shape):
     bb = shape.bounding_box()
     return {

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -9,7 +9,7 @@ see each other, and `run` gathers them.
 
 import pathlib
 from dataclasses import dataclass, field, replace
-from math import asin, degrees
+from math import asin, atan2, cos, degrees, pi, sin
 
 from build123d import Axis, CenterOf, GeomType, Vector
 
@@ -179,19 +179,25 @@ def build_volume(shape, ctx):
     if _standing(shape, up) is None:
         got = sorted([size.X, size.Y, size.Z], reverse=True)
         fits = all(g <= b for g, b in zip(got, sorted(ctx.bed, reverse=True)))
+        if not fits:
+            # The box is the wrong question for a part that fits turned on the
+            # plate: issue #55's 364mm tray sits on a 350mm bed at 36 degrees.
+            fits = _fits_rotated(shape, ctx.bed)
         orientation = "in any orientation"
     else:
         # A stance facet fixes the build direction. The part may turn on the plate,
         # but rolling it onto another axis would put the facet in the air again.
         bed, top = _span(shape, up)
+        height = top - bed
         footprint = sorted(
             _span(shape, axis)[1] - _span(shape, axis)[0]
             for axis in _bed_axes(up)
         )
         plate = sorted(ctx.bed[:2])
-        got = [top - bed, *footprint]
-        fits = top - bed <= ctx.bed[2] and all(
-            got <= available for got, available in zip(footprint, plate)
+        got = [height, *footprint]
+        fits = height <= ctx.bed[2] and (
+            all(got <= available for got, available in zip(footprint, plate))
+            or _fits_rotated(shape, ctx.bed, up)
         )
         orientation = "in its fixed build orientation"
     if fits:
@@ -259,6 +265,120 @@ def _bed_axes(up):
     guide = Vector(1, 0, 0) if abs(up.X) < 0.9 else Vector(0, 1, 0)
     first = up.cross(guide).normalized()
     return first, up.cross(first).normalized()
+
+
+def _hull(points):
+    """Convex hull of 2d points, by monotone chain."""
+    pts = sorted({(round(float(x), 2), round(float(y), 2)) for x, y in points})
+    if len(pts) <= 2:
+        return pts
+
+    def turn(o, a, b):
+        return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+
+    out = []
+    for chain in (pts, reversed(pts)):
+        base = len(out)
+        for p in chain:
+            while len(out) - base >= 2 and turn(out[-2], out[-1], p) <= 0:
+                out.pop()
+            out.append(p)
+        out.pop()
+    return out
+
+
+def _rotated_spans(points, angle):
+    c, s = cos(angle), sin(angle)
+    xs = [x * c - y * s for x, y in points]
+    ys = [x * s + y * c for x, y in points]
+    return max(xs) - min(xs), max(ys) - min(ys)
+
+
+def _footprint_fits(points, plate):
+    """Whether a 2d footprint fits a rectangular plate at some rotation.
+
+    Between orientations parallel to hull edges, the vertices supporting each side
+    of the bounding box stay fixed. The worst normalized span can reach its minimum
+    only at one of those boundaries or where the two normalized spans cross, so those
+    finite candidates give the exact answer without an angle grid.
+    """
+    hull = _hull(points)
+    if not hull:
+        return False
+
+    quarter = pi / 2
+    cuts = {0.0, quarter}
+    if len(hull) > 1:
+        for p, q in zip(hull, hull[1:] + hull[:1]):
+            edge = atan2(q[1] - p[1], q[0] - p[0])
+            cuts.add((-edge) % quarter)
+    cuts = sorted(cuts)
+    candidates = list(cuts)
+    orientations = (plate, plate[::-1])
+
+    for low, high in zip(cuts, cuts[1:]):
+        if high - low <= 1e-12:
+            continue
+        mid = (low + high) / 2
+        c, s = cos(mid), sin(mid)
+
+        def x_at(p):
+            return p[0] * c - p[1] * s
+
+        def y_at(p):
+            return p[0] * s + p[1] * c
+
+        x_high, x_low = max(hull, key=x_at), min(hull, key=x_at)
+        y_high, y_low = max(hull, key=y_at), min(hull, key=y_at)
+        dx, dy = x_high[0] - x_low[0], x_high[1] - x_low[1]
+        ex, ey = y_high[0] - y_low[0], y_high[1] - y_low[1]
+
+        for across, deep in orientations:
+            cos_term = deep * dx - across * ey
+            sin_term = -deep * dy - across * ex
+            if abs(cos_term) + abs(sin_term) <= 1e-12:
+                continue
+            crossing = atan2(-cos_term, sin_term) % pi
+            if low < crossing < high:
+                candidates.append(crossing)
+
+    for angle in candidates:
+        width, depth = _rotated_spans(hull, angle)
+        if any(
+            width <= across + 1e-6 and depth <= deep + 1e-6
+            for across, deep in orientations
+        ):
+            return True
+    return False
+
+
+def _fits_rotated(shape, bed, up=None):
+    """Whether the part fits the plate turned about some build axis.
+
+    The slow path, reached only after the bounding box has already failed. The
+    footprint is the hull of a tessellation rather than of the B-rep's own
+    vertices, because a curved outline has vertices only at its seams.
+    """
+    from . import builder
+
+    verts = builder.to_mesh(shape, 0.1).vertices
+    if up is not None:
+        first, second = _bed_axes(up)
+
+        def projected(point):
+            point = Vector(*point)
+            return point.dot(first), point.dot(second)
+
+        footprint = [projected(point) for point in verts]
+        return _footprint_fits(footprint, bed[:2])
+
+    for axis in range(3):
+        if verts[:, axis].max() - verts[:, axis].min() > bed[2] + 1e-6:
+            continue
+        flat = [c for c in range(3) if c != axis]
+        if _footprint_fits(verts[:, flat], bed[:2]):
+            return True
+    return False
 
 
 def _reach(face, up):

--- a/src/nurb/cli.py
+++ b/src/nurb/cli.py
@@ -235,8 +235,13 @@ def _project_formats(root):
     return block.get("export", {}).get("formats")
 
 
+def _artifact_size(path):
+    n = path.stat().st_size
+    return f"{n / 1e6:.1f}MB" if n >= 1e6 else f"{n / 1e3:.0f}kB"
+
+
 def cmd_export(args):
-    from build123d import export_step, export_stl
+    from build123d import export_step
 
     from . import builder
 
@@ -267,7 +272,7 @@ def cmd_export(args):
         for fmt in formats:
             target = out / f"{name}.{fmt}"
             if fmt == "stl":
-                export_stl(shape, str(target))
+                builder.write_stl(shape, target)
             elif fmt == "step":
                 export_step(shape, str(target))
             elif fmt == "glb":
@@ -276,7 +281,10 @@ def cmd_export(args):
                 # The print used to sit outside this chain, so a typo in `--formats`
                 # reported a filename that was never written and exited 0.
                 sys.exit(f"  no exporter for {fmt!r}. have: {', '.join(FORMATS)}")
-            print(f"  {target.relative_to(root)}")
+            note = _artifact_size(target)
+            if fmt == "stl":
+                note += f", {builder.stl_triangles(target):,} triangles"
+            print(f"  {target.relative_to(root)}  {note}")
 
 
 # What OCCT says when a chamfer will not land. A part refusing to grow in its own words
@@ -596,7 +604,13 @@ def _pick_port(asked):
     for port in range(DEFAULT_PORT, DEFAULT_PORT + 40):
         if _is_free(port):
             return port
-    sys.exit(f"  nothing free between {DEFAULT_PORT} and {DEFAULT_PORT + 40}")
+    # Forty viewers is unusual but not a reason to refuse to start (issue #55 hit
+    # this wall): fall back to whatever the OS hands out, as headless renders do.
+    import socket
+
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
 
 
 def cmd_dev(args):

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -396,7 +396,7 @@ class Server:
         import tempfile
         import zipfile
 
-        from build123d import export_step, export_stl
+        from build123d import export_step
 
         def solid(path, stem):
             """(bytes, None) for a part, (None, scene) for an assembly."""
@@ -406,7 +406,10 @@ class Server:
                 return None, scene
             with tempfile.TemporaryDirectory() as scratch:
                 target = pathlib.Path(scratch) / f"{stem}.{fmt}"
-                (export_stl if fmt == "stl" else export_step)(built, str(target))
+                if fmt == "stl":
+                    builder.write_stl(built, target)
+                else:
+                    export_step(built, str(target))
                 return target.read_bytes(), None
 
         path = next((p for p in builder.find_parts(self.root) if p.stem == name), None)

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -147,6 +147,7 @@
   body.nogl #nogl { display: grid; }
   body.nogl #empty { display: none !important; }
   body.nogl #sectionbtn, body.nogl .sep:has(+ #sectionbtn), body.nogl #reframe { display: none; }
+  body.nogl #pinsbtn, body.nogl .sep:has(+ #pinsbtn) { display: none; }
   #checks {
     position: absolute; top: 14px; left: 16px; max-width: 46%; max-height: 60%;
     overflow: auto; display: none; font-size: 11px; line-height: 1.6;
@@ -294,6 +295,7 @@
   <symbol id="i-cube" viewBox="0 0 18 18"><path d="m7.997,2.332l-4.25,2.465c-.617.358-.997,1.017-.997,1.73v4.946c0,.713.38,1.372.997,1.73l4.25,2.465c.621.36,1.386.36,2.007,0l4.25-2.465c.617-.358.997-1.017.997-1.73v-4.946c0-.713-.38-1.372-.997-1.73l-4.25-2.465c-.621-.36-1.386-.36-2.007,0Z" fill="currentColor" opacity=".3" stroke-width="0"/><path d="m7.997,2.332l-4.25,2.465c-.617.358-.997,1.017-.997,1.73v4.946c0,.713.38,1.372.997,1.73l4.25,2.465c.621.36,1.386.36,2.007,0l4.25-2.465c.617-.358.997-1.017.997-1.73v-4.946c0-.713-.38-1.372-.997-1.73l-4.25-2.465c-.621-.36-1.386-.36-2.007,0Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><polyline points="12.251 7.1035 9 9 5.75 7.1035" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><line x1="9.0005" y1="12.7817" x2="9" y2="9" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
   <symbol id="i-variant" viewBox="0 0 12 12"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><line x1="11.25" y1="8.75" x2="6.25" y2="8.75"/><circle cx="4.25" cy="8.75" r="2"/><line x1="2.25" y1="8.75" x2=".75" y2="8.75"/><line x1=".75" y1="3.25" x2="5.75" y2="3.25"/><circle cx="7.75" cy="3.25" r="2"/><line x1="9.75" y1="3.25" x2="11.25" y2="3.25"/></g></symbol>
   <symbol id="i-cubes" viewBox="0 0 18 18"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><path d="M4.648,8.086l-2.55,1.479c-.37,.215-.598,.61-.598,1.038v2.968c0,.428,.228,.823,.598,1.038l2.55,1.479c.372,.216,.832,.216,1.204,0l2.55-1.479c.37-.215,.598-.61,.598-1.038v-2.968c0-.428-.228-.823-.598-1.038l-2.55-1.479c-.372-.216-.832-.216-1.204,0Z"/><polyline points="8.84 10.005 5.25 12.087 1.66 10.005"/><line x1="5.25" y1="16.25" x2="5.25" y2="12.087"/><path d="M12.148,8.086l-2.55,1.479c-.37,.215-.598,.61-.598,1.038v2.968c0,.428,.228,.823,.598,1.038l2.55,1.479c.372,.216,.832,.216,1.204,0l2.55-1.479c.37-.215,.598-.61,.598-1.038v-2.968c0-.428-.228-.823-.598-1.038l-2.55-1.479c-.372-.216-.832-.216-1.204,0Z"/><polyline points="16.34 10.005 12.75 12.087 9.16 10.005"/><line x1="12.75" y1="16.25" x2="12.75" y2="12.087"/><path d="M8.398,1.586l-2.55,1.479c-.37,.215-.598,.61-.598,1.038v2.968c0,.428,.228,.823,.598,1.038l2.55,1.479c.372,.216,.832,.216,1.204,0l2.55-1.479c.37-.215,.598-.61,.598-1.038v-2.968c0-.428-.228-.823-.598-1.038l-2.55-1.479c-.372-.216-.832-.216-1.204,0Z"/><polyline points="12.59 3.505 9 5.587 5.41 3.505"/><line x1="9" y1="9.75" x2="9" y2="5.587"/></g></symbol>
+  <symbol id="i-pin" viewBox="0 0 12 12"><path d="M6 .75c-2.35 0-4.25 1.87-4.25 4.18 0 3.07 4.25 6.32 4.25 6.32s4.25-3.25 4.25-6.32C10.25 2.62 8.35.75 6 .75Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><circle cx="6" cy="4.9" r="1.4" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
   <symbol id="i-reset" viewBox="0 0 18 18"><path d="M5.25 9.5L3 7.25L0.75 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13.495 13.345C12.3587 14.5226 10.7641 15.25 9 15.25C5.548 15.25 2.75 12.45 2.75 9C2.75 8.4 2.834 7.83003 2.99 7.28003" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M12.75 8.5L15 10.75L17.25 8.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M4.50629 4.65564C5.64249 3.48544 7.23658 2.75 8.99998 2.75C12.452 2.75 15.25 5.55 15.25 9C15.25 9.58 15.171 10.14 15.024 10.67" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
 </svg>
 <aside>
@@ -344,6 +346,8 @@
       <button id="polishbtn" title="chamfer the exposed edges; off is the faster draft build"><svg><use href="#i-wand"/></svg><span>polish</span></button>
       <span class="sep"></span>
       <button id="sectionbtn" title="cut the part open along an axis"><svg><use href="#i-layers"/></svg><span>section</span></button>
+      <span class="sep"></span>
+      <button id="pinsbtn" class="on" title="hide the finding markers to see what they cover; the checks stay on"><svg><use href="#i-pin"/></svg><span>pins</span></button>
     </div>
     <div class="pill" id="cut">
       <button data-axis="x">x</button>
@@ -442,10 +446,60 @@ const pinMat = {
   fail: new THREE.MeshBasicMaterial({ color: 0xf87171, depthTest: false, depthWrite: false }),
   warn: new THREE.MeshBasicMaterial({ color: 0xf0c274, depthTest: false, depthWrite: false }),
 };
+// Drawing through the solid cuts both ways: a pin over the exact corner being diagnosed
+// hides the geometry it is diagnosing (issue #55). `pinsWanted` is the user's toggle,
+// `pinsPlaced` is the rebuild lifecycle; a pin shows only when both agree.
+let pinsWanted = true, pinsPlaced = true;
+function syncPins() { pins.visible = pinsWanted && pinsPlaced; }
 
 const material = new THREE.MeshStandardMaterial({
   color: 0x9aa6b8, metalness: 0.05, roughness: 0.62, flatShading: false,
 });
+
+// ---- axis triad ----
+// Issue #55: a tray's front kept reading as its rear while orbiting. A corner triad
+// pinned to the model axes gives the eye something fixed to hold onto. Its camera
+// orbits the origin in lockstep with the main one, so the triad turns with the part.
+const triad = new THREE.Scene();
+const triadCam = new THREE.PerspectiveCamera(45, 1, 0.1, 20);
+triadCam.up.set(0, 0, 1);
+{
+  const axes = new THREE.AxesHelper(1);
+  axes.setColors(new THREE.Color(0xf87171), new THREE.Color(0x6ee7a8), new THREE.Color(0x60a5fa));
+  triad.add(axes);
+  const label = (text, color, x, y, z) => {
+    const c = document.createElement('canvas');
+    c.width = c.height = 128;
+    const g = c.getContext('2d');
+    g.font = '600 76px ui-monospace, SFMono-Regular, Menlo, monospace';
+    g.textAlign = 'center'; g.textBaseline = 'middle';
+    g.fillStyle = color;
+    g.fillText(text, 64, 68);
+    const s = new THREE.Sprite(new THREE.SpriteMaterial({ map: new THREE.CanvasTexture(c) }));
+    s.position.set(x, y, z);
+    s.scale.setScalar(0.55);
+    triad.add(s);
+  };
+  label('x', '#f87171', 1.42, 0, 0);
+  label('y', '#6ee7a8', 0, 1.42, 0);
+  label('z', '#60a5fa', 0, 0, 1.42);
+}
+const TRIAD = { size: 100, pad: 10 };
+function renderTriad() {
+  if (bare) return;   // headless stills document the part, not the viewer chrome
+  // 45deg fov at this distance keeps the labels inside the inset from every angle.
+  triadCam.position.copy(camera.position).sub(controls.target).setLength(4.2);
+  triadCam.lookAt(0, 0, 0);
+  renderer.autoClear = false;
+  renderer.clearDepth();
+  renderer.setScissorTest(true);
+  renderer.setScissor(lastW - TRIAD.size - TRIAD.pad, TRIAD.pad, TRIAD.size, TRIAD.size);
+  renderer.setViewport(lastW - TRIAD.size - TRIAD.pad, TRIAD.pad, TRIAD.size, TRIAD.size);
+  renderer.render(triad, triadCam);
+  renderer.setScissorTest(false);
+  renderer.setViewport(0, 0, lastW, lastH);
+  renderer.autoClear = true;
+}
 
 let lastW = 0, lastH = 0;
 function resize() {
@@ -463,6 +517,7 @@ if (renderer) {
     requestAnimationFrame(tick);
     controls.update();
     renderer.render(scene, camera);
+    renderTriad();
   })();
 }
 
@@ -618,6 +673,12 @@ document.getElementById('sectionbtn').onclick = ev => {
   ev.currentTarget.classList.toggle('on', cutting);
   document.getElementById('cut').classList.toggle('open', cutting);
   sectionUpdate();
+};
+
+document.getElementById('pinsbtn').onclick = ev => {
+  pinsWanted = !pinsWanted;
+  ev.currentTarget.classList.toggle('on', pinsWanted);
+  syncPins();
 };
 document.getElementById('cutpos').oninput = ev => { cutAt = +ev.target.value; sectionUpdate(); };
 for (const b of document.querySelectorAll('#cut button')) {
@@ -853,18 +914,21 @@ function checks(name) {
     // every save; keep the last panel dim, but not its now-misplaced pins.
     if (e && !e.error && box.dataset.for === name) {
       box.classList.add('pending');
-      pins.visible = false;  // their old coordinates do not belong to the new mesh
+      pinsPlaced = false;  // their old coordinates do not belong to the new mesh
+      syncPins();
       return;
     }
     box.classList.remove('pending');
-    pins.visible = true;
+    pinsPlaced = true;
+    syncPins();
     pins.clear();
     delete box.dataset.for;
     box.style.display = 'none';
     return;
   }
   box.classList.remove('pending');
-  pins.visible = true;
+  pinsPlaced = true;
+  syncPins();
   pins.clear();
   box.dataset.for = name;
   box.style.display = 'block';

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,14 @@ def test_an_unasked_port_walks_past_one_that_is_busy():
         assert cli._is_free(busy) is False
 
 
+def test_an_exhausted_walk_falls_back_to_an_ephemeral_port(monkeypatch):
+    """Forty viewers is not a reason to refuse to start (issue #55)."""
+    monkeypatch.setattr(cli, "_is_free", lambda port: False)
+    port = cli._pick_port(None)
+    assert port not in range(cli.DEFAULT_PORT, cli.DEFAULT_PORT + 40)
+    assert port > 0
+
+
 def test_asking_for_a_busy_port_is_an_error_not_a_suggestion():
     """`--port 7373` picking 7374 would open a tab onto somebody else's parts."""
     import socket
@@ -269,6 +277,23 @@ def test_export_reads_the_projects_formats(tmp_path, monkeypatch):
     assert not (tmp_path / "build" / "thing.step").exists()
     cli.cmd_export(argparse.Namespace(part=None, formats=["step"]))
     assert (tmp_path / "build" / "thing.step").exists()
+
+
+def test_stl_is_meshed_for_printing_not_archival(tmp_path):
+    """build123d's 1e-3mm default made a 145x364mm tray 97k triangles (issue #55).
+
+    Fresh shapes per export, because OCCT caches the triangulation on the shape and
+    an export at a coarser tolerance silently reuses an existing finer mesh.
+    """
+    from build123d import Cylinder, export_stl
+
+    from nurb import builder
+
+    export_stl(Cylinder(20, 40), str(tmp_path / "default.stl"))
+    builder.write_stl(Cylinder(20, 40), tmp_path / "ours.stl")
+    assert builder.stl_triangles(tmp_path / "ours.stl") < builder.stl_triangles(
+        tmp_path / "default.stl"
+    )
 
 
 def test_the_shim_promises_what_export_actually_writes():

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -4,7 +4,7 @@ A rule that agrees with itself proves nothing. These are all cases where the exp
 finding is obvious from the geometry: a known angle, a known count, a known tip.
 """
 
-from math import tan, radians
+from math import cos, radians, sin, tan
 
 from build123d import Align, Box, Cylinder, Plane, Pos, Rot, extrude, Polygon
 import pytest
@@ -161,11 +161,40 @@ def test_sliver_counts_and_the_baseline_silences_it():
 
 
 def test_build_volume_uses_the_best_orientation():
-    """300 x 10 x 10 does not fit a 256 bed lying down, but it fits standing up."""
+    """260 x 10 x 10 does not fit a 256 bed square-on, but it fits standing up."""
     tall = Box(260, 10, 10)
     assert only(tall, "build_volume", Context(bed=(256, 256, 300))) == [], "stands up"
-    assert only(tall, "build_volume", Context(bed=(256, 256, 256))) != [], "260 > 256"
     assert only(tall, "build_volume", Context(bed=(100, 100, 100)))[0].severity == FAIL
+
+
+def test_build_volume_allows_a_diagonal_footprint():
+    """The box is not the part: a 300mm bar lies on a 256mm bed at 30-odd degrees,
+    and issue #55's 364mm tray sits on a 350mm bed the same way. Past the bed's
+    diagonal, no rotation saves it."""
+    bed = Context(bed=(256, 256, 100))  # too short to stand either bar on end
+    assert only(Box(300, 10, 10), "build_volume", bed) == []
+    assert only(Box(400, 10, 10), "build_volume", bed)[0].severity == FAIL
+
+
+def test_build_volume_finds_a_narrow_rotation_window():
+    """A long part can have less than 0.1 degrees of usable rotation."""
+    angle = radians(36.05)
+    bed = Context(
+        bed=(
+            300 * cos(angle) + 10 * sin(angle) + 0.1,
+            300 * sin(angle) + 10 * cos(angle) + 0.1,
+            100,
+        )
+    )
+    assert only(Box(300, 10, 10), "build_volume", bed) == []
+
+
+def test_build_volume_turns_a_stood_part_on_the_plate():
+    """A stance fixes build-up, not rotation around build-up."""
+    from nurb import stand
+
+    stood = stand(Box(4, 120, 20), tilt=45, facet=2.0, fins=False)
+    assert only(stood, "build_volume", Context(bed=(100, 100, 100))) == []
 
 
 def test_build_volume_keeps_a_stood_parts_facet_on_the_bed():


### PR DESCRIPTION
Fixes from the cockpit-tray feedback in #55, leaving the big rim item for a later spike.

Exported STLs are now meshed at print scale (0.01mm chord error instead of build123d's 1e-3mm default), which cuts a 145x364mm tray from 97k triangles to a fraction, and `nurb export` reports each artifact's size and triangle count. The build-volume check now rotates a footprint on the plate, so a 364mm tray passes on a 350mm bed at an angle, including stood parts turning around their build axis. `nurb dev` falls back to an OS-assigned port instead of refusing to start when forty viewers are running. The viewer gains a pins toggle to see the geometry a finding marker covers, and a corner axis triad so orientation reads while orbiting. `docs/rim-helper-research.md` records the research for a future `crown()` variable-height rim helper, the one item from the issue deliberately left out.