### PR TITLE
Add the v0.11.0 changelog entry

### DIFF
--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,19 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.11.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.11.0">v0.11.0</a></span><time datetime="2026-08-04">August 4, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>The desktop app.</b> A Mac app that puts your projects, your AI, and the live viewer in one window. Chat with Claude, Codex, Cursor, or Grok on the left and watch the part change on the right. It sets everything up on first launch and updates itself with one click.</span></li>
+      <li><b class="tag new">new</b><span><b>Inspection reports.</b> Your AI can now show you exactly where a problem lives: each finding is drawn on the face it belongs to, parts can be cut open to see inside, and a verify run bundles the full checklist with rendered stills.</span></li>
+      <li><b class="tag new">new</b><span><b>The model leaderboard.</b> A public benchmark scores AI models on designing real printable parts, so you can see how the model you talk to stacks up.</span></li>
+      <li><b class="tag">improved</b><span>The viewer draws your printer's actual bed and centers the part on it, so what you see is what will sit on the plate.</span></li>
+      <li><b class="tag">improved</b><span>Your AI looks up published dimensions itself, like a battery size or a rail spacing, and only asks you to measure what can't be found.</span></li>
+      <li><b class="tag">improved</b><span>Tell nurb about your printer once and every project on your machine knows it. Your AI records it for you and checks there before asking again.</span></li>
+      <li><b class="tag">improved</b><span>Exports write just the STL you print from by default. Other formats are one ask away, and a stale file sitting next to a fresh export gets flagged instead of looking current.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.10.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.10.0">v0.10.0</a></span><time datetime="2026-08-02">August 2, 2026</time></div>
     <ul>


### PR DESCRIPTION
The site entry for v0.11.0: the desktop app, inspection reports, the model leaderboard, bed rendering, researched dimensions, the machine-wide printer config, and STL-only default exports. Screenshot-verified against the served page.