### PR TITLE
Release 0.11.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.10.0"
+version = "0.11.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.10.0"
+  version: "0.11.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.10.0"
+  version: "0.11.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Bumps the version to 0.11.0 everywhere it lives: the package, both skill files, and the desktop app. Merging this is the release.

What shipped since v0.10.0, in user-visible terms:

- **The nurb desktop app.** A signed Mac app that wraps the viewer, with one-click updates, plus the viewer's embed mode that makes it possible.
- **Parts sit on the printer's actual bed.** The viewer centers parts on the build plate and draws the real bed for the named printer profile.
- **`nurb verify --report`** bundles the verification list with renders, and `nurb inspect` shows each finding on its face, with `--section` to cut parts open.
- **A machine-wide config file**, and STEP dropped from the default export.
- **Published specs count as measurements**, and the agent researches them before asking.
- **The LLM eval suite and leaderboard**: three task classes, a subscription-CLI runner, generated REPORT.md, and a contribute wizard that opens the PR itself.

Merging kicks off publish.yml (PyPI, tag, GitHub release); the desktop build follows from this Mac.