### PR TITLE
Generate REPORT.md from the submissions

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -57,7 +57,7 @@ A submission can be any number of trials, including one: `--trials 1` is a valid
 
 Open a PR that copies your `results/<label>/results.jsonl`, each `<task>/trial_<n>/transcript.txt`, and the auditable candidate source into `submissions/<label>/`. Preserve `project/parts/*.py` plus any project-root or package `.py` files they import; leave cards, meshes, renders, and other generated project files out. Replace machine-specific home paths in transcripts and source with `<home>` or `<workspace>`. `results/` itself is gitignored so a submission is always a deliberate copy, never a bulk commit of local runs.
 
-Your PR should also carry the regenerated `site/benchmarks.html`: the page at [nurb.dev/benchmarks](https://nurb.dev/benchmarks.html) is generated from the committed submissions, and a test fails when it goes stale. The wizard regenerates it for you and says so in its closing instructions; on the manual path, run `uv run python -m nurb_evals.site` yourself. Verdict sentences on that page live in `src/nurb_evals/site.py` and are editorial; a new row renders numbers-only until a maintainer writes one.
+Your PR should also carry the two generated artifacts, `site/benchmarks.html` and `evals/REPORT.md`: both are generated from the committed submissions and a test fails when either goes stale. The wizard regenerates both for you and says so in its closing instructions; on the manual path, run `uv run python -m nurb_evals.site` and `uv run python -m nurb_evals.report --write` yourself. Verdict sentences on the page live in `src/nurb_evals/site.py` and are editorial; a new row renders numbers-only until a maintainer writes one.
 
 Rows land on the leaderboard in one of two tiers:
 

--- a/evals/REPORT.md
+++ b/evals/REPORT.md
@@ -1,9 +1,9 @@
 # nurb leaderboard
 
-No rows yet: the benchmark was reset before its first deploy, so every published row will come from the released pipeline, run exactly as the instructions describe. Run one on your own subscription:
+Generated from the committed submissions by `python -m nurb_evals.report --write`, so it can never disagree with them; the reader-facing version is [nurb.dev/benchmarks](https://nurb.dev/benchmarks.html), built from the same rows. Matching rows pool across submissions, single runs included, and every row's transcripts and parts live under [submissions/](submissions/). See [README.md](README.md) to run one.
+
+No rows yet. Run one on your own subscription:
 
 ```
 curl -fsSL https://nurb.dev/bench.sh | sh
 ```
-
-See [README.md](README.md) for how rows work, the task classes, and how submissions pool. The rendered leaderboard lives at [nurb.dev/benchmarks](https://nurb.dev/benchmarks.html), generated from the committed submissions by `python -m nurb_evals.site`.

--- a/evals/src/nurb_evals/contribute.py
+++ b/evals/src/nurb_evals/contribute.py
@@ -207,6 +207,7 @@ def main():
     # The published page regenerates here, not as a step the contributor has to
     # remember: the submission ships with the benchmarks.html it produces, so the
     # stale-page test passes on the PR as opened.
+    from . import report as report_module
     from . import site as site_module
 
     paths = sorted(
@@ -216,6 +217,7 @@ def main():
         site_module.render(site_module.summarize(site_module.rows_from(paths))),
         encoding="utf-8",
     )
+    report_module.write(EVALS / "submissions", EVALS / "REPORT.md")
 
     # First dogfooding run went wrong two ways this text now prevents: the commit
     # commands ran in a different nurb checkout than the clone the wizard staged
@@ -225,10 +227,11 @@ def main():
     print(
         f"\nDone. Staged in THIS checkout ({repo}):\n"
         f"  {sub}\n"
-        f"  {site_module.SITE}  (the regenerated leaderboard page, commit it too)\n\n"
+        f"  {site_module.SITE}  (the regenerated leaderboard page)\n"
+        f"  {EVALS / 'REPORT.md'}  (the regenerated report)\n\n"
         f"To put it on the leaderboard, from {repo}:\n"
         f"  git checkout -b bench-{label}\n"
-        f"  git add evals/submissions site/benchmarks.html\n"
+        f"  git add evals/submissions evals/REPORT.md site/benchmarks.html\n"
         f"  git commit -m 'benchmark row: {label}'\n"
         f"  gh repo fork Shpigford/nurb --clone=false   # skip if you have push access\n"
         f"  gh pr create --title 'benchmark row: {label}' --fill\n\n"

--- a/evals/src/nurb_evals/report.py
+++ b/evals/src/nurb_evals/report.py
@@ -142,10 +142,46 @@ def table(summary):
     return "\n".join(lines).rstrip() + "\n"
 
 
+EVALS = pathlib.Path(__file__).parents[2]
+
+HEADER = """\
+# nurb leaderboard
+
+Generated from the committed submissions by `python -m nurb_evals.report --write`, so it can never disagree with them; the reader-facing version is [nurb.dev/benchmarks](https://nurb.dev/benchmarks.html), built from the same rows. Matching rows pool across submissions, single runs included, and every row's transcripts and parts live under [submissions/](submissions/). See [README.md](README.md) to run one.
+"""
+
+EMPTY = """\
+No rows yet. Run one on your own subscription:
+
+```
+curl -fsSL https://nurb.dev/bench.sh | sh
+```
+"""
+
+
+def write(submissions=None, out=None):
+    """Regenerate REPORT.md from the committed submissions. The contribute wizard
+    calls this so a PR ships with the report its rows produce."""
+    submissions = pathlib.Path(submissions or EVALS / "submissions")
+    out = pathlib.Path(out or EVALS / "REPORT.md")
+    summary = summarize(rows_from(sorted(submissions.glob("*/results.jsonl"))))
+    body = table(summary) if summary else EMPTY
+    out.write_text(HEADER + "\n" + body, encoding="utf-8")
+    return out
+
+
 def main():
     ap = argparse.ArgumentParser(description="results.jsonl rows to a leaderboard table")
-    ap.add_argument("results", nargs="+", help="results.jsonl files or their directories")
+    ap.add_argument("results", nargs="*", help="results.jsonl files or their directories")
+    ap.add_argument(
+        "--write", action="store_true", help="regenerate REPORT.md from the committed submissions"
+    )
     args = ap.parse_args()
+    if args.write:
+        print(f"wrote {write()}")
+        return
+    if not args.results:
+        ap.error("results paths required unless --write")
     sys.stdout.write(table(summarize(rows_from(args.results))))
 
 

--- a/evals/tests/test_contribute.py
+++ b/evals/tests/test_contribute.py
@@ -86,6 +86,7 @@ def test_wizard_runs_and_stages_a_sanitized_submission(tmp_path, monkeypatch, ca
     # benchmarks.html its rows produce and the stale-page test passes as opened.
     page = (root / "benchmarks.html").read_text(encoding="utf-8")
     assert "stub-model" in page
+    assert "stub-model" in (root / "REPORT.md").read_text(encoding="utf-8")
 
     printed = capsys.readouterr().out
     assert "Staged in THIS checkout" in printed and str(root) in printed

--- a/evals/tests/test_report.py
+++ b/evals/tests/test_report.py
@@ -125,14 +125,12 @@ def test_committed_submission_artifacts_are_complete_and_sanitized():
     # from community and maintainer runs of the released pipeline.
 
 
-def test_committed_report_rows_match_the_submissions():
-    evals = pathlib.Path(__file__).parents[1]
-    submitted = report.rows_from(sorted((evals / "submissions").glob("*/results.jsonl")))
-    generated = report.table(report.summarize(submitted))
-    committed = (evals / "REPORT.md").read_text(encoding="utf-8")
-    for line in generated.splitlines():
-        if line.startswith("|"):
-            assert line in committed
+def test_committed_report_matches_the_submissions(tmp_path):
+    """REPORT.md is generated, never hand-edited, so submissions and report can
+    never drift; the wizard regenerates it with every staged contribution."""
+    regenerated = report.write(out=tmp_path / "REPORT.md").read_text(encoding="utf-8")
+    committed = (pathlib.Path(__file__).parents[1] / "REPORT.md").read_text(encoding="utf-8")
+    assert committed == regenerated, "REPORT.md is stale: run python -m nurb_evals.report --write"
 
 
 def test_site_page_renders_from_the_committed_submissions():


### PR DESCRIPTION
The first dogfooded row (#69) failed CI because REPORT.md was hand-written prose around pasted tables: nothing regenerated it when rows landed. REPORT.md is now fully generated (`python -m nurb_evals.report --write`), the wizard regenerates it alongside the page, the staleness test compares full content the way the page's test does, and the wizard's printed `git add` names all three artifacts.