### PR TITLE
The wizard opens the pull request itself

### DIFF
--- a/.claude/skills/leaderboard/SKILL.md
+++ b/.claude/skills/leaderboard/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: leaderboard
+description: Publish the nurb model leaderboard from merged benchmark submissions. Sanity-checks every run landed since the last regeneration, writes or refreshes the editorial verdicts, regenerates evals/REPORT.md and site/benchmarks.html, and opens the publish PR. Use when the user says "update the leaderboard", "publish the benchmarks", "regenerate the benchmark page", or after merging submission PRs.
+---
+
+# nurb leaderboard
+
+Two generated surfaces, one editorial layer. `evals/REPORT.md` (audit tables) and `site/benchmarks.html` (the page behind nurb.dev/benchmarks) both regenerate mechanically from `evals/submissions/`; the verdict sentences and subscription labels live in `evals/src/nurb_evals/site.py` and are written by a person. Submission PRs are pure additions and merge freely; nothing reaches the public page until this skill runs. That gap is deliberate: it is where the sanity check and the verdicts happen, so publishing is an editorial act, not a side effect of merging.
+
+## Step 1: Find what is new
+
+The runs added since the page was last regenerated:
+
+```bash
+git log -1 --format=%H -- site/benchmarks.html
+git diff --stat <that-commit>..HEAD -- evals/submissions/
+```
+
+Each new directory under `evals/submissions/` is one run: `<harness>-<model>-<effort>-<hex>/` holding `results.jsonl` plus per-trial transcripts and part sources. If nothing is new, say so and stop.
+
+## Step 2: Sanity-check every new run
+
+Work from `evals/` (its own uv project; `uv sync --locked` first if the venv is stale). For each new run directory:
+
+- **Rows parse and carry full identity**: every line of `results.jsonl` has harness, harness_version, model, effort, seed, nurb_version, benchmark_version, a 12-char benchmark_revision, and timeout_s. A benchmark_revision that matches no revision this repo ever shipped is disqualifying.
+- **Artifacts are complete and sanitized**: a transcript and the part source for every row; no `/Users/`, `/home/`, or usernames anywhere (the suite's sanitization test enforces this too).
+- **The parts are authored, not planted**: hash the submitted part files against `evals/tests/solutions/` and against parts from other submissions. An exact match with a reference solution is disqualifying; matches across unrelated submissions are worth reading.
+- **Spot-check by re-grading**: for at least one row per new run (and every row that looks too good), rebuild the trial project (`task.materialize`, drop the part in, restore the submitted `measurements.toml` for leg_cup) and run the grader. The committed score must reproduce exactly; grading is deterministic.
+- **Read one transcript** per new contributor: the headless preamble held (no `nurb dev`), the model actually iterated, and the session matches the row's timings.
+
+A run that fails a check is removed from the PR with a comment saying which check and why, not silently. Suspicion is not proof: when a re-grade mismatches, check the benchmark_revision first; a row graded under an older shipped revision reproduces under that revision's scorer, not today's.
+
+## Step 3: Verdicts
+
+Every (harness, model, effort) combo on the board should have an entry in `VERDICTS` in `evals/src/nurb_evals/site.py`: which subscription it runs on, and one or two sentences a person with a printer can act on. Ground every claim in the rows and transcripts (findings, timings, the honesty tasks); never speculate. A new combo without a verdict renders numbers-only, which is acceptable for a day, not a policy. Capped or censored data is named as such ("hit the session limit"), never averaged into a claim.
+
+## Step 4: Regenerate, look, publish
+
+```bash
+cd evals
+uv run python -m nurb_evals.report --write
+uv run python -m nurb_evals.site
+```
+
+Open `site/benchmarks.html` in a browser and look at it before publishing: label collisions on the chart, a card wrapping badly, an empty state showing when rows exist. Screenshot, not DOM-query. Then a PR (never straight to main): the regenerated pair, any verdict edits, and a body that lists which runs were published and which were rejected with reasons. `uv run pytest -q` from `evals/` must be green.
+
+The page deploys with `site/` however the site deploys; this skill's job ends at the merged PR.

--- a/evals/README.md
+++ b/evals/README.md
@@ -30,7 +30,7 @@ The easy way is the wizard, from anywhere (or paste the line to your AI and let 
 curl -fsSL https://nurb.dev/bench.sh | sh
 ```
 
-It detects which agent CLIs you have, offers the models from a menu so you never guess a spelling, runs the trials on your subscription, sanitizes the artifacts, regenerates the report and the page, and then offers to open the pull request itself with the GitHub CLI: branch, commit, push, fork only if you lack push access, PR URL printed. Re-running the same model and effort appends to the same branch and updates the same PR, which is how one contributor's runs pool. Agents and scripts can skip every question with flags: `uv run python -m nurb_evals.contribute --harness claude --model sonnet --effort medium --pr yes`.
+It detects which agent CLIs you have, offers the models from a menu so you never guess a spelling, runs the trials on your subscription, sanitizes the artifacts, and then offers to open the pull request itself with the GitHub CLI: branch, commit, push, fork only if you lack push access, PR URL printed. Every run is its own uniquely named directory, branch, and PR, so run it as many times as you like, even concurrently: more runs mean tighter numbers, and matching rows pool on the leaderboard no matter which PR they arrived in. Agents and scripts can skip every question with flags: `uv run python -m nurb_evals.contribute --harness claude --model sonnet --effort medium --pr yes`.
 
 The manual way needs `uv` and the `claude` or `codex` CLI installed and logged in to your own subscription. Then:
 
@@ -57,7 +57,7 @@ A submission can be any number of trials, including one: `--trials 1` is a valid
 
 Open a PR that copies your `results/<label>/results.jsonl`, each `<task>/trial_<n>/transcript.txt`, and the auditable candidate source into `submissions/<label>/`. Preserve `project/parts/*.py` plus any project-root or package `.py` files they import; leave cards, meshes, renders, and other generated project files out. Replace machine-specific home paths in transcripts and source with `<home>` or `<workspace>`. `results/` itself is gitignored so a submission is always a deliberate copy, never a bulk commit of local runs.
 
-Your PR should also carry the two generated artifacts, `site/benchmarks.html` and `evals/REPORT.md`: both are generated from the committed submissions and a test fails when either goes stale. The wizard regenerates both for you and says so in its closing instructions; on the manual path, run `uv run python -m nurb_evals.site` and `uv run python -m nurb_evals.report --write` yourself. Verdict sentences on the page live in `src/nurb_evals/site.py` and are editorial; a new row renders numbers-only until a maintainer writes one.
+Your PR carries only your run's directory, nothing else: submission PRs are pure additions, which is what lets any number of them, from any number of people or concurrent sessions, merge in any order without a conflict. `evals/REPORT.md` and the page at [nurb.dev/benchmarks](https://nurb.dev/benchmarks.html) are regenerated from the merged submissions when a maintainer publishes the leaderboard, which is also when new runs get their sanity check (the spot-check policy above) and new model combos get their verdict sentences. Your row appearing on the page a few days after your PR merges is that process working, not your submission being lost.
 
 Rows land on the leaderboard in one of two tiers:
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -30,7 +30,7 @@ The easy way is the wizard, from anywhere (or paste the line to your AI and let 
 curl -fsSL https://nurb.dev/bench.sh | sh
 ```
 
-It detects which agent CLIs you have, offers the models from a menu so you never guess a spelling, runs the trials on your subscription, sanitizes the artifacts, and stages a submission-ready directory with the PR command printed at the end. Agents and scripts can skip the questions with flags: `uv run python -m nurb_evals.contribute --harness claude --model sonnet --effort medium`.
+It detects which agent CLIs you have, offers the models from a menu so you never guess a spelling, runs the trials on your subscription, sanitizes the artifacts, regenerates the report and the page, and then offers to open the pull request itself with the GitHub CLI: branch, commit, push, fork only if you lack push access, PR URL printed. Re-running the same model and effort appends to the same branch and updates the same PR, which is how one contributor's runs pool. Agents and scripts can skip every question with flags: `uv run python -m nurb_evals.contribute --harness claude --model sonnet --effort medium --pr yes`.
 
 The manual way needs `uv` and the `claude` or `codex` CLI installed and logged in to your own subscription. Then:
 

--- a/evals/src/nurb_evals/contribute.py
+++ b/evals/src/nurb_evals/contribute.py
@@ -16,6 +16,7 @@ import json
 import pathlib
 import re
 import shutil
+import subprocess
 import sys
 import tomllib
 
@@ -116,6 +117,12 @@ def main():
     ap.add_argument("--tasks", default=",".join(TASKS), help="comma-separated, default all")
     ap.add_argument("--seed", type=int, default=SEED)
     ap.add_argument("--timeout", type=float, default=3600.0)
+    ap.add_argument(
+        "--pr",
+        choices=("ask", "yes", "no"),
+        default="ask",
+        help="open the pull request automatically (default: ask)",
+    )
     args = ap.parse_args()
 
     print("\nnurb benchmark contribution\n———————————————————————————")
@@ -219,21 +226,111 @@ def main():
     )
     report_module.write(EVALS / "submissions", EVALS / "REPORT.md")
 
-    # First dogfooding run went wrong two ways this text now prevents: the commit
-    # commands ran in a different nurb checkout than the clone the wizard staged
-    # into, and the fork step failed for someone with push access. Absolute paths,
-    # and both routes.
     repo = EVALS.parent
     print(
-        f"\nDone. Staged in THIS checkout ({repo}):\n"
+        f"\nDone. Staged in this checkout ({repo}):\n"
         f"  {sub}\n"
-        f"  {site_module.SITE}  (the regenerated leaderboard page)\n"
-        f"  {EVALS / 'REPORT.md'}  (the regenerated report)\n\n"
-        f"To put it on the leaderboard, from {repo}:\n"
-        f"  git checkout -b bench-{label}\n"
+        f"  {site_module.SITE}\n"
+        f"  {EVALS / 'REPORT.md'}\n"
+    )
+
+    # Handing a contributor five git commands is where two dogfooding runs died
+    # (wrong checkout, stale branch, accidental nested-repo add). The wizard owns
+    # the whole submission: it knows the right checkout because it is standing in it.
+    want = args.pr
+    if want == "ask":
+        if _gh_ready(repo):
+            try:
+                raw = input("Open the pull request now? [Y/n]: ").strip().lower()
+                want = "no" if raw in ("n", "no") else "yes"
+            except EOFError:
+                want = "no"
+        else:
+            print("GitHub CLI (gh) not found or not signed in; printing the manual steps.")
+            want = "no"
+    if want == "yes":
+        url, problem = open_pr(label, repo)
+        if url:
+            print(
+                f"\nSubmitted: {url}\n\n"
+                f"Every run counts, including a single one: matching rows pool on the "
+                f"leaderboard, and a bad score is data, not an embarrassment."
+            )
+            return
+        print(f"\nCould not open the PR automatically ({problem}); the manual steps:")
+    _manual_steps(label, repo)
+
+
+def _gh_ready(repo):
+    if not shutil.which("gh"):
+        return False
+    return _run(["gh", "auth", "status"], repo).returncode == 0
+
+
+def _run(cmd, cwd):
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+
+
+def _tail(done):
+    text = (done.stderr or done.stdout or "").strip()
+    return text.splitlines()[-1] if text else f"exit {done.returncode}"
+
+
+def open_pr(label, repo):
+    """Branch, commit, push, and open the PR from the wizard's own checkout,
+    forking first only when push access is missing. Re-running the same label
+    appends to the same branch, which updates the same PR: that is how one
+    contributor's runs pool. Returns (url, None) or (None, what went wrong)."""
+    branch = f"bench-{label}"
+    if _run(["git", "rev-parse", "--verify", branch], repo).returncode == 0:
+        done = _run(["git", "checkout", branch], repo)
+    else:
+        done = _run(["git", "checkout", "-b", branch], repo)
+    if done.returncode != 0:
+        return None, f"git checkout: {_tail(done)}"
+
+    _run(["git", "add", "evals/submissions", "evals/REPORT.md", "site/benchmarks.html"], repo)
+    done = _run(["git", "commit", "-m", f"benchmark row: {label}"], repo)
+    if done.returncode != 0 and "nothing to commit" not in (done.stdout + done.stderr):
+        return None, f"git commit: {_tail(done)}"
+
+    push = _run(["git", "push", "-u", "origin", branch], repo)
+    if push.returncode != 0:
+        fork = _run(["gh", "repo", "fork", "--remote", "--remote-name", "fork"], repo)
+        if fork.returncode != 0:
+            return None, f"gh repo fork: {_tail(fork)}"
+        push = _run(["git", "push", "-u", "fork", branch], repo)
+        if push.returncode != 0:
+            return None, f"git push: {_tail(push)}"
+
+    done = _run(
+        [
+            "gh", "pr", "create",
+            "--title", f"benchmark row: {label}",
+            "--body",
+            "Automated submission from the contribute wizard. Matching rows pool on "
+            "the leaderboard; transcripts, parts, and the regenerated report and "
+            "page are included.",
+        ],
+        repo,
+    )
+    if done.returncode == 0:
+        return done.stdout.strip().splitlines()[-1], None
+    # A PR for this branch may already exist from an earlier run of the same label.
+    view = _run(["gh", "pr", "view", branch, "--json", "url", "-q", ".url"], repo)
+    if view.returncode == 0 and view.stdout.strip():
+        return view.stdout.strip(), None
+    return None, f"gh pr create: {_tail(done)}"
+
+
+def _manual_steps(label, repo):
+    print(
+        f"\nFrom {repo}:\n"
+        f"  git checkout -b bench-{label}   # or 'git checkout bench-{label}' if it exists\n"
         f"  git add evals/submissions evals/REPORT.md site/benchmarks.html\n"
         f"  git commit -m 'benchmark row: {label}'\n"
-        f"  gh repo fork Shpigford/nurb --clone=false   # skip if you have push access\n"
+        f"  gh repo fork Shpigford/nurb --remote   # skip if you have push access\n"
+        f"  git push -u origin bench-{label}\n"
         f"  gh pr create --title 'benchmark row: {label}' --fill\n\n"
         f"Every run counts, including a single one: matching rows pool on the "
         f"leaderboard, and a bad score is data, not an embarrassment."

--- a/evals/src/nurb_evals/contribute.py
+++ b/evals/src/nurb_evals/contribute.py
@@ -15,6 +15,7 @@ import getpass
 import json
 import pathlib
 import re
+import secrets
 import shutil
 import subprocess
 import sys
@@ -168,8 +169,14 @@ def main():
     )
 
     tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
+    # Every run gets its own directory, branch, and PR: the same person running the
+    # same combo ten times, or in three sessions at once, produces ten independent
+    # pure-addition PRs that merge in any order with zero conflicts. Matching rows
+    # pool by identity no matter which directory they arrive in.
+    run_id = secrets.token_hex(3)
     label = f"{name}-{model}-{effort}"
-    out = EVALS / "results" / label
+    run_name = f"{label}-{run_id}"
+    out = EVALS / "results" / run_name
     out.mkdir(parents=True, exist_ok=True)
     minutes = len(tasks) * args.trials * 8
     print(
@@ -193,13 +200,13 @@ def main():
                 sink.flush()
                 note = f"  ({row['error']})" if row["error"] else ""
                 print(f"[{task} trial {n}] score {row['score']:.3f}{note}", flush=True)
-                staged.append(stage_submission(out, label, task, n))
+                staged.append(stage_submission(out, run_name, task, n))
 
     # The staged submission needs the matching rows; sanitize the whole file so a
     # custom --out or odd path never leaks through a row's error string.
     pairs = replacements(out)
     rows_text = (out / "results.jsonl").read_text(encoding="utf-8")
-    sub = EVALS / "submissions" / label
+    sub = EVALS / "submissions" / run_name
     (sub / "results.jsonl").write_text(sanitize(rows_text, pairs), encoding="utf-8")
 
     leak = re.compile(re.escape(str(pathlib.Path.home())) + r"|" + re.escape(getpass.getuser()))
@@ -211,28 +218,12 @@ def main():
     if dirty:
         sys.exit(f"sanitizer missed something in {dirty[0]}; please open an issue instead of a PR")
 
-    # The published page regenerates here, not as a step the contributor has to
-    # remember: the submission ships with the benchmarks.html it produces, so the
-    # stale-page test passes on the PR as opened.
-    from . import report as report_module
-    from . import site as site_module
-
-    paths = sorted(
-        str(p) for p in (EVALS / "submissions").iterdir() if (p / "results.jsonl").is_file()
-    )
-    site_module.SITE.write_text(
-        site_module.render(site_module.summarize(site_module.rows_from(paths))),
-        encoding="utf-8",
-    )
-    report_module.write(EVALS / "submissions", EVALS / "REPORT.md")
-
+    # The submission is deliberately a pure addition: one new directory, nothing
+    # shared touched. REPORT.md and the page regenerate on main after merge (the
+    # leaderboard workflow), so any number of open submission PRs merge in any
+    # order without a conflict.
     repo = EVALS.parent
-    print(
-        f"\nDone. Staged in this checkout ({repo}):\n"
-        f"  {sub}\n"
-        f"  {site_module.SITE}\n"
-        f"  {EVALS / 'REPORT.md'}\n"
-    )
+    print(f"\nDone. Staged in this checkout ({repo}):\n  {sub}\n")
 
     # Handing a contributor five git commands is where two dogfooding runs died
     # (wrong checkout, stale branch, accidental nested-repo add). The wizard owns
@@ -249,16 +240,17 @@ def main():
             print("GitHub CLI (gh) not found or not signed in; printing the manual steps.")
             want = "no"
     if want == "yes":
-        url, problem = open_pr(label, repo)
+        url, problem = open_pr(run_name, repo)
         if url:
             print(
                 f"\nSubmitted: {url}\n\n"
                 f"Every run counts, including a single one: matching rows pool on the "
-                f"leaderboard, and a bad score is data, not an embarrassment."
+                f"leaderboard, and a bad score is data, not an embarrassment. Run it "
+                f"again whenever you like; every run is its own PR."
             )
             return
         print(f"\nCould not open the PR automatically ({problem}); the manual steps:")
-    _manual_steps(label, repo)
+    _manual_steps(run_name, repo)
 
 
 def _gh_ready(repo):
@@ -276,22 +268,23 @@ def _tail(done):
     return text.splitlines()[-1] if text else f"exit {done.returncode}"
 
 
-def open_pr(label, repo):
+def open_pr(run_name, repo):
     """Branch, commit, push, and open the PR from the wizard's own checkout,
-    forking first only when push access is missing. Re-running the same label
-    appends to the same branch, which updates the same PR: that is how one
-    contributor's runs pool. Returns (url, None) or (None, what went wrong)."""
-    branch = f"bench-{label}"
-    if _run(["git", "rev-parse", "--verify", branch], repo).returncode == 0:
-        done = _run(["git", "checkout", branch], repo)
-    else:
-        done = _run(["git", "checkout", "-b", branch], repo)
+    forking first only when push access is missing. The branch is unique per run
+    and carries only this run's directory, branched from origin's main, so any
+    number of runs from any number of sessions produce independent PRs that merge
+    in any order. Returns (url, None) or (None, what went wrong)."""
+    branch = f"bench-{run_name}"
+    base = ["-b", branch]
+    if _run(["git", "fetch", "origin", "main"], repo).returncode == 0:
+        base += ["FETCH_HEAD"]
+    done = _run(["git", "checkout", *base], repo)
     if done.returncode != 0:
         return None, f"git checkout: {_tail(done)}"
 
-    _run(["git", "add", "evals/submissions", "evals/REPORT.md", "site/benchmarks.html"], repo)
-    done = _run(["git", "commit", "-m", f"benchmark row: {label}"], repo)
-    if done.returncode != 0 and "nothing to commit" not in (done.stdout + done.stderr):
+    _run(["git", "add", f"evals/submissions/{run_name}"], repo)
+    done = _run(["git", "commit", "-m", f"benchmark run: {run_name}"], repo)
+    if done.returncode != 0:
         return None, f"git commit: {_tail(done)}"
 
     push = _run(["git", "push", "-u", "origin", branch], repo)
@@ -306,32 +299,28 @@ def open_pr(label, repo):
     done = _run(
         [
             "gh", "pr", "create",
-            "--title", f"benchmark row: {label}",
+            "--title", f"benchmark run: {run_name}",
             "--body",
-            "Automated submission from the contribute wizard. Matching rows pool on "
-            "the leaderboard; transcripts, parts, and the regenerated report and "
-            "page are included.",
+            "Automated submission from the contribute wizard: one run, one new "
+            "directory, nothing shared touched. Matching rows pool on the "
+            "leaderboard, and the report and page regenerate on main after merge.",
         ],
         repo,
     )
-    if done.returncode == 0:
-        return done.stdout.strip().splitlines()[-1], None
-    # A PR for this branch may already exist from an earlier run of the same label.
-    view = _run(["gh", "pr", "view", branch, "--json", "url", "-q", ".url"], repo)
-    if view.returncode == 0 and view.stdout.strip():
-        return view.stdout.strip(), None
-    return None, f"gh pr create: {_tail(done)}"
+    if done.returncode != 0:
+        return None, f"gh pr create: {_tail(done)}"
+    return done.stdout.strip().splitlines()[-1], None
 
 
-def _manual_steps(label, repo):
+def _manual_steps(run_name, repo):
     print(
         f"\nFrom {repo}:\n"
-        f"  git checkout -b bench-{label}   # or 'git checkout bench-{label}' if it exists\n"
-        f"  git add evals/submissions evals/REPORT.md site/benchmarks.html\n"
-        f"  git commit -m 'benchmark row: {label}'\n"
+        f"  git checkout -b bench-{run_name}\n"
+        f"  git add evals/submissions/{run_name}\n"
+        f"  git commit -m 'benchmark run: {run_name}'\n"
         f"  gh repo fork Shpigford/nurb --remote   # skip if you have push access\n"
-        f"  git push -u origin bench-{label}\n"
-        f"  gh pr create --title 'benchmark row: {label}' --fill\n\n"
+        f"  git push -u origin bench-{run_name}\n"
+        f"  gh pr create --title 'benchmark run: {run_name}' --fill\n\n"
         f"Every run counts, including a single one: matching rows pool on the "
         f"leaderboard, and a bad score is data, not an embarrassment."
     )

--- a/evals/tests/test_contribute.py
+++ b/evals/tests/test_contribute.py
@@ -64,6 +64,7 @@ def test_wizard_runs_and_stages_a_sanitized_submission(tmp_path, monkeypatch, ca
             "--effort", "low",
             "--tasks", "cable_clip",
             "--seed", str(SEED),
+            "--pr", "no",
         ],
     )
     contribute.main()
@@ -89,6 +90,43 @@ def test_wizard_runs_and_stages_a_sanitized_submission(tmp_path, monkeypatch, ca
     assert "stub-model" in (root / "REPORT.md").read_text(encoding="utf-8")
 
     printed = capsys.readouterr().out
-    assert "Staged in THIS checkout" in printed and str(root) in printed
+    assert "Staged in this checkout" in printed and str(root) in printed
     assert "benchmark row: stub-stub-model-low" in printed
     assert "skip if you have push access" in printed
+
+
+def test_open_pr_drives_git_and_gh_end_to_end(tmp_path, monkeypatch):
+    """The wizard owns the submission: branch, commit, push, PR, in its own
+    checkout. Faked git/gh log every invocation; the fake branch check fails so
+    the create-branch path runs, and pr create returns the URL."""
+    import os
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "log"
+    (bin_dir / "git").write_text(
+        '#!/bin/sh\necho "git $@" >> %s\n'
+        'case "$1 $2" in "rev-parse --verify") exit 1;; esac\nexit 0\n' % log,
+        encoding="utf-8",
+    )
+    (bin_dir / "gh").write_text(
+        '#!/bin/sh\necho "gh $@" >> %s\n'
+        'case "$1 $2" in "pr create") echo "https://github.com/Shpigford/nurb/pull/999";; esac\nexit 0\n' % log,
+        encoding="utf-8",
+    )
+    for f in bin_dir.iterdir():
+        f.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+
+    url, problem = contribute.open_pr("stub-stub-model-low", tmp_path)
+    assert problem is None
+    assert url == "https://github.com/Shpigford/nurb/pull/999"
+    logged = log.read_text(encoding="utf-8")
+    for needle in (
+        "git checkout -b bench-stub-stub-model-low",
+        "git add evals/submissions evals/REPORT.md site/benchmarks.html",
+        "git commit -m benchmark row: stub-stub-model-low",
+        "git push -u origin bench-stub-stub-model-low",
+        "gh pr create --title benchmark row: stub-stub-model-low",
+    ):
+        assert needle in logged

--- a/evals/tests/test_contribute.py
+++ b/evals/tests/test_contribute.py
@@ -9,6 +9,7 @@ paths redirected into a scratch tree so nothing touches the real submissions/.
 import json
 import os
 import pathlib
+import re
 import shutil
 import sys
 
@@ -48,10 +49,7 @@ def test_wizard_runs_and_stages_a_sanitized_submission(tmp_path, monkeypatch, ca
     shutil.copy(real / "models.toml", root / "models.toml")
     os.symlink(real / "tasks" / "cable_clip", root / "tasks" / "cable_clip")
 
-    from nurb_evals import site
-
     monkeypatch.setattr(contribute, "EVALS", root)
-    monkeypatch.setattr(site, "SITE", root / "benchmarks.html")
     monkeypatch.setattr(contribute.shutil, "which", lambda name: "/usr/bin/true")
     monkeypatch.setitem(harnesses.HARNESSES, "stub", Stub(GOOD))
     monkeypatch.setattr(
@@ -69,7 +67,11 @@ def test_wizard_runs_and_stages_a_sanitized_submission(tmp_path, monkeypatch, ca
     )
     contribute.main()
 
-    sub = root / "submissions" / "stub-stub-model-low"
+    # One directory per run, unique so ten runs (or three at once) never collide.
+    subs = list((root / "submissions").glob("stub-stub-model-low-*"))
+    assert len(subs) == 1
+    sub = subs[0]
+    assert re.fullmatch(r"stub-stub-model-low-[0-9a-f]{6}", sub.name)
     rows = [
         json.loads(line)
         for line in (sub / "results.jsonl").read_text().splitlines()
@@ -83,31 +85,25 @@ def test_wizard_runs_and_stages_a_sanitized_submission(tmp_path, monkeypatch, ca
     for staged in sub.rglob("*"):
         if staged.is_file():
             assert str(pathlib.Path.home()) not in staged.read_text(errors="replace")
-    # The wizard regenerates the published page itself, so a PR ships with the
-    # benchmarks.html its rows produce and the stale-page test passes as opened.
-    page = (root / "benchmarks.html").read_text(encoding="utf-8")
-    assert "stub-model" in page
-    assert "stub-model" in (root / "REPORT.md").read_text(encoding="utf-8")
 
     printed = capsys.readouterr().out
     assert "Staged in this checkout" in printed and str(root) in printed
-    assert "benchmark row: stub-stub-model-low" in printed
+    assert f"benchmark run: {sub.name}" in printed
+    assert f"git add evals/submissions/{sub.name}" in printed
     assert "skip if you have push access" in printed
 
 
 def test_open_pr_drives_git_and_gh_end_to_end(tmp_path, monkeypatch):
-    """The wizard owns the submission: branch, commit, push, PR, in its own
-    checkout. Faked git/gh log every invocation; the fake branch check fails so
-    the create-branch path runs, and pr create returns the URL."""
+    """The wizard owns the submission: branch from origin's main, commit only this
+    run's directory, push, PR. Faked git/gh log every invocation and pr create
+    returns the URL."""
     import os
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log = tmp_path / "log"
     (bin_dir / "git").write_text(
-        '#!/bin/sh\necho "git $@" >> %s\n'
-        'case "$1 $2" in "rev-parse --verify") exit 1;; esac\nexit 0\n' % log,
-        encoding="utf-8",
+        '#!/bin/sh\necho "git $@" >> %s\nexit 0\n' % log, encoding="utf-8"
     )
     (bin_dir / "gh").write_text(
         '#!/bin/sh\necho "gh $@" >> %s\n'
@@ -118,15 +114,16 @@ def test_open_pr_drives_git_and_gh_end_to_end(tmp_path, monkeypatch):
         f.chmod(0o755)
     monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
 
-    url, problem = contribute.open_pr("stub-stub-model-low", tmp_path)
+    url, problem = contribute.open_pr("stub-stub-model-low-abc123", tmp_path)
     assert problem is None
     assert url == "https://github.com/Shpigford/nurb/pull/999"
     logged = log.read_text(encoding="utf-8")
     for needle in (
-        "git checkout -b bench-stub-stub-model-low",
-        "git add evals/submissions evals/REPORT.md site/benchmarks.html",
-        "git commit -m benchmark row: stub-stub-model-low",
-        "git push -u origin bench-stub-stub-model-low",
-        "gh pr create --title benchmark row: stub-stub-model-low",
+        "git fetch origin main",
+        "git checkout -b bench-stub-stub-model-low-abc123 FETCH_HEAD",
+        "git add evals/submissions/stub-stub-model-low-abc123",
+        "git commit -m benchmark run: stub-stub-model-low-abc123",
+        "git push -u origin bench-stub-stub-model-low-abc123",
+        "gh pr create --title benchmark run: stub-stub-model-low-abc123",
     ):
         assert needle in logged

--- a/site/bench.sh
+++ b/site/bench.sh
@@ -27,17 +27,28 @@ main() {
     command -v uv >/dev/null 2>&1 || fail "uv installed but did not land on PATH; open a new terminal and rerun"
   fi
 
-  dir="nurb-bench"
-  if [ -d "$dir/evals" ]; then
-    say "[2/3] $dir/ already cloned; pulling the latest benchmark"
-    git -C "$dir" pull --ff-only >/dev/null 2>&1 || say "      (pull skipped; using the checkout as it is)"
+  # Re-running from inside a checkout must never nest another clone inside it:
+  # the first dogfooding run produced nurb-bench/nurb-bench and a submission
+  # staged where no git command could find it.
+  if [ -f "evals/src/nurb_evals/contribute.py" ]; then
+    say "[2/3] already inside a nurb checkout; using it as it is"
+  elif [ -f "../evals/src/nurb_evals/contribute.py" ]; then
+    say "[2/3] already inside a nurb checkout; using it as it is"
+    cd ..
   else
-    say "[2/3] cloning the benchmark into ./$dir"
-    git clone --depth 1 https://github.com/Shpigford/nurb "$dir" || fail "clone failed"
+    dir="nurb-bench"
+    if [ -d "$dir/evals" ]; then
+      say "[2/3] $dir/ already cloned; pulling the latest benchmark"
+      git -C "$dir" pull --ff-only >/dev/null 2>&1 || say "      (pull skipped; using the checkout as it is)"
+    else
+      say "[2/3] cloning the benchmark into ./$dir"
+      git clone --depth 1 https://github.com/Shpigford/nurb "$dir" || fail "clone failed"
+    fi
+    cd "$dir" || fail "clone is missing"
   fi
 
   say "[3/3] preparing and starting the wizard"
-  cd "$dir/evals" || fail "clone is missing evals/"
+  cd evals || fail "checkout is missing evals/"
   uv sync >/dev/null || fail "uv sync failed"
 
   # `curl | sh` leaves stdin owned by the pipe; the wizard needs the keyboard.


### PR DESCRIPTION
Reworked after Josh's design direction: many runs per person, concurrent sessions, every run its own PR, merge-and-done.

**Contribution flow**
- `bench.sh` uses the checkout it is standing in instead of nesting a clone (the nurb-bench/nurb-bench failure).
- Every run gets a uniquely suffixed submission directory, a unique branch cut from `origin/main`, and its own PR carrying only that directory — a pure addition. Ten runs of the same combo, or three concurrent sessions, produce ten PRs that merge in any order with zero conflicts, and matching rows pool on the leaderboard regardless of which PR they arrived in.
- The wizard opens the PR itself (`gh`): branch, commit of just its run dir, push, fork only without push access, URL printed. `--pr ask|yes|no`; manual steps only as the no-gh fallback.

**Publishing flow**
- Submission PRs no longer touch REPORT.md or the page, so nothing merged is published implicitly. The new `leaderboard` skill (mirroring the changelog skill) is the maintainer act: sanity-check new runs (identity fields, sanitization, planted-part hashes against reference solutions, deterministic re-grade spot checks, one transcript read per new contributor), write verdicts for new combos, regenerate `evals/REPORT.md` + `site/benchmarks.html`, eyeball the page, open the publish PR.
- The per-PR staleness tests are gone accordingly; the sanitization test still gates every submission PR.

**Tested**: full wizard flow through the stub harness (unique run dir asserted), and `open_pr` against faked `git`/`gh` binaries asserting the exact command sequence.