### PR TITLE
Add Check for Updates to the app menu and check every six hours

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -331,11 +331,19 @@ fn test_hook(app: AppHandle) {
 }
 
 /// macOS ships an empty Help submenu, and a chromeless window has nowhere else to
-/// put a link. These two are the only place in the app that reaches the outside
-/// world, alongside the same pair in the about box.
-fn install_help_menu(app: &AppHandle) -> tauri::Result<()> {
+/// put a link. The two Help items are the only place in the app that reaches the
+/// outside world, alongside the same pair in the about box. "Check for Updates…"
+/// sits under About where every Mac app keeps it; the webview owns the update
+/// state, so the click is forwarded there as an event.
+fn install_menu(app: &AppHandle) -> tauri::Result<()> {
     use tauri::menu::{Menu, MenuItem, HELP_SUBMENU_ID};
     let menu = Menu::default(app)?;
+    if let Some(appmenu) = menu.items()?.first().and_then(|i| i.as_submenu().cloned()) {
+        appmenu.insert(
+            &MenuItem::with_id(app, "app:check-updates", "Check for Updates…", true, None::<&str>)?,
+            1,
+        )?;
+    }
     if let Some(help) = menu.get(HELP_SUBMENU_ID).and_then(|i| i.as_submenu().cloned()) {
         help.append_items(&[
             &MenuItem::with_id(app, "help:github", "nurb on GitHub", true, None::<&str>)?,
@@ -344,8 +352,13 @@ fn install_help_menu(app: &AppHandle) -> tauri::Result<()> {
     }
     app.set_menu(menu)?;
     app.on_menu_event(|app, event| {
+        use tauri::Emitter;
         use tauri_plugin_opener::OpenerExt;
         let url = match event.id().as_ref() {
+            "app:check-updates" => {
+                let _ = app.emit("menu:check-updates", ());
+                return;
+            }
             "help:github" => "https://github.com/Shpigford/nurb",
             "help:issue" => "https://github.com/Shpigford/nurb/issues/new",
             _ => return,
@@ -381,7 +394,7 @@ pub fn run() {
             app.manage(Registry::load(&dir));
             app.manage(sessions::SessionStore::load(&dir));
             app.manage(prefs::PrefStore::load(&dir));
-            install_help_menu(app.handle())?;
+            install_menu(app.handle())?;
             #[cfg(debug_assertions)]
             test_hook(app.handle().clone());
             Ok(())

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -2,7 +2,7 @@ import { Fragment, FormEvent, useCallback, useEffect, useMemo, useRef, useState 
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { open as pickFolder } from "@tauri-apps/plugin-dialog";
+import { ask, message, open as pickFolder } from "@tauri-apps/plugin-dialog";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import { check, Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
@@ -137,6 +137,10 @@ function App() {
   const [showAgentsHelp, setShowAgentsHelp] = useState(false);
   const [update, setUpdate] = useState<Update | null>(null);
   const [updating, setUpdating] = useState(false);
+  // The one update this run acts on: found once, downloaded eagerly so the
+  // restart is instant. `ready` resolves false if the background download
+  // failed, in which case installing downloads again.
+  const found = useRef<{ update: Update; ready: Promise<boolean> } | null>(null);
 
   useEffect(() => {
     invoke<boolean>("provision_status")
@@ -144,31 +148,75 @@ function App() {
       .catch(() => setReady(false));
   }, []);
 
-  useEffect(() => {
-    // The update check runs at launch, not behind the provisioning gate: an
-    // app whose first-run setup is broken can still be rescued by an update.
-    // `tauri dev` serves the vite dev build and skips the check; a missing or
-    // unreachable endpoint fails silently either way.
-    if (import.meta.env.PROD) check().then(setUpdate).catch(() => {});
+  // Checks run outside the provisioning gate: an app whose first-run setup is
+  // broken can still be rescued by an update. `tauri dev` serves the vite dev
+  // build and skips the check entirely.
+  const findUpdate = useCallback(async () => {
+    if (!import.meta.env.PROD || found.current) return found.current?.update ?? null;
+    const next = await check();
+    if (next && !found.current) {
+      found.current = { update: next, ready: next.download().then(() => true, () => false) };
+      setUpdate(next);
+    }
+    return next;
   }, []);
+
+  useEffect(() => {
+    // At launch and every six hours after: the app stays open for days, and a
+    // missing or unreachable endpoint fails silently on these timed checks.
+    findUpdate().catch(() => {});
+    const timer = setInterval(() => findUpdate().catch(() => {}), 6 * 60 * 60 * 1000);
+    return () => clearInterval(timer);
+  }, [findUpdate]);
 
   useEffect(() => {
     if (ready !== true) return;
     invoke<AboutInfo>("about_info").then(setAbout).catch(() => {});
   }, [ready]);
 
-  const installUpdate = async () => {
-    if (!update || updating) return;
+  const installUpdate = useCallback(async () => {
+    if (!found.current || updating) return;
     setUpdating(true);
     setError(null);
     try {
-      await update.downloadAndInstall();
+      const pending = found.current;
+      if (await pending.ready) await pending.update.install();
+      else await pending.update.downloadAndInstall();
       await relaunch();
     } catch (e) {
       setError(String(e));
       setUpdating(false);
     }
-  };
+  }, [updating]);
+
+  // The macOS "Check for Updates…" item. The menu lives in Rust and the
+  // update state lives here, so the click arrives as an event; unlike the
+  // timed checks, this one answers even when there is nothing to install.
+  useEffect(() => {
+    const unlisten = listen("menu:check-updates", async () => {
+      // The dev build never checks, so saying "newest version" would be a lie.
+      if (!import.meta.env.PROD) return;
+      try {
+        const next = await findUpdate();
+        if (!next) {
+          await message("You're on the newest version.", { title: "nurb" });
+        } else if (
+          await ask(`nurb ${next.version} is ready to install.`, {
+            title: "nurb",
+            okLabel: "Restart & Update",
+            cancelLabel: "Later",
+          })
+        ) {
+          await installUpdate();
+        }
+      } catch (e) {
+        setError(String(e));
+      }
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [findUpdate, installUpdate]);
 
   // Two things the embedded viewer cannot do for itself. It forwards mousedowns
   // from its own top strip (the titlebar area lives inside the iframe, out of


### PR DESCRIPTION
The desktop updater had a signed feed and a one-shot check at launch, but no way to check on demand and no re-check while the app stayed open. This adds a native Check for Updates item under About in the app menu (forwarded to the webview as an event, since the update state lives there), repeats the check every six hours, and eagerly downloads a found update in the background so the restart button applies it instantly, with a fallback re-download if the background fetch failed. The manual check answers either way: an up-to-date dialog or a Restart & Update prompt. The app never relaunches unprompted, because it hosts live agent conversations. Verified on a debug build driven over accessibility: menu placement, the event path, a real check against the live feed, and the up-to-date dialog; the update-available branch gets its first end-to-end run at the next release, since it needs a feed newer than the installed app.