### PR TITLE
Release 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.9.0"
+version = "0.10.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.9.0"
+  version: "0.10.0"
 ---
 
 # nurb

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.9.0"
+  version: "0.10.0"
 ---
 
 # nurb

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Bumps the version to 0.10.0 and matches the `version:` line in both skill files.

Since v0.9.0:
- `crown()`, a one-call rounded rim for variable-height walls (#61)
- stepped bridging holes for floating counterbore ceilings (#59)
- the nurb.dev changelog page and its skill (#60)
- fixes from issue #55 feedback (#58)
- secure WebSockets behind HTTPS proxies (#56)

New public API means a minor bump. Merging this publishes to PyPI and cuts the tag and GitHub release.