### PR TITLE
The bench clone lives in ~/.nurb/bench, never in the current directory

### DIFF
--- a/evals/src/nurb_evals/contribute.py
+++ b/evals/src/nurb_evals/contribute.py
@@ -287,6 +287,7 @@ def open_pr(run_name, repo):
     if done.returncode != 0:
         return None, f"git commit: {_tail(done)}"
 
+    head = branch
     push = _run(["git", "push", "-u", "origin", branch], repo)
     if push.returncode != 0:
         fork = _run(["gh", "repo", "fork", "--remote", "--remote-name", "fork"], repo)
@@ -295,10 +296,19 @@ def open_pr(run_name, repo):
         push = _run(["git", "push", "-u", "fork", branch], repo)
         if push.returncode != 0:
             return None, f"git push: {_tail(push)}"
+        login = _run(["gh", "api", "user", "-q", ".login"], repo)
+        if login.returncode == 0 and login.stdout.strip():
+            head = f"{login.stdout.strip()}:{branch}"
 
+    # --base and --head make pr create fully non-interactive: without them gh can
+    # decide it has a question to ask, and a question with no terminal is an abort
+    # (a dogfooding run died exactly there, one step from the URL).
     done = _run(
         [
             "gh", "pr", "create",
+            "--repo", "Shpigford/nurb",
+            "--base", "main",
+            "--head", head,
             "--title", f"benchmark run: {run_name}",
             "--body",
             "Automated submission from the contribute wizard: one run, one new "
@@ -320,7 +330,7 @@ def _manual_steps(run_name, repo):
         f"  git commit -m 'benchmark run: {run_name}'\n"
         f"  gh repo fork Shpigford/nurb --remote   # skip if you have push access\n"
         f"  git push -u origin bench-{run_name}\n"
-        f"  gh pr create --title 'benchmark run: {run_name}' --fill\n\n"
+        f"  gh pr create --repo Shpigford/nurb --base main --head bench-{run_name} --title 'benchmark run: {run_name}' --fill\n\n"
         f"Every run counts, including a single one: matching rows pool on the "
         f"leaderboard, and a bad score is data, not an embarrassment."
     )

--- a/evals/tests/test_contribute.py
+++ b/evals/tests/test_contribute.py
@@ -124,6 +124,6 @@ def test_open_pr_drives_git_and_gh_end_to_end(tmp_path, monkeypatch):
         "git add evals/submissions/stub-stub-model-low-abc123",
         "git commit -m benchmark run: stub-stub-model-low-abc123",
         "git push -u origin bench-stub-stub-model-low-abc123",
-        "gh pr create --title benchmark run: stub-stub-model-low-abc123",
+        "gh pr create --repo Shpigford/nurb --base main --head bench-stub-stub-model-low-abc123 --title benchmark run: stub-stub-model-low-abc123",
     ):
         assert needle in logged

--- a/site/bench.sh
+++ b/site/bench.sh
@@ -27,24 +27,28 @@ main() {
     command -v uv >/dev/null 2>&1 || fail "uv installed but did not land on PATH; open a new terminal and rerun"
   fi
 
-  # Re-running from inside a checkout must never nest another clone inside it:
-  # the first dogfooding run produced nurb-bench/nurb-bench and a submission
-  # staged where no git command could find it.
+  # The wizard needs a repo checkout: tasks and scorer to run, a git tree to
+  # commit the submission into. It must never land in whatever directory the
+  # user happens to be standing in (a dogfooding run left a full replica of the
+  # repo inside a dev checkout); it lives in one fixed hidden place, like any
+  # tool's cache, and re-runs and concurrent sessions all share it. Standing
+  # inside a nurb checkout already? That checkout is used as it is.
   if [ -f "evals/src/nurb_evals/contribute.py" ]; then
     say "[2/3] already inside a nurb checkout; using it as it is"
   elif [ -f "../evals/src/nurb_evals/contribute.py" ]; then
     say "[2/3] already inside a nurb checkout; using it as it is"
     cd ..
   else
-    dir="nurb-bench"
+    dir="${NURB_BENCH_HOME:-$HOME/.nurb/bench}"
     if [ -d "$dir/evals" ]; then
-      say "[2/3] $dir/ already cloned; pulling the latest benchmark"
+      say "[2/3] updating the benchmark checkout at $dir"
       git -C "$dir" pull --ff-only >/dev/null 2>&1 || say "      (pull skipped; using the checkout as it is)"
     else
-      say "[2/3] cloning the benchmark into ./$dir"
+      say "[2/3] cloning the benchmark into $dir"
+      mkdir -p "$(dirname "$dir")"
       git clone --depth 1 https://github.com/Shpigford/nurb "$dir" || fail "clone failed"
     fi
-    cd "$dir" || fail "clone is missing"
+    cd "$dir" || fail "checkout is missing"
   fi
 
   say "[3/3] preparing and starting the wizard"


### PR DESCRIPTION
From the third dogfooding run: a full replica of the repo sitting inside `~/Development/nurb` because the wizard's working clone lands in whatever directory the user happens to be standing in.

The clone exists for two real reasons (the tasks and scorer have to run from somewhere, and the submission has to be committed into a git tree for the PR), but its location is now a fixed hidden home, `~/.nurb/bench` (`NURB_BENCH_HOME` overrides), shared by re-runs and concurrent sessions, matching the `~/.config/nurb` convention. Standing inside a nurb checkout still uses that checkout as it is.

Note: the `nurb-bench` replica in your dev checkout (and the nested one inside it) is now dead weight and safe to delete; nurb.dev is also still serving the pre-#72 `bench.sh`, so the next site deploy picks up both fixes.