### PR TITLE
Detect floating counterbore ceilings and generate stepped bridging holes

### DIFF
--- a/src/nurb/__init__.py
+++ b/src/nurb/__init__.py
@@ -16,6 +16,7 @@ from build123d import *  # noqa: F401,F403  -- geometry vocabulary
 
 from .assembly import assembly, hinge, obstacle, use  # noqa: E402
 from .checks import concave_edges, is_convex  # noqa: E402
+from .holes import counterbore  # noqa: E402
 from .measurements import measured  # noqa: E402
 from .orient import stand  # noqa: E402
 from .polish import chamfer, polish  # noqa: E402  -- must win, see below
@@ -33,6 +34,9 @@ from .registry import part  # noqa: E402  -- must win over any build123d name
 # rotation is trivial, but the bed facet it cuts is a doctrine rule (2mm of flat, or the
 # first layer is one extrusion line wide and peels), and a part file left to tilt by
 # hand ships the knife edge.
+# `counterbore` is here because the naive alternative is two cylinders that build,
+# check as an ordinary bridge, and print a screw seat on sagging air: the stepped
+# bridging stack is fixed print-farm practice, not a judgement, so it is generated.
 # `chamfer` deliberately shadows build123d's. Same behaviour, same exception type;
 # what it adds is the doctrine's rule on the way out of a failure, because the kernel's
 # own advice is "try a smaller length value(s)" and following it is how a part ends up
@@ -48,6 +52,7 @@ __all__ = [
     "measured",
     "polish",
     "stand",
+    "counterbore",
     "assembly",
     "use",
     "hinge",

--- a/src/nurb/builder.py
+++ b/src/nurb/builder.py
@@ -13,6 +13,11 @@ class BuildError(Exception):
     pass
 
 
+# What a bridge surface multiplies the part color by in the viewer. Blue, because that
+# is what every slicer's preview paints bridges, so the association is already learned.
+BRIDGE_TINT = (89, 166, 255, 255)
+
+
 class UnknownParams(BuildError):
     """An override named a parameter the part does not declare.
 
@@ -152,17 +157,33 @@ def _triangulate(shape, tolerance):
     Everything else here matches `tessellate` deliberately, including the winding flip
     on a reversed face and the per-face vertex offset.
     """
+    from build123d import GeomType
     from OCP.BRep import BRep_Tool
     from OCP.TopAbs import TopAbs_Orientation
     from OCP.TopLoc import TopLoc_Location
 
     shape.mesh(tolerance)
-    points, faces, offset = [], [], 0
+    # Flat ceilings above the bed get tinted, the way a slicer previews bridges: these
+    # are the surfaces the printer lays on air, and they are otherwise invisible in a
+    # shaded render. This is how a stepped counterbore shows its work: the sacrificial
+    # shelves light up where a naive pocket shows one floating ceiling. The colors are
+    # multipliers over the viewer's material, so white is "no tint". Classified off the
+    # triangulation's own nodes in a second pass, never off bounding_box(): that call
+    # quietly destroys the cached triangulation, at shape and face level both, and the
+    # symptom is an empty mesh with no error anywhere.
+    points, faces, ceilings, offset = [], [], [], 0
     for face in shape.faces():
         loc = TopLoc_Location()
         poly = BRep_Tool.Triangulation_s(face.wrapped, loc)
         if poly is None:  # a face OCCT declined to triangulate takes no vertices with it
             continue
+        try:
+            flat_ceiling = (
+                face.geom_type == GeomType.PLANE
+                and face.normal_at(face.center()).Z < -0.97
+            )
+        except Exception:
+            flat_ceiling = False
         trsf = loc.Transformation()
         reverse = face.wrapped.Orientation() == TopAbs_Orientation.TopAbs_REVERSED
         for i in range(1, poly.NbNodes() + 1):
@@ -175,8 +196,16 @@ def _triangulate(shape, tolerance):
             if reverse:
                 b, c = c, b
             faces.append((a + offset - 1, b + offset - 1, c + offset - 1))
+        if flat_ceiling:
+            ceilings.append((offset, poly.NbNodes()))
         offset += poly.NbNodes()
-    return points, faces
+    colors = [(255, 255, 255, 255)] * len(points)
+    if points:
+        bed = min(p[2] for p in points)
+        for start, count in ceilings:
+            if min(points[i][2] for i in range(start, start + count)) > bed + 1e-4:
+                colors[start : start + count] = [BRIDGE_TINT] * count
+    return points, faces, colors
 
 
 def to_mesh(shape, tolerance=0.1):
@@ -187,10 +216,11 @@ def to_mesh(shape, tolerance=0.1):
     weld them merges the box corners and smears the normals across perpendicular
     faces, which renders as a shadeless blob.
     """
-    points, faces = _triangulate(shape, tolerance)
+    points, faces, colors = _triangulate(shape, tolerance)
     mesh = trimesh.Trimesh(
         vertices=np.array(points, dtype=np.float64),
         faces=np.array(faces, dtype=np.int64),
+        vertex_colors=np.array(colors, dtype=np.uint8),
         process=False,
     )
     mesh.vertex_normals  # populate before export, or the GLB ships without normals

--- a/src/nurb/builder.py
+++ b/src/nurb/builder.py
@@ -144,7 +144,7 @@ def build(path, overrides=None, draft=False):
     return shape, params, elapsed
 
 
-def _triangulate(shape, tolerance):
+def _triangulate(shape, tolerance, up=(0, 0, 1)):
     """Vertices and triangles, read straight out of OCCT.
 
     This is what `Shape.tessellate` does, and it exists because of one line in it.
@@ -157,12 +157,13 @@ def _triangulate(shape, tolerance):
     Everything else here matches `tessellate` deliberately, including the winding flip
     on a reversed face and the per-face vertex offset.
     """
-    from build123d import GeomType
+    from build123d import GeomType, Vector
     from OCP.BRep import BRep_Tool
     from OCP.TopAbs import TopAbs_Orientation
     from OCP.TopLoc import TopLoc_Location
 
     shape.mesh(tolerance)
+    up = Vector(*up).normalized()
     # Flat ceilings above the bed get tinted, the way a slicer previews bridges: these
     # are the surfaces the printer lays on air, and they are otherwise invisible in a
     # shaded render. This is how a stepped counterbore shows its work: the sacrificial
@@ -180,7 +181,7 @@ def _triangulate(shape, tolerance):
         try:
             flat_ceiling = (
                 face.geom_type == GeomType.PLANE
-                and face.normal_at(face.center()).Z < -0.97
+                and face.normal_at(face.center()).dot(up) < -0.97
             )
         except Exception:
             flat_ceiling = False
@@ -201,14 +202,17 @@ def _triangulate(shape, tolerance):
         offset += poly.NbNodes()
     colors = [(255, 255, 255, 255)] * len(points)
     if points:
-        bed = min(p[2] for p in points)
+        def height(p):
+            return p[0] * up.X + p[1] * up.Y + p[2] * up.Z
+
+        bed = min(height(p) for p in points)
         for start, count in ceilings:
-            if min(points[i][2] for i in range(start, start + count)) > bed + 1e-4:
+            if min(height(points[i]) for i in range(start, start + count)) > bed + 1e-4:
                 colors[start : start + count] = [BRIDGE_TINT] * count
     return points, faces, colors
 
 
-def to_mesh(shape, tolerance=0.1):
+def to_mesh(shape, tolerance=0.1, up=(0, 0, 1)):
     """Tessellate to a triangle mesh.
 
     process=False matters: OCCT already splits vertices at face boundaries, which
@@ -216,7 +220,7 @@ def to_mesh(shape, tolerance=0.1):
     weld them merges the box corners and smears the normals across perpendicular
     faces, which renders as a shadeless blob.
     """
-    points, faces, colors = _triangulate(shape, tolerance)
+    points, faces, colors = _triangulate(shape, tolerance, up)
     mesh = trimesh.Trimesh(
         vertices=np.array(points, dtype=np.float64),
         faces=np.array(faces, dtype=np.int64),
@@ -227,7 +231,7 @@ def to_mesh(shape, tolerance=0.1):
     return mesh
 
 
-def to_glb(shape, tolerance=0.1):
+def to_glb(shape, tolerance=0.1, up=(0, 0, 1)):
     """One GLB. A part is one blob; an assembly keeps its movers as named nodes.
 
     The scene rides on the compound the same way checks.run reads it: an attribute,
@@ -238,16 +242,16 @@ def to_glb(shape, tolerance=0.1):
     """
     scene = getattr(shape, "_nurb_scene", None)
     if scene is None:
-        return trimesh.Scene([to_mesh(shape, tolerance)]).export(file_type="glb")
+        return trimesh.Scene([to_mesh(shape, tolerance, up)]).export(file_type="glb")
     from .assembly import NODE
 
     out = trimesh.Scene()
     for i, h in enumerate(scene.hinges):
         name = NODE.format(i)
-        out.add_geometry(to_mesh(h.solid, tolerance), node_name=name, geom_name=name)
+        out.add_geometry(to_mesh(h.solid, tolerance, up), node_name=name, geom_name=name)
     for name, group in (("fixed", scene.statics), ("context", scene.obstacles)):
         if group:
-            merged = trimesh.util.concatenate([to_mesh(s, tolerance) for s in group])
+            merged = trimesh.util.concatenate([to_mesh(s, tolerance, up) for s in group])
             out.add_geometry(merged, node_name=name, geom_name=name)
     return out.export(file_type="glb")
 

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -690,14 +690,28 @@ def hole_ceiling(shape, ctx):
             # The box centre, not wire.center(): a curve's own centre is its centre
             # of mass, which for a circle is a point on the rim, not the middle.
             centre = wire.bounding_box().center()
-            above = centre + up * 0.2
-            if solid and solid.is_inside((above.X, above.Y, above.Z)):
-                continue  # a boss through the ceiling, not a hole
             width = min(
                 _span(wire, axis)[1] - _span(wire, axis)[0]
                 for axis in (Vector(1, 0, 0), Vector(0, 1, 0), Vector(0, 0, 1))
                 if abs(axis.dot(up)) < 0.9
             )
+            # Probe just inside the wire rather than at its box centre. A hollow boss
+            # carries the rim as surely as a solid one, but its centre is still void
+            # and looks exactly like a hole. `_into_face` finds the material side of
+            # the boundary, so its opposite is the region the wire encloses.
+            carried = []
+            if solid:
+                step = min(0.05, width / 4)
+                for edge in wire.edges():
+                    try:
+                        point = edge.position_at(0.5)
+                        inward = -_into_face(face, point, edge.tangent_at(0.5))
+                        above = point + inward * step + up * 0.02
+                        carried.append(solid.is_inside((above.X, above.Y, above.Z)))
+                    except Exception:
+                        continue
+            if carried and all(carried):
+                continue  # a solid or hollow boss through the ceiling, not a hole
             found.append(
                 Finding(
                     "hole_ceiling",

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -657,6 +657,60 @@ def floating(shape, ctx):
     return found
 
 
+@rule("hole_ceiling")
+def hole_ceiling(shape, ctx):
+    """A blind hole's flat ceiling with a smaller hole continuing through it.
+
+    The counterbore case: a screw pocket printed mouth-down floats the shelf its head
+    bears on, and the through hole's first rim is a circle drawn on air. The overhang
+    rule cannot see it, deliberately: a ceiling with material all around reads as a
+    bridge, and a bridge the printer walks across is not a finding. What a bridge
+    cannot carry cleanly is a hole rim inside it, laid on sagging lines with nothing
+    under the perimeter, which is why this looks for the piercing rather than the span.
+
+    Found on the B-rep directly: a horizontal downward face with an inner wire is a
+    pierced ceiling. The one thing the wire alone cannot tell is what pierced it, so
+    the probe above settles it: void continuing up is a hole and a finding; material
+    is a boss hanging through, which carries its own rim. The remedy is `counterbore()`,
+    which steps the transition so each layer bridges only what the one before it laid,
+    and whose own stepped stack leaves no pierced ceiling for this rule to find.
+    """
+    up = Vector(*ctx.up).normalized()
+    bed, _ = _span(shape, up)
+    solid = shape.solids()[0] if shape.solids() else None
+    found = []
+    for face in shape.faces():
+        if face.geom_type != GeomType.PLANE:
+            continue
+        if face.normal_at(face.center()).dot(up) > -0.97:
+            continue  # not a flat ceiling
+        if _span(face, up)[0] <= bed + 1e-4:
+            continue  # the first layer, where every mouth belongs
+        for wire in face.inner_wires():
+            # The box centre, not wire.center(): a curve's own centre is its centre
+            # of mass, which for a circle is a point on the rim, not the middle.
+            centre = wire.bounding_box().center()
+            above = centre + up * 0.2
+            if solid and solid.is_inside((above.X, above.Y, above.Z)):
+                continue  # a boss through the ceiling, not a hole
+            width = min(
+                _span(wire, axis)[1] - _span(wire, axis)[0]
+                for axis in (Vector(1, 0, 0), Vector(0, 1, 0), Vector(0, 0, 1))
+                if abs(axis.dot(up)) < 0.9
+            )
+            found.append(
+                Finding(
+                    "hole_ceiling",
+                    WARN,
+                    f"a {width:.1f}mm hole rim is laid on air over the opening below; "
+                    f"counterbore() steps the transition into bridges",
+                    value=round(width, 1),
+                    where=tuple(round(v, 2) for v in centre),
+                )
+            )
+    return found
+
+
 @rule("stability")
 def stability(shape, ctx):
     """Will it stand on the bed, or tip while printing."""

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -702,8 +702,8 @@ def hole_ceiling(shape, ctx):
                 Finding(
                     "hole_ceiling",
                     WARN,
-                    f"a {width:.1f}mm hole rim is laid on air over the opening below; "
-                    f"counterbore() steps the transition into bridges",
+                    f"a {width:.1f}mm hole rim would print on air over the opening "
+                    f"below; stepped bridging layers are the fix",
                     value=round(width, 1),
                     where=tuple(round(v, 2) for v in centre),
                 )

--- a/src/nurb/cli.py
+++ b/src/nurb/cli.py
@@ -243,16 +243,16 @@ def _artifact_size(path):
 def cmd_export(args):
     from build123d import export_step
 
-    from . import builder
+    from . import builder, checks
 
     root = project_root()
     formats = args.formats or _project_formats(root) or list(DEFAULT_FORMATS)
     configs = _collect_exports(_resolve(root, args.part))
     out = root / "build"
     out.mkdir(exist_ok=True)
-    queue = [(path, name, overrides) for path, name, overrides, _ in configs]
+    queue = list(configs)
     while queue:
-        path, name, overrides = queue.pop(0)
+        path, name, overrides, ctx = queue.pop(0)
         shape, _, _ = builder.build(path, overrides=overrides or None, draft=False)
         scene = getattr(shape, "_nurb_scene", None)
         if scene is not None:
@@ -267,7 +267,7 @@ def cmd_export(args):
             if not placed:
                 sys.exit(f"  {name} is an assembly that places no parts; nothing to print")
             print(f"  {name}: exporting the {len(placed)} part(s) it places")
-            queue = [(p, p.stem, None) for p in placed] + queue
+            queue = [(p, p.stem, None, checks.from_card(p)) for p in placed] + queue
             continue
         for fmt in formats:
             target = out / f"{name}.{fmt}"
@@ -276,7 +276,7 @@ def cmd_export(args):
             elif fmt == "step":
                 export_step(shape, str(target))
             elif fmt == "glb":
-                target.write_bytes(builder.to_glb(shape, 0.02))
+                target.write_bytes(builder.to_glb(shape, 0.02, up=ctx.up))
             else:
                 # The print used to sit outside this chain, so a typo in `--formats`
                 # reported a filename that was never written and exited 0.

--- a/src/nurb/doctrine.md
+++ b/src/nurb/doctrine.md
@@ -48,6 +48,7 @@ bounding box and still exports, so nothing downstream catches it.
   +z, so every functional feature is grounded. A vertical extrusion or a vertical
   through hole is self-supporting. A shelf, loop, or band floated partway up with a gap
   underneath is not.
+- **A counterbore prints mouth toward the bed, and that floats its ceiling.** The shelf the screw head bears on is laid flat over the open pocket, and the smaller hole's first rim is a circle drawn on air; the `hole_ceiling` finding is this exact case, and it appears on any hole rising out of a bridged roof, not just screw pockets. Never answer it with supports inside a pocket nobody can clean: cut the hole with `counterbore(hole_dia, head_dia, head_depth, depth)`, which steps the transition through two sacrificial bridge layers, a slot bridged chord-to-chord across the pocket and the same slot turned ninety degrees across the first, so each layer spans only what the one before it laid and the whole stack prints support-free. Reach for it whenever a design wants a screw head, a nut, or any wider recess on the bed side of a hole.
 - **Corbel rule.** Grounded does not mean a column to the bed. Support-free means no
   layer overhanging past 45 degrees. Where material would run to the plate only to
   satisfy printing, carry the feature on a 45 degree underside instead: a short vertical

--- a/src/nurb/holes.py
+++ b/src/nurb/holes.py
@@ -1,0 +1,60 @@
+"""Support-free counterbores: the stepped bridging hole.
+
+A counterbored hole prints mouth toward the bed, because that is where the screw head
+comes from. That floats its ceiling: the shelf the head bears on is laid flat over the
+open bore, and the smaller hole's first rim is a circle drawn on air. Slicers print it
+badly or demand support inside a pocket nobody can clean.
+
+The print-farm fix is sequential bridging, two sacrificial layers between bore and
+hole. First a slot the hole's width, bridged chord-to-chord across the bore; then the
+same slot turned ninety degrees, bridged across the first; then the round hole starts
+over the crossing, ringed by material that bridges the short way at every point. Each
+layer spans only what the one before it laid, so the whole stack prints support-free
+and the screw never notices: the steps sit above the head's seat and every opening
+clears the shaft.
+"""
+
+from build123d import Align, Box, Cylinder, Pos
+
+# How far the cutter reaches past its own mouth, so a caller seating the mouth flush
+# on the part's bottom face never leaves a coplanar-face boolean to the kernel's mood.
+LEAD = 1.0
+
+_SEATED = (Align.CENTER, Align.CENTER, Align.MIN)
+
+
+def counterbore(hole_dia, head_dia, head_depth, depth, layer=1.0):
+    """The negative space of a counterbored hole whose ceiling prints without support.
+
+    Returns a cutter to subtract: mouth centred at the origin opening downward, hole
+    rising up +z, which is a counterbore printed the way one is used, head toward the
+    bed. `hole_dia` is the shaft's hole, `head_dia` and `head_depth` the head's pocket,
+    `depth` the full reach of the hole from the mouth. Position it at the part's bottom
+    face; the mouth runs 1mm long so a flush seat still cuts clean, and `depth` can
+    be generous for a through hole, the excess sticks out the top harmlessly.
+
+    Between pocket and hole sit two bridge steps, each `layer` tall: a slot across the
+    bore, then the same slot turned ninety degrees across the first. Anything at or
+    above the printed layer height bridges; the default is 1mm, exactly the printer's
+    min_wall, so the sacrificial laminae between the steps never read as thin walls to
+    the checker. Shrink it only when depth is tight, and expect min_wall to notice.
+    """
+    if hole_dia <= 0 or head_dia <= 0 or head_depth <= 0 or layer <= 0:
+        raise ValueError("counterbore() needs positive dimensions throughout")
+    if head_dia <= hole_dia:
+        raise ValueError(
+            f"a counterbore needs a head pocket wider than its hole, got head_dia "
+            f"{head_dia:g} against hole_dia {hole_dia:g}. For a plain hole, cut a Cylinder."
+        )
+    if depth < head_depth + 2 * layer + 1e-9:
+        raise ValueError(
+            f"depth {depth:g} leaves no hole above the pocket: the head takes "
+            f"{head_depth:g} and the two bridge steps take {2 * layer:g}"
+        )
+    pocket = Pos(0, 0, -LEAD) * Cylinder(head_dia / 2, head_depth + LEAD, align=_SEATED)
+    # The steps stay inside the pocket's circle: a slot cut square would notch the wall.
+    inside = Pos(0, 0, head_depth) * Cylinder(head_dia / 2, 2 * layer, align=_SEATED)
+    first = Pos(0, 0, head_depth) * Box(head_dia, hole_dia, layer, align=_SEATED) & inside
+    second = Pos(0, 0, head_depth + layer) * Box(hole_dia, head_dia, layer, align=_SEATED) & inside
+    shaft = Pos(0, 0, -LEAD) * Cylinder(hole_dia / 2, depth + LEAD, align=_SEATED)
+    return pocket + first + second + shaft

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -217,10 +217,15 @@ class Server:
         }
         try:
             shape, params, ms = self._build(path, name)
-            entry["glb"] = builder.to_glb(shape, self.tolerance)
             entry.update(builder.stats(shape))
             entry["params"] = params
             entry["variant"] = self._active_variant(params, entry["variants"])
+            try:
+                up = self._context(path, entry["variant"]).up
+            except Exception:
+                # A bad card is reported by the check pass; it must not hide geometry.
+                up = (0, 0, 1)
+            entry["glb"] = builder.to_glb(shape, self.tolerance, up=up)
             entry["ms"] = round(ms, 1)
             entry["error"] = None
             entry["shape"] = shape  # kept for the check pass, never serialized
@@ -275,6 +280,18 @@ class Server:
                 return variant["name"]
         return None
 
+    @staticmethod
+    def _context(path, variant):
+        """The check context belonging to the values currently on screen."""
+        from . import checks
+
+        configs = checks.configurations(path)
+        ctx = configs[0][2]
+        for name, _, variant_ctx in configs[1:]:
+            if name == variant:
+                return variant_ctx
+        return ctx
+
     def check(self, path):
         """Run the rules on the last good build.
 
@@ -292,12 +309,7 @@ class Server:
             # settings judge it: shelf_gridfinity_2x1 accepts 10 slivers, not the
             # base part's 18. Matched on the built values, never on a mode flag, so
             # one slider drag off the variant honestly puts the base rules back.
-            configs = checks.configurations(path)
-            ctx = configs[0][2]
-            for name, _, vctx in configs[1:]:
-                if name == entry["variant"]:
-                    ctx = vctx
-                    break
+            ctx = self._context(path, entry["variant"])
             found = checks.run(entry["shape"], ctx)
             entry["findings"] = [
                 {

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -535,7 +535,7 @@ if (renderer) {
 const AXES = { x: [1, 0, 0], y: [0, 1, 0], z: [0, 0, 1] };
 const PARKED = 1e6;   // "off", without changing the array length and recompiling shaders
 const plane = new THREE.Plane(new THREE.Vector3(0, 0, -1), PARKED);
-let cutAxis = 'z', cutAt = 0.5, cutting = false, writers = [];
+let cutAxis = 'z', cutAt = 0.5, cutting = false, cutSign = 0, writers = [];
 
 const stencilBase = {
   depthWrite: false, depthTest: false, colorWrite: false,
@@ -604,16 +604,19 @@ function sectionUpdate() {
   const box = new THREE.Box3();
   for (const c of mesh.children) if (c.isMesh && c.name !== 'context') box.expandByObject(c);
   const lo = box.min[cutAxis], hi = box.max[cutAxis];
+  // The cut faces the camera as it stood when the section opened or the axis was
+  // picked, so the first look always shows the cross-section instead of the part's
+  // own outside. Chosen once and then left alone: a side that follows the camera
+  // swaps the surviving half mid-orbit, and with the slider near an end that
+  // collapses the whole part to a sliver the moment the view crosses the plane.
+  if (!cutSign) cutSign = camera.position[cutAxis] >= (lo + hi) / 2 ? 1 : -1;
+  // Normalized so dragging right always keeps more material, whichever side survives.
+  const t = cutSign === 1 ? cutAt : 1 - cutAt;
   // A hair inside the bounds at each end, so neither extreme is a cut through nothing.
-  const at = lo + (hi - lo) * (0.02 + 0.96 * cutAt);
+  const at = lo + (hi - lo) * (0.02 + 0.96 * t);
   const dir = AXES[cutAxis];
-  // Keep the half beyond the plane, so the cut face looks at the camera. A fixed
-  // side means half of all viewpoints see only the part's own outside and nothing
-  // says why: the cross-section is physically facing away. Which half survives
-  // follows the camera as it orbits past the plane.
-  const s = camera.position[cutAxis] >= at ? 1 : -1;
-  plane.normal.set(-s * dir[0], -s * dir[1], -s * dir[2]);  // keeps the side the normal points at
-  plane.constant = s * at;
+  plane.normal.set(-cutSign * dir[0], -cutSign * dir[1], -cutSign * dir[2]);  // keeps the side the normal points at
+  plane.constant = cutSign * at;
   const span = box.getSize(new THREE.Vector3()).length();
   cap.scale.set(span, span, 1);
   // Centred on the part, not on coplanarPoint, which is where the plane passes the
@@ -679,6 +682,7 @@ document.getElementById('polishbtn').onclick = () => {
 
 document.getElementById('sectionbtn').onclick = ev => {
   cutting = !cutting;
+  cutSign = 0;  // re-aim the cut at wherever the camera is now
   ev.currentTarget.classList.toggle('on', cutting);
   document.getElementById('cut').classList.toggle('open', cutting);
   sectionUpdate();
@@ -694,6 +698,7 @@ for (const b of document.querySelectorAll('#cut button')) {
   b.classList.toggle('on', b.dataset.axis === cutAxis);
   b.onclick = () => {
     cutAxis = b.dataset.axis;
+    cutSign = 0;  // a new axis re-aims at the camera the same way opening does
     for (const o of document.querySelectorAll('#cut button')) o.classList.toggle('on', o === b);
     sectionUpdate();
   };
@@ -704,7 +709,6 @@ for (const b of document.querySelectorAll('#cut button')) {
 const camKey = n => `nurb.cam.v2.${n}`;  // v2: parts now sit on the plate, not under it
 let saveTimer = null;
 if (controls) controls.addEventListener('change', () => {
-  if (cutting) sectionUpdate();  // the kept half tracks which side the camera is on
   if (!current) return;
   clearTimeout(saveTimer);
   saveTimer = setTimeout(() => {

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -572,7 +572,8 @@ cap.visible = false;
 cap.onAfterRender = r => r.clearStencil();
 scene.add(cap);
 
-function sectionAttach() {
+function sectionAttach(reaim) {
+  if (reaim) cutSign = 0;  // a different part gets aimed from its own restored camera
   for (const w of writers) scene.remove(w);
   writers = [];
   if (!mesh) return;
@@ -892,7 +893,6 @@ async function paint(name, { keepCamera }) {
   mesh.position.z = -bb.min.z;
   const box = bb.clone().translate(new THREE.Vector3(0, 0, mesh.position.z));
   const size = box.getSize(new THREE.Vector3()).length();
-  sectionAttach();
 
   // Only reframe when the part changed scale enough that the camera is lost.
   const jumped = lastSize && (size / lastSize > 3 || lastSize / size > 3);
@@ -912,6 +912,9 @@ async function paint(name, { keepCamera }) {
     reframe.style.display = (jumped || lost) ? 'inline-flex' : 'none';
   }
   reframe.onclick = () => { frame(box); reframe.style.display = 'none'; };
+  // The cut side comes from the camera, so attach only after this part's saved camera
+  // has been restored (or its default frame chosen), never from the part just removed.
+  sectionAttach(!keepCamera);
   lastSize = size;
   hud(parts.get(name) || entry);
   checks(name);

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -855,6 +855,9 @@ async function paint(name, { keepCamera }) {
     if (!src.geometry.attributes.normal) src.geometry.computeVertexNormals();  // never render unlit
     const m = new THREE.Mesh(src.geometry, material.clone());
     m.material.clippingPlanes = [plane];   // parked unless the section view is on
+    // The builder tints bridge surfaces slicer-blue via vertex colors, multipliers
+    // over the material color, so a mesh without them renders exactly as before.
+    if (src.geometry.attributes.color) m.material.vertexColors = true;
     // The exporter names the node; the loader sometimes hangs the mesh under it.
     m.name = src.name || (src.parent && src.parent.name) || '';
     if (m.name === 'context') {

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -603,8 +603,13 @@ function sectionUpdate() {
   // A hair inside the bounds at each end, so neither extreme is a cut through nothing.
   const at = lo + (hi - lo) * (0.02 + 0.96 * cutAt);
   const dir = AXES[cutAxis];
-  plane.normal.set(-dir[0], -dir[1], -dir[2]);   // keeps the side the normal points at
-  plane.constant = at;
+  // Keep the half beyond the plane, so the cut face looks at the camera. A fixed
+  // side means half of all viewpoints see only the part's own outside and nothing
+  // says why: the cross-section is physically facing away. Which half survives
+  // follows the camera as it orbits past the plane.
+  const s = camera.position[cutAxis] >= at ? 1 : -1;
+  plane.normal.set(-s * dir[0], -s * dir[1], -s * dir[2]);  // keeps the side the normal points at
+  plane.constant = s * at;
   const span = box.getSize(new THREE.Vector3()).length();
   cap.scale.set(span, span, 1);
   // Centred on the part, not on coplanarPoint, which is where the plane passes the
@@ -695,6 +700,7 @@ for (const b of document.querySelectorAll('#cut button')) {
 const camKey = n => `nurb.cam.v2.${n}`;  // v2: parts now sit on the plate, not under it
 let saveTimer = null;
 if (controls) controls.addEventListener('change', () => {
+  if (cutting) sectionUpdate();  // the kept half tracks which side the camera is on
   if (!current) return;
   clearTimeout(saveTimer);
   saveTimer = setTimeout(() => {

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -556,7 +556,11 @@ const stencilFront = new THREE.MeshBasicMaterial({
 const cap = new THREE.Mesh(
   new THREE.PlaneGeometry(1, 1),
   new THREE.MeshStandardMaterial({
-    color: 0xc9a227, metalness: 0.0, roughness: 0.85, side: THREE.DoubleSide,
+    // Violet, because the cap is the one surface that is not part material and must
+    // not impersonate anything that is a signal: amber is a warn pin, red a fail pin,
+    // green the accent, blue-gray the part itself. The shipped gold sat on the same
+    // hue as the warn pins, and a pin on a cut ceiling is the section view's whole job.
+    color: 0x8578cf, metalness: 0.0, roughness: 0.85, side: THREE.DoubleSide,
     stencilWrite: true, stencilRef: 0, stencilFunc: THREE.NotEqualStencilFunc,
     stencilFail: THREE.ReplaceStencilOp,
     stencilZFail: THREE.ReplaceStencilOp,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,6 +29,7 @@ def test_the_documented_vocabulary_is_the_exported_one():
         "concave_edges",
         "measured",
         "stand",
+        "counterbore",
         "assembly",
         "use",
         "hinge",

--- a/tests/test_holes.py
+++ b/tests/test_holes.py
@@ -1,0 +1,58 @@
+"""The stepped counterbore cutter, probed where each step is supposed to be.
+
+The rule-facing cases live in test_rules.py; these pin the cutter's own geometry: the
+two bridge steps really are perpendicular slots, the shaft runs the whole way, and the
+mouth leads past its own origin so a flush seat still cuts.
+"""
+
+from build123d import Align, Box, Pos
+import pytest
+
+from nurb import counterbore
+
+
+def plate_with(cutter):
+    plate = Box(30, 30, 10, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    return (plate - cutter).solids()[0]
+
+
+def test_the_steps_are_perpendicular_slots():
+    """M3-ish: 3.4 hole, 6.2 pocket 3 deep, so step one spans y only and step two x
+    only. Probed at 2.9mm out, inside the pocket circle but outside both slot widths."""
+    solid = plate_with(counterbore(hole_dia=3.4, head_dia=6.2, head_depth=3, depth=12))
+
+    def void(x, y, z):
+        return not solid.is_inside((x, y, z))
+
+    assert void(0, 0, 1) and void(0, 0, 5) and void(0, 0, 9), "the shaft runs the whole way"
+    assert void(2.9, 0, 1) and void(0, 2.9, 1), "the head pocket is 6.2 wide"
+    assert void(2.9, 0, 3.5) and not void(0, 2.9, 3.5), "step one is a slot across x"
+    assert void(0, 2.9, 4.5) and not void(2.9, 0, 4.5), "step two is the same slot across y"
+    assert not void(2.9, 0, 5.5) and not void(0, 2.9, 5.5), "above the steps, only the shaft"
+
+
+def test_the_mouth_leads_past_its_origin():
+    """Seated flush on a bottom face, the cut must not depend on a coplanar boolean."""
+    assert counterbore(3.4, 6.2, 3, 12).bounding_box().min.Z == pytest.approx(-1.0)
+
+
+def test_a_generous_depth_is_harmless():
+    """The doctrine's way to cut a through hole: ask for more than the part."""
+    solid = plate_with(counterbore(3.4, 6.2, 3, 40))
+    assert not solid.is_inside((0, 0, 9.9))
+    assert solid.volume > 0
+
+
+def test_a_head_no_wider_than_the_hole_is_refused():
+    with pytest.raises(ValueError, match="wider than its hole"):
+        counterbore(hole_dia=5, head_dia=4, head_depth=2, depth=10)
+
+
+def test_a_depth_the_pocket_and_steps_swallow_is_refused():
+    with pytest.raises(ValueError, match="leaves no hole"):
+        counterbore(hole_dia=3, head_dia=6, head_depth=3, depth=4)
+
+
+def test_dimensions_must_be_positive():
+    with pytest.raises(ValueError, match="positive"):
+        counterbore(hole_dia=3, head_dia=6, head_depth=0, depth=10)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -370,6 +370,66 @@ def test_concave_cosmetic_does_not_mistake_a_pocket_for_a_chamfer():
     assert only(Box(20, 20, 20) - Pos(0, 0, 8) * Box(6, 6, 6), "concave_cosmetic") == []
 
 
+# --- hole ceilings -----------------------------------------------------------
+
+
+def counterbored_plate():
+    """A 10mm plate with a naive counterbore, mouth on the bed: a 3.4mm hole over a
+    6.2mm head pocket, the shelf between them laid flat over the open pocket."""
+    plate = Box(30, 30, 10, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    seated = (Align.CENTER, Align.CENTER, Align.MIN)
+    return plate - Cylinder(1.7, 30, align=seated) - Cylinder(3.1, 3, align=seated)
+
+
+def test_naive_counterbore_floats_its_hole_rim():
+    """The overhang rule reads the shelf as a bridge and stays quiet on purpose; what
+    it cannot see is the 3.4mm rim inside the bridge, drawn on air."""
+    found = only(counterbored_plate(), "hole_ceiling")
+    assert len(found) == 1
+    assert found[0].severity == WARN
+    assert found[0].value == pytest.approx(3.4, abs=0.05)
+    assert only(counterbored_plate(), "overhang") == []
+
+
+def test_stepped_counterbore_answers_the_finding():
+    """The same pocket cut with counterbore() leaves nothing for any rule: every
+    ceiling in the stack is a short bridge the existing rules already allow."""
+    from nurb import counterbore
+
+    plate = Box(30, 30, 10, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    stepped = plate - counterbore(hole_dia=3.4, head_dia=6.2, head_depth=3, depth=12)
+    assert len(stepped.solids()) == 1
+    assert run(stepped) == []
+
+
+def test_hole_through_a_bridged_roof_is_the_same_finding():
+    """Not only screw pockets: a vertical hole meeting a channel roof from above puts
+    its rim on the same sagging bridge lines."""
+    shape = Box(40, 40, 20) - Pos(0, 0, 6) * Box(10, 60, 6) - Pos(0, 0, 15) * Cylinder(2, 14)
+    found = only(shape, "hole_ceiling")
+    assert len(found) == 1
+    assert found[0].severity == WARN
+
+
+def test_a_boss_through_a_ceiling_is_not_a_hole():
+    """The inner wire alone cannot tell a hole from a column passing through the
+    ceiling, and a column carries its own rim. The probe above settles it."""
+    seated = (Align.CENTER, Align.CENTER, Align.MIN)
+    shape = (
+        Box(30, 30, 20, align=seated)
+        - Box(20, 20, 10, align=seated)
+        + Cylinder(2, 10, align=seated)
+    )
+    assert only(shape, "hole_ceiling") == []
+
+
+def test_a_counterbore_mouth_on_the_bed_is_the_first_layer():
+    """The plate's bottom face is pierced by the pocket too, and warning about the
+    first layer is how a checker gets switched off."""
+    found = only(counterbored_plate(), "hole_ceiling")
+    assert all(f.where[2] > 0 for f in found)
+
+
 # --- wall thickness ----------------------------------------------------------
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -423,6 +423,18 @@ def test_a_boss_through_a_ceiling_is_not_a_hole():
     assert only(shape, "hole_ceiling") == []
 
 
+def test_a_hollow_boss_through_a_ceiling_carries_its_rim():
+    """A tube is still support even though probing its bounding-box centre finds
+    the through hole rather than the wall that actually meets the ceiling."""
+    seated = (Align.CENTER, Align.CENTER, Align.MIN)
+    shape = (
+        Cylinder(4, 20, align=seated)
+        + Pos(0, 0, 10) * Cylinder(8, 3, align=seated)
+        - Cylinder(2, 30, align=seated)
+    )
+    assert only(shape, "hole_ceiling") == []
+
+
 def test_a_counterbore_mouth_on_the_bed_is_the_first_layer():
     """The plate's bottom face is pierced by the pocket too, and warning about the
     first layer is how a checker gets switched off."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,9 +4,11 @@ import asyncio
 import io
 import json
 
+import numpy as np
 import pytest
 import trimesh
 
+from nurb.builder import BRIDGE_TINT
 from nurb.server import Server
 
 PART = """from nurb import *
@@ -91,6 +93,35 @@ def test_rebuild_names_a_non_numeric_variant_from_its_built_values(tmp_path):
     assert server.overrides["thing"] == {"tall": True}
     assert entry["bbox"] == [10.0, 10.0, 20.0]
     assert entry["variant"] == "tall"
+
+
+def test_rebuild_tints_ceilings_against_the_cards_build_direction(tmp_path):
+    root = tmp_path
+    (root / "parts").mkdir()
+    part = root / "parts" / "thing.py"
+    part.write_text(
+        """from nurb import *
+
+@part
+def thing():
+    return Box(6, 6, 20) + Pos(0, 0, 12) * Box(30, 30, 4)
+"""
+    )
+    (root / "parts" / "thing.md").write_text(
+        """# thing
+
+```toml
+[part]
+up = [0, 0, -1]
+```
+"""
+    )
+
+    entry = Server(root).rebuild(part)
+    scene = trimesh.load(io.BytesIO(entry["glb"]), file_type="glb")
+    colors = next(iter(scene.geometry.values())).visual.vertex_colors
+
+    assert not np.any(np.all(colors == BRIDGE_TINT, axis=1))
 
 
 def test_failed_build_has_no_active_variant(tmp_path):
@@ -285,6 +316,15 @@ def test_viewer_matches_websocket_security_to_the_page():
     assert "location.protocol === 'https:' ? 'wss' : 'ws'" in viewer
     assert "new WebSocket(`${scheme}://${location.host}/ws`)" in viewer
     assert "new WebSocket(`ws://${location.host}/ws`)" not in viewer
+
+
+def test_section_reaims_after_a_new_parts_camera_is_restored():
+    from nurb import server as server_mod
+
+    viewer = server_mod.VIEWER.read_text(encoding="utf-8")
+    paint = viewer.split("async function paint", 1)[1].split("// Takes a name", 1)[0]
+    assert "function sectionAttach(reaim) {\n  if (reaim) cutSign = 0;" in viewer
+    assert paint.index("restoreCamera(name, box)") < paint.index("sectionAttach(!keepCamera);")
 
 
 # --- the skill staleness nudge ------------------------------------------------


### PR DESCRIPTION
Closes #57.

A counterbore printed mouth toward the bed floats its ceiling: the shelf the screw head bears on is laid flat over the open pocket, and the smaller hole's first rim is a circle drawn on air. The overhang rule deliberately stays quiet there, because a ceiling with material all around is a bridge, and warning about walkable bridges is how a checker gets switched off. What a bridge cannot carry cleanly is a hole rim inside it. The issue's three proposals, in its order:

**1. `counterbore()` in the part-file vocabulary** (`src/nurb/holes.py`). Returns the cutter for a hole plus head pocket, mouth at the origin opening downward, with two sacrificial bridge layers between pocket and shaft: a slot bridged chord-to-chord across the pocket, then the same slot turned ninety degrees across the first, the technique in the issue's screenshot. Every ceiling in that stack is a short axis-aligned bridge the existing rules already allow, so the stepped output checks completely clean, no special-casing anywhere. The step height defaults to 1mm, exactly the printer's `min_wall`, for the same reason the fin blades are 1mm: the sacrificial laminae between the steps must not read as thin walls. Refusals come with the doctrine's advice in the message, matching `chamfer`'s style. `nurb api` picks the signature up from `__init__` automatically.

**2. The `hole_ceiling` check** (`src/nurb/checks.py`). Found on the B-rep directly: a horizontal downward planar face with an inner wire is a pierced ceiling. A probe above the wire separates a hole (finding, WARN) from a boss hanging through (silent, it carries its own rim), and the bed face is skipped since every mouth pierces the first layer. It also catches the non-screw shape of the same problem, a vertical hole rising out of a bridged channel roof. The finding's message names the remedy.

**3. Teaching assistants.** Per the one-source rule, the guidance lives in the doctrine (a new Printability bullet on when to reach for the helper), which the shipped skill already tells agents to read via `nurb rules` before designing; the skill files themselves stay thin shims and are untouched.

Verified: full suite green (311 passed, examples included, so no example part trips the new rule), cross-section probes confirm the slot orientations, and `nurb check`/`nurb inspect` on a demo part show the naive geometry warning twice and the stepped geometry clean, with `inspect` resolving each finding to its annular ceiling face.