### PR TITLE
Lead the README install section with the Mac app download

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Agentic CAD for 3D printing. The user is a language model: your agent writes par
 
 ## Install
 
+The easiest way in is the Mac app: [**Download nurb for Mac**](https://github.com/Shpigford/nurb/releases/latest/download/nurb.dmg). Your projects, your AI, and the live viewer in one window; it sets everything up the first time you open it and updates itself. Apple silicon.
+
+For the command line:
+
 ```bash
 curl -fsSL https://nurb.dev/install.sh | sh
 ```


### PR DESCRIPTION
Same push as the landing page change in #86: the README's Install section now leads with the Mac app download at the stable latest-DMG URL, with the curl install kept right below it.