### PR TITLE
Add a machine-wide config file and drop STEP from the default export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ nurb update          upgrade nurb, then re-sync the installed skill to match
 nurb card [part]     regenerate a card's AUTO block
 nurb verify [part]   the doctrine's verification list, --strict-ish exit code, --report bundles it with renders
 nurb render [part]   write build/renders/<part>.png, --section cuts it open, needs the render extra
-nurb export [part]   write STL and STEP into build/, --formats for GLB
+nurb export [part]   write STL into build/, --formats for STEP or GLB
 nurb extract         find duplication across sibling parts
 nurb launcher        write viewer.command, a double-clickable `nurb dev`
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ nurb update         upgrade nurb, then re-sync the installed skill to match
 nurb card [part]    regenerate a card's AUTO block
 nurb verify [part]  run the doctrine's verification list; --report bundles it with renders
 nurb render [part]  write a PNG into build/renders/; --section cuts it open
-nurb export [part]  write STL and STEP into build/, --formats for GLB
+nurb export [part]  write STL into build/, --formats for STEP or GLB
 nurb extract        find duplication across parts
 nurb launcher       write viewer.command, a double-clickable `nurb dev`
 ```
@@ -81,7 +81,7 @@ projection_ratio  reach over height, for a part cantilevered off a wall
 build_volume      does it fit the printer at all
 ```
 
-Name your machine once in `printer.toml` (`profile = "bambu_a1_mini"`), or try another with `nurb check --printer prusa_mk4s`. The same file carries the project's export preference: an `[export]` table with `formats = ["stl"]` drops STEP from every `nurb export`, and `--formats` still wins for one run. A part records what it has already justified on its card, so known findings stay silent and new ones are regressions:
+Name your machine once in `printer.toml` (`profile = "bambu_a1_mini"`), or try another with `nurb check --printer prusa_mk4s`. Better: a printer is a fact about your workshop, not your project, so `~/.config/nurb/config.toml` takes the same schema and answers for every project on the machine; `printer.toml` wins where they disagree, and `nurb check` says which file supplied the profile. Either file carries the export preference too: an `[export]` table with `formats = ["stl", "step"]` adds STEP to every `nurb export`, and `--formats` still wins for one run. A part records what it has already justified on its card, so known findings stay silent and new ones are regressions:
 
 ```toml
 [part]

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -55,13 +55,13 @@ nurb inspect [part]   faces, normals, concave edges, each finding on its face; -
 nurb card [part]      regenerate a card's AUTO block
 nurb verify [part]    the doctrine's verification list: solids, flex, checks, card. --report bundles verdict and renders into build/renders/
 nurb render [part]    PNG into build/renders/, so you can look at what you made; --section z:4mm cuts it open
-nurb export [part]    STL and STEP into build/, --formats for GLB
+nurb export [part]    STL into build/, --formats for STEP or GLB
 nurb extract          find duplication across parts
 nurb dev              watch, rebuild, serve the viewer on :7373 or the next free port
 nurb launcher         rewrite viewer.command, the double-clickable `nurb dev` a project is born with
 ```
 
-A standing preference is a file, not a flag you have to remember: a user who never wants STEP gets `formats = ["stl"]` under `[export]` in `printer.toml`, and every bare `nurb export` honors it.
+A standing preference is a file, not a flag you have to remember, and a printer is a fact about the workshop, not the project. When the user tells you what machine they own, record it once in `~/.config/nurb/config.toml` (`profile = "bambu_a1_mini"`) so no project ever asks again; check that file before asking, because they may have answered in an earlier project. The same file takes an `[export]` table (`formats = ["stl", "step"]` for a user who always wants STEP alongside), and every bare `nurb export` honors it. `printer.toml` at the project root takes the same schema and wins where they disagree, which is what makes it the right place for the exception: the one project aimed at a different machine.
 
 Read `parts/<name>.md` before editing `parts/<name>.py`. Its `## Don't` section is what was tried and rejected, and it is the only place that records it.
 

--- a/src/nurb/agents.md
+++ b/src/nurb/agents.md
@@ -49,13 +49,13 @@ nurb inspect [part]   faces, normals, concave edges, each finding on its face; -
 nurb card [part]      regenerate a card's AUTO block
 nurb verify [part]    the doctrine's verification list: solids, flex, checks, card. --report bundles verdict and renders into build/renders/
 nurb render [part]    PNG into build/renders/, so you can look at what you made; --section z:4mm cuts it open
-nurb export [part]    STL and STEP into build/, --formats for GLB
+nurb export [part]    STL into build/, --formats for STEP or GLB
 nurb extract          find duplication across parts
 nurb dev              watch, rebuild, serve the viewer on :7373 or the next free port
 nurb launcher         rewrite viewer.command, the double-clickable `nurb dev` a project is born with
 ```
 
-A standing preference is a file, not a flag you have to remember: a user who never wants STEP gets `formats = ["stl"]` under `[export]` in `printer.toml`, and every bare `nurb export` honors it.
+A standing preference is a file, not a flag you have to remember, and a printer is a fact about the workshop, not the project. When the user tells you what machine they own, record it once in `~/.config/nurb/config.toml` (`profile = "bambu_a1_mini"`) so no project ever asks again; check that file before asking, because they may have answered in an earlier project. The same file takes an `[export]` table (`formats = ["stl", "step"]` for a user who always wants STEP alongside), and every bare `nurb export` honors it. `printer.toml` at the project root takes the same schema and wins where they disagree, which is what makes it the right place for the exception: the one project aimed at a different machine.
 
 Read `parts/<name>.md` before editing `parts/<name>.py`. Its `## Don't` section is what was tried and rejected, and it is the only place that records it.
 

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -772,6 +772,42 @@ PRINTERS = pathlib.Path(__file__).parent / "printers.toml"
 PRINTER_FILE = "printer.toml"  # optional, at the project root, like measurements.toml
 
 
+def global_file():
+    """~/.config/nurb/config.toml, the machine's standing answers.
+
+    A printer is a fact about the workshop, not the project, so it is named once
+    here instead of in every printer.toml. Same schema as printer.toml, read fresh
+    each call because tests move it with XDG_CONFIG_HOME.
+    """
+    import os
+
+    base = os.environ.get("XDG_CONFIG_HOME") or pathlib.Path.home() / ".config"
+    return pathlib.Path(base) / "nurb" / "config.toml"
+
+
+def _read_toml(file, label):
+    import tomllib
+
+    if not file.is_file():
+        return {}
+    try:
+        return tomllib.loads(file.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"{label}: not valid TOML ({exc})") from exc
+
+
+def profile_choice(root):
+    """The profile a project resolves to and where it was named: the project's
+    printer.toml, then the global config. (None, None) when neither says."""
+    block = _read_toml(pathlib.Path(root) / PRINTER_FILE, PRINTER_FILE)
+    if block.get("profile"):
+        return block["profile"], PRINTER_FILE
+    home = _read_toml(global_file(), str(global_file()))
+    if home.get("profile"):
+        return home["profile"], "global"
+    return None, None
+
+
 def profiles():
     """The shipped printer profiles: machine facts, keyed by name."""
     import tomllib
@@ -786,24 +822,19 @@ def _project_root(part_path):
 
 
 def printer(root, name=None):
-    """The machine's Context: a shipped profile, then the project's printer.toml.
+    """The machine's Context: a shipped profile, then the global config, then the
+    project's printer.toml.
 
     A bed size belongs to the machine, not to a part, so it is picked once here
-    rather than written onto every card. The file names a shipped profile and can
-    override any check setting machine-wide; a card still wins for what its part
-    has justified, because `_apply` runs the card on top of this.
+    rather than written onto every card. Either file names a shipped profile and can
+    override any check setting machine-wide; the project's wins over the global's,
+    and a card still wins for what its part has justified, because `_apply` runs the
+    card on top of this.
     """
-    import tomllib
-
     ctx = Context()
-    block = {}
-    file = pathlib.Path(root) / PRINTER_FILE
-    if file.is_file():
-        try:
-            block = tomllib.loads(file.read_text(encoding="utf-8"))
-        except tomllib.TOMLDecodeError as exc:
-            raise ValueError(f"{PRINTER_FILE}: not valid TOML ({exc})") from exc
-    name = name or block.pop("profile", None)
+    home = _read_toml(global_file(), str(global_file()))
+    block = _read_toml(pathlib.Path(root) / PRINTER_FILE, PRINTER_FILE)
+    name = name or block.get("profile") or home.get("profile")
     if name:
         have = profiles()
         if name not in have:
@@ -811,9 +842,11 @@ def printer(root, name=None):
                 f"no printer profile called {name!r}. have: {', '.join(sorted(have))}"
             )
         _apply(ctx, {"printer": have[name]}, f"profile {name!r}")
-    block.pop("profile", None)  # named on the command line, so the file's loses
-    block.pop("export", None)  # a workflow preference, not a machine fact; cmd_export reads it
-    return _apply(ctx, {"printer": block}, PRINTER_FILE)
+    # profile is resolved above; export is a workflow preference cmd_export reads
+    for settings_block, where in ((home, str(global_file())), (block, PRINTER_FILE)):
+        facts = {k: v for k, v in settings_block.items() if k not in ("profile", "export")}
+        _apply(ctx, {"printer": facts}, where)
+    return ctx
 
 
 # --- per part settings -------------------------------------------------------

--- a/src/nurb/cli.py
+++ b/src/nurb/cli.py
@@ -158,6 +158,15 @@ def cmd_check(args):
             base = checks.printer(root, args.printer)
         except ValueError as exc:
             sys.exit(f"  {exc}")
+    else:
+        # A profile picked up from a file is invisible, and invisible is how two
+        # machines check the same part differently for no stated reason.
+        try:
+            profile, source = checks.profile_choice(root)
+        except ValueError:
+            profile = None  # a broken file gets its real error on the first part
+        if profile:
+            print(f"  printer: {profile} ({source})")
     worst = 0
     for path in _resolve(root, args.part):
         configs = _configs(path, base=base)
@@ -215,24 +224,27 @@ def _collect_exports(paths):
     return found
 
 
-def _project_formats(root):
-    """printer.toml's `[export] formats`, the project's standing preference.
+def _standing_formats(root):
+    """`[export] formats`, from the project's printer.toml, then the global config.
 
     A syntax error is left for checks.printer to report, which every export
     reaches on its way to a Context and which names the file and the line.
     """
     import tomllib
 
-    from .checks import PRINTER_FILE
+    from . import checks
 
-    file = root / PRINTER_FILE
-    if not file.is_file():
-        return None
-    try:
-        block = tomllib.loads(file.read_text(encoding="utf-8"))
-    except tomllib.TOMLDecodeError:
-        return None
-    return block.get("export", {}).get("formats")
+    for file in (root / checks.PRINTER_FILE, checks.global_file()):
+        if not file.is_file():
+            continue
+        try:
+            block = tomllib.loads(file.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError:
+            continue
+        formats = block.get("export", {}).get("formats")
+        if formats:
+            return formats
+    return None
 
 
 def _artifact_size(path):
@@ -246,7 +258,7 @@ def cmd_export(args):
     from . import builder, checks
 
     root = project_root()
-    formats = args.formats or _project_formats(root) or list(DEFAULT_FORMATS)
+    formats = args.formats or _standing_formats(root) or list(DEFAULT_FORMATS)
     configs = _collect_exports(_resolve(root, args.part))
     out = root / "build"
     out.mkdir(exist_ok=True)
@@ -285,6 +297,15 @@ def cmd_export(args):
             if fmt == "stl":
                 note += f", {builder.stl_triangles(target):,} triangles"
             print(f"  {target.relative_to(root)}  {note}")
+        # A file this export did not rewrite still sits in build/ looking current,
+        # and a stale STEP shared as fresh is worse than a missing one.
+        for fmt in (f for f in FORMATS if f not in formats):
+            stale = out / f"{name}.{fmt}"
+            if stale.exists():
+                print(
+                    f"  {stale.relative_to(root)}  not rewritten ({fmt} is not in this "
+                    f"export's formats), delete it or add the format"
+                )
 
 
 # What OCCT says when a chamfer will not land. A part refusing to grow in its own words
@@ -502,8 +523,8 @@ ISO = (0.588, -0.630, 0.504)
 def _renders(root):
     """Where every camera-made file lands: stills, sections, finding shots, reports.
 
-    build/ itself is the catalog of deliverables, the STL and STEP a slicer picks
-    from, and pictures were drowning it. Everything made to be looked at rather than
+    build/ itself is the catalog of deliverables, the STL a slicer picks up, and
+    pictures were drowning it. Everything made to be looked at rather than
     printed lives one level down instead.
     """
     return root / "build" / "renders"
@@ -717,7 +738,7 @@ DEFAULT_PORT = 7373
 
 # GLB is the viewer's format, so it is on request rather than written every time.
 FORMATS = ("stl", "step", "glb")
-DEFAULT_FORMATS = ("stl", "step")
+DEFAULT_FORMATS = ("stl",)
 
 
 def _is_free(port):
@@ -897,7 +918,7 @@ def main(argv=None):
     s.add_argument("part", nargs="?")
     s.add_argument(
         "--formats", nargs="+", default=None,
-        help=f"default: {' '.join(DEFAULT_FORMATS)}, or printer.toml's [export] formats. also: glb",
+        help=f"default: {' '.join(DEFAULT_FORMATS)}, or printer.toml's [export] formats. also: step, glb",
     )
     s.set_defaults(fn=cmd_export)
 

--- a/src/nurb/doctrine.md
+++ b/src/nurb/doctrine.md
@@ -241,7 +241,9 @@ Plus two machine-facing pieces:
   the sentence that earns it, because a count on its own is a magic number. Machine facts
   stay out of it: a bed size belongs to the machine, so it lives in `printer.toml` at the
   project root, which names a shipped profile (`profile = "bambu_a1_mini"`) and can
-  override any check setting machine-wide.
+  override any check setting machine-wide. A printer is really a fact about the workshop,
+  not the project, so `~/.config/nurb/config.toml` takes the same schema and covers every
+  project on the machine; `printer.toml` overrides it where they disagree.
 
 ```toml
 [part]

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -654,30 +654,38 @@ class Server:
                 self.clients.discard(client)
 
     async def broadcast(self, entry, kind="rebuilt"):
-        # printer.toml is watched like a part source. Carrying the current bed on the
-        # rebuild is what lets that edit resize an already-open viewer.
+        # Printer settings are watched like part sources. Carrying the current bed on
+        # the rebuild is what lets an edit resize an already-open viewer.
         await self.send({"type": kind, "bed": self._bed(), **self._wire(entry)})
 
     # ---------- watching ----------
 
     def watch(self):
+        from . import checks
+
         server = self
         parts_dir = self.root / "parts"
+        global_config = checks.global_file().resolve()
 
         class Handler(FileSystemEventHandler):
             def on_any_event(self, event):
                 if event.is_directory:
                     return
-                path = pathlib.Path(getattr(event, "dest_path", "") or event.src_path)
+                path = pathlib.Path(
+                    getattr(event, "dest_path", "") or event.src_path
+                ).resolve()
                 # "." skips the atomic-save temp files editors and sed leave behind
                 if path.name.startswith((".", "_")):
                     return
-                # printer.toml changes every part's checks and measurements.toml can
-                # feed any part's geometry, so either rebuilds the project the way
-                # system.py does: they land in the else branch below.
-                if path.suffix not in (".py", ".md") and path.name not in (
-                    "printer.toml",
-                    "measurements.toml",
+                if path != global_config and path.parent not in (parts_dir, server.root):
+                    return
+                # Printer settings change every part's checks, whether they came from
+                # the project or the global config. measurements.toml can feed any
+                # part's geometry, so all three rebuild the whole project below.
+                if (
+                    path != global_config
+                    and path.suffix not in (".py", ".md")
+                    and path.name not in ("printer.toml", "measurements.toml")
                 ):
                     return
                 # A card carries what the part has already justified, so editing one
@@ -702,6 +710,12 @@ class Server:
         self.observer = Observer()
         self.observer.schedule(Handler(), str(parts_dir), recursive=False)
         self.observer.schedule(Handler(), str(self.root), recursive=False)
+        global_dir = global_config.parent
+        if global_dir.is_dir() and global_dir not in {
+            parts_dir.resolve(),
+            self.root.resolve(),
+        }:
+            self.observer.schedule(Handler(), str(global_dir), recursive=False)
         self.observer.daemon = True
         self.observer.start()
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -55,13 +55,13 @@ nurb inspect [part]   faces, normals, concave edges, each finding on its face; -
 nurb card [part]      regenerate a card's AUTO block
 nurb verify [part]    the doctrine's verification list: solids, flex, checks, card. --report bundles verdict and renders into build/renders/
 nurb render [part]    PNG into build/renders/, so you can look at what you made; --section z:4mm cuts it open
-nurb export [part]    STL and STEP into build/, --formats for GLB
+nurb export [part]    STL into build/, --formats for STEP or GLB
 nurb extract          find duplication across parts
 nurb dev              watch, rebuild, serve the viewer on :7373 or the next free port
 nurb launcher         rewrite viewer.command, the double-clickable `nurb dev` a project is born with
 ```
 
-A standing preference is a file, not a flag you have to remember: a user who never wants STEP gets `formats = ["stl"]` under `[export]` in `printer.toml`, and every bare `nurb export` honors it.
+A standing preference is a file, not a flag you have to remember, and a printer is a fact about the workshop, not the project. When the user tells you what machine they own, record it once in `~/.config/nurb/config.toml` (`profile = "bambu_a1_mini"`) so no project ever asks again; check that file before asking, because they may have answered in an earlier project. The same file takes an `[export]` table (`formats = ["stl", "step"]` for a user who always wants STEP alongside), and every bare `nurb export` honors it. `printer.toml` at the project root takes the same schema and wins where they disagree, which is what makes it the right place for the exception: the one project aimed at a different machine.
 
 Read `parts/<name>.md` before editing `parts/<name>.py`. Its `## Don't` section is what was tried and rejected, and it is the only place that records it.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def hermetic_global_config(monkeypatch, tmp_path_factory):
+    """The developer's real ~/.config/nurb/config.toml must never leak into the
+    suite: it names their printer, and every default-context assertion would
+    quietly become an assertion about their workshop."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path_factory.mktemp("xdg")))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -330,13 +330,70 @@ def test_export_reads_the_projects_formats(tmp_path, monkeypatch):
     parts = tmp_path / "parts"
     parts.mkdir()
     (parts / "thing.py").write_text(PLAIN)
-    (tmp_path / "printer.toml").write_text('[export]\nformats = ["stl"]\n')
+    (tmp_path / "printer.toml").write_text('[export]\nformats = ["stl", "step"]\n')
     monkeypatch.chdir(tmp_path)
     cli.cmd_export(argparse.Namespace(part=None, formats=None))
     assert (tmp_path / "build" / "thing.stl").exists()
-    assert not (tmp_path / "build" / "thing.step").exists()
-    cli.cmd_export(argparse.Namespace(part=None, formats=["step"]))
     assert (tmp_path / "build" / "thing.step").exists()
+    (tmp_path / "build" / "thing.step").unlink()
+    cli.cmd_export(argparse.Namespace(part=None, formats=["stl"]))
+    assert not (tmp_path / "build" / "thing.step").exists()
+
+
+def test_export_flags_the_formats_it_left_stale(tmp_path, monkeypatch, capsys):
+    """An old STEP sitting next to a fresh STL looks current, and sharing it as
+    current is the upgrade trap of the STL-only default. The export says so."""
+    import argparse
+
+    parts = tmp_path / "parts"
+    parts.mkdir()
+    (parts / "thing.py").write_text(PLAIN)
+    monkeypatch.chdir(tmp_path)
+    cli.cmd_export(argparse.Namespace(part=None, formats=["stl", "step"]))
+    capsys.readouterr()
+    cli.cmd_export(argparse.Namespace(part=None, formats=["stl"]))
+    out = capsys.readouterr().out
+    assert "thing.step" in out
+    assert "not rewritten" in out
+
+
+def _global_config(text):
+    from nurb.checks import global_file
+
+    global_file().parent.mkdir(parents=True, exist_ok=True)
+    global_file().write_text(text)
+
+
+def test_export_falls_back_to_the_global_formats(tmp_path, monkeypatch):
+    """The global config covers projects that say nothing; printer.toml still wins."""
+    import argparse
+
+    parts = tmp_path / "parts"
+    parts.mkdir()
+    (parts / "thing.py").write_text(PLAIN)
+    _global_config('[export]\nformats = ["stl", "step"]\n')
+    monkeypatch.chdir(tmp_path)
+    cli.cmd_export(argparse.Namespace(part=None, formats=None))
+    assert (tmp_path / "build" / "thing.step").exists()
+    (tmp_path / "build" / "thing.step").unlink()
+    (tmp_path / "printer.toml").write_text('[export]\nformats = ["stl"]\n')
+    cli.cmd_export(argparse.Namespace(part=None, formats=None))
+    assert not (tmp_path / "build" / "thing.step").exists()
+
+
+def test_check_says_where_the_printer_came_from(tmp_path, monkeypatch, capsys):
+    """A profile picked up from a file is invisible without this line, and invisible
+    is how two machines check the same part differently for no stated reason."""
+    parts = tmp_path / "parts"
+    parts.mkdir()
+    (parts / "thing.py").write_text(PLAIN)
+    _global_config('profile = "bambu_a1_mini"\n')
+    monkeypatch.chdir(tmp_path)
+    cli.main(["check"])
+    assert "printer: bambu_a1_mini (global)" in capsys.readouterr().out
+    (tmp_path / "printer.toml").write_text('profile = "prusa_mk4s"\n')
+    cli.main(["check"])
+    assert "printer: prusa_mk4s (printer.toml)" in capsys.readouterr().out
 
 
 def test_stl_is_meshed_for_printing_not_archival(tmp_path):
@@ -358,8 +415,8 @@ def test_stl_is_meshed_for_printing_not_archival(tmp_path):
 
 def test_the_shim_promises_what_export_actually_writes():
     shim = (pathlib.Path(cli.__file__).parent / "agents.md").read_text(encoding="utf-8")
-    assert "STL and STEP" in shim
-    assert list(cli.DEFAULT_FORMATS) == ["stl", "step"]
+    assert "STL into build/" in shim
+    assert list(cli.DEFAULT_FORMATS) == ["stl"]
 
 
 # --- the agent skill ----------------------------------------------------------

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -7,7 +7,7 @@ because the card is applied on top of the machine.
 
 import pytest
 
-from nurb.checks import Context, _apply, from_card, printer, profiles
+from nurb.checks import Context, _apply, from_card, global_file, printer, profiles
 
 
 def project(tmp_path, printer_toml=None, card=None):
@@ -18,6 +18,12 @@ def project(tmp_path, printer_toml=None, card=None):
     if card is not None:
         (tmp_path / "parts" / "thing.md").write_text(card)
     return part
+
+
+def global_config(text):
+    """conftest points XDG_CONFIG_HOME at a fresh directory for every test."""
+    global_file().parent.mkdir(parents=True, exist_ok=True)
+    global_file().write_text(text)
 
 
 def test_every_shipped_profile_is_valid_context_settings():
@@ -75,6 +81,38 @@ def test_the_card_still_wins_for_what_the_part_justified(tmp_path):
 def test_broken_toml_names_the_file(tmp_path):
     project(tmp_path, "profile = \n")
     with pytest.raises(ValueError, match="printer.toml"):
+        printer(tmp_path)
+
+
+# --- the global config -------------------------------------------------------
+
+
+def test_the_global_config_names_the_profile(tmp_path):
+    """A printer is a fact about the workshop, so naming it once covers every project."""
+    project(tmp_path)
+    global_config('profile = "bambu_a1_mini"\n')
+    assert printer(tmp_path).bed == (180.0, 180.0, 180.0)
+
+
+def test_the_projects_profile_beats_the_globals(tmp_path):
+    project(tmp_path, 'profile = "prusa_mk4s"\n')
+    global_config('profile = "bambu_a1_mini"\n')
+    assert printer(tmp_path).bed == (250.0, 210.0, 220.0)
+
+
+def test_a_global_setting_layers_under_the_project(tmp_path):
+    """The global file can override machine facts too, and the project still wins."""
+    project(tmp_path, "min_wall = 1.5\n")
+    global_config("min_wall = 0.8\nbed = [300, 300, 300]\n")
+    ctx = printer(tmp_path)
+    assert ctx.min_wall == 1.5  # the project's
+    assert ctx.bed == (300, 300, 300)  # the global's, unopposed
+
+
+def test_broken_global_toml_names_the_file(tmp_path):
+    project(tmp_path)
+    global_config("profile = \n")
+    with pytest.raises(ValueError, match="config.toml"):
         printer(tmp_path)
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@
 import asyncio
 import io
 import json
+import pathlib
 from types import SimpleNamespace
 
 import numpy as np
@@ -246,6 +247,51 @@ def test_rebuild_broadcast_carries_a_changed_printer_bed(tmp_path):
 
     assert out[0]["type"] == "rebuilt"
     assert out[0]["bed"] == [180, 120]
+
+
+def test_global_config_change_queues_every_part(tmp_path, monkeypatch):
+    """The global printer file lives outside both directories normally watched."""
+    from nurb import checks
+    from nurb import server as server_mod
+
+    config = checks.global_file()
+    config.parent.mkdir(parents=True)
+    config.write_text('profile = "bambu_a1_mini"\n')
+    server = project(tmp_path)
+    server.queue = asyncio.Queue()
+    server.loop = SimpleNamespace(call_soon_threadsafe=lambda fn, arg: fn(arg))
+
+    class FakeObserver:
+        def __init__(self):
+            self.scheduled = []
+
+        def schedule(self, handler, path, recursive):
+            self.scheduled.append((handler, path, recursive))
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(server_mod, "Observer", FakeObserver)
+    server.watch()
+    watched = next(
+        handler
+        for handler, path, _ in server.observer.scheduled
+        if pathlib.Path(path) == config.parent
+    )
+    watched.on_any_event(
+        SimpleNamespace(
+            is_directory=False,
+            src_path=str(config.parent / "unrelated.py"),
+            dest_path="",
+        )
+    )
+    assert server.queue.empty()
+
+    watched.on_any_event(
+        SimpleNamespace(is_directory=False, src_path=str(config), dest_path="")
+    )
+
+    assert server.queue.get_nowait() == str(tmp_path / "parts" / "thing.py")
 
 
 def test_upgrade_declines_outside_a_uv_tool_install(tmp_path):


### PR DESCRIPTION
A printer is a fact about the workshop, not the project, so `~/.config/nurb/config.toml` now takes the same schema as `printer.toml` and answers for every project on the machine: a shipped profile, machine-fact overrides, and an `[export]` table, with the project file winning where they disagree and cards still winning for what a part has justified. `nurb check` opens with `printer: bambu_a1_mini (global)` so a file-supplied profile is never invisible, and `nurb dev` watches the global file so editing it resizes an already-open viewer. `nurb export` now writes STL alone by default, since STEP is one `--formats` away or a standing `[export]` preference in either file, and the export flags any format left in `build/` that it did not rewrite, because a stale STEP next to a fresh STL looks current. The agent skill now tells the agent to record the user's printer globally once and to check that file before asking again, and the suite pins `XDG_CONFIG_HOME` to a temp directory so a developer's real config cannot leak into default-context assertions.