### PR TITLE
Fix the contribute wizard's closing instructions from the first dogfooding run

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -57,7 +57,7 @@ A submission can be any number of trials, including one: `--trials 1` is a valid
 
 Open a PR that copies your `results/<label>/results.jsonl`, each `<task>/trial_<n>/transcript.txt`, and the auditable candidate source into `submissions/<label>/`. Preserve `project/parts/*.py` plus any project-root or package `.py` files they import; leave cards, meshes, renders, and other generated project files out. Replace machine-specific home paths in transcripts and source with `<home>` or `<workspace>`. `results/` itself is gitignored so a submission is always a deliberate copy, never a bulk commit of local runs.
 
-Then run `uv run python -m nurb_evals.site`: the user-facing page at [nurb.dev/benchmarks](https://nurb.dev/benchmarks.html) is generated into `site/benchmarks.html` from the committed submissions, and a test fails when it goes stale. Verdict sentences on that page live in `src/nurb_evals/site.py` and are editorial; a new row renders numbers-only until a maintainer writes one.
+Your PR should also carry the regenerated `site/benchmarks.html`: the page at [nurb.dev/benchmarks](https://nurb.dev/benchmarks.html) is generated from the committed submissions, and a test fails when it goes stale. The wizard regenerates it for you and says so in its closing instructions; on the manual path, run `uv run python -m nurb_evals.site` yourself. Verdict sentences on that page live in `src/nurb_evals/site.py` and are editorial; a new row renders numbers-only until a maintainer writes one.
 
 Rows land on the leaderboard in one of two tiers:
 

--- a/evals/src/nurb_evals/contribute.py
+++ b/evals/src/nurb_evals/contribute.py
@@ -204,16 +204,34 @@ def main():
     if dirty:
         sys.exit(f"sanitizer missed something in {dirty[0]}; please open an issue instead of a PR")
 
+    # The published page regenerates here, not as a step the contributor has to
+    # remember: the submission ships with the benchmarks.html it produces, so the
+    # stale-page test passes on the PR as opened.
+    from . import site as site_module
+
+    paths = sorted(
+        str(p) for p in (EVALS / "submissions").iterdir() if (p / "results.jsonl").is_file()
+    )
+    site_module.SITE.write_text(
+        site_module.render(site_module.summarize(site_module.rows_from(paths))),
+        encoding="utf-8",
+    )
+
+    # First dogfooding run went wrong two ways this text now prevents: the commit
+    # commands ran in a different nurb checkout than the clone the wizard staged
+    # into, and the fork step failed for someone with push access. Absolute paths,
+    # and both routes.
+    repo = EVALS.parent
     print(
-        f"\nDone. Your submission is staged at evals/submissions/{label}/ with "
-        f"machine-specific paths scrubbed.\n\n"
-        f"To put it on the leaderboard, two steps:\n"
-        f"  1. Fork github.com/Shpigford/nurb and commit that directory.\n"
-        f"  2. Open a PR titled 'benchmark row: {label}'.\n\n"
-        f"Or, if you use the GitHub CLI, from the repo root:\n"
-        f"  gh repo fork Shpigford/nurb --clone=false && git checkout -b bench-{label} && "
-        f"git add evals/submissions && git commit -m 'benchmark row: {label}' && "
-        f"gh pr create --title 'benchmark row: {label}' --fill\n\n"
+        f"\nDone. Staged in THIS checkout ({repo}):\n"
+        f"  {sub}\n"
+        f"  {site_module.SITE}  (the regenerated leaderboard page, commit it too)\n\n"
+        f"To put it on the leaderboard, from {repo}:\n"
+        f"  git checkout -b bench-{label}\n"
+        f"  git add evals/submissions site/benchmarks.html\n"
+        f"  git commit -m 'benchmark row: {label}'\n"
+        f"  gh repo fork Shpigford/nurb --clone=false   # skip if you have push access\n"
+        f"  gh pr create --title 'benchmark row: {label}' --fill\n\n"
         f"Every run counts, including a single one: matching rows pool on the "
         f"leaderboard, and a bad score is data, not an embarrassment."
     )

--- a/evals/tests/test_contribute.py
+++ b/evals/tests/test_contribute.py
@@ -48,7 +48,10 @@ def test_wizard_runs_and_stages_a_sanitized_submission(tmp_path, monkeypatch, ca
     shutil.copy(real / "models.toml", root / "models.toml")
     os.symlink(real / "tasks" / "cable_clip", root / "tasks" / "cable_clip")
 
+    from nurb_evals import site
+
     monkeypatch.setattr(contribute, "EVALS", root)
+    monkeypatch.setattr(site, "SITE", root / "benchmarks.html")
     monkeypatch.setattr(contribute.shutil, "which", lambda name: "/usr/bin/true")
     monkeypatch.setitem(harnesses.HARNESSES, "stub", Stub(GOOD))
     monkeypatch.setattr(
@@ -79,5 +82,12 @@ def test_wizard_runs_and_stages_a_sanitized_submission(tmp_path, monkeypatch, ca
     for staged in sub.rglob("*"):
         if staged.is_file():
             assert str(pathlib.Path.home()) not in staged.read_text(errors="replace")
+    # The wizard regenerates the published page itself, so a PR ships with the
+    # benchmarks.html its rows produce and the stale-page test passes as opened.
+    page = (root / "benchmarks.html").read_text(encoding="utf-8")
+    assert "stub-model" in page
+
     printed = capsys.readouterr().out
-    assert "staged at" in printed and "benchmark row: stub-stub-model-low" in printed
+    assert "Staged in THIS checkout" in printed and str(root) in printed
+    assert "benchmark row: stub-stub-model-low" in printed
+    assert "skip if you have push access" in printed


### PR DESCRIPTION
From Josh's first real run of `bench.sh`:

- The printed commit commands assumed you were in your main nurb checkout, but the wizard stages into the `nurb-bench` clone it runs in — the instructions now print absolute paths and say plainly which checkout the submission lives in.
- `gh repo fork` fails for anyone with push access to the repo; the fork step is now explicitly skippable.
- Regenerating `site/benchmarks.html` was a step the contributor had to remember; the wizard now does it itself, so a PR ships with the page its rows produce and the stale-page test passes as opened. `evals/README.md` reflects the split (wizard: automatic; manual path: run `python -m nurb_evals.site`).

The wizard's end-to-end test now asserts the regenerated page and the corrected instructions.