### PR TITLE
Fix the desktop app's frozen viewer when switching parts in the rail

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -555,12 +555,37 @@ function App() {
   };
 
   // ?embed hides the viewer's own title and part list; the rail is the one
-  // place parts live in the app.
-  const viewerSrc = activeServer && partsReady
-    ? selectedPart
-      ? `${activeServer.url}/?embed&part=${encodeURIComponent(selectedPart)}`
-      : `${activeServer.url}/?embed`
-    : null;
+  // place parts live in the app. The src is pinned per project: WKWebView
+  // suspends requestAnimationFrame in an iframe that is navigated in place, so
+  // following the selection with the URL freezes the canvas. The iframe loads
+  // once per server and part switches travel by postMessage instead.
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
+  const [frame, setFrame] = useState<{ key: string; src: string } | null>(null);
+  useEffect(() => {
+    if (!activeServer || !partsReady) {
+      setFrame(null);
+      return;
+    }
+    setFrame((prev) =>
+      prev?.key === activeServer.url
+        ? prev
+        : {
+            key: activeServer.url,
+            src: selectedPart
+              ? `${activeServer.url}/?embed&part=${encodeURIComponent(selectedPart)}`
+              : `${activeServer.url}/?embed`,
+          },
+    );
+  }, [activeServer, partsReady, selectedPart]);
+
+  const postPart = useCallback(() => {
+    if (!frame || !selectedPart) return;
+    frameRef.current?.contentWindow?.postMessage(
+      { type: "nurb:part", name: selectedPart },
+      frame.key,
+    );
+  }, [frame, selectedPart]);
+  useEffect(postPart, [postPart]);
 
   if (ready !== true) {
     // The status check settles in well under a second; until then the window
@@ -877,8 +902,17 @@ function App() {
         </section>
       )}
       <main className="viewer">
-        {viewerSrc ? (
-          <iframe className="viewer-frame" src={viewerSrc} title="nurb viewer" />
+        {frame ? (
+          <iframe
+            key={frame.key}
+            ref={frameRef}
+            className="viewer-frame"
+            src={frame.src}
+            title="nurb viewer"
+            // The selection can move while the document is still loading and a
+            // message posted into a loading frame is dropped; repeat it on load.
+            onLoad={postPart}
+          />
         ) : active && opening[active] ? (
           <div className="viewer-status">starting the CAD engine…</div>
         ) : (

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -455,6 +455,21 @@ if (embed) {
   const article = { stl: 'an STL', step: 'a STEP' };
   for (const b of document.querySelectorAll('#download button'))
     b.title = `save ${article[b.dataset.fmt]} into the project's build folder and show it in Finder`;
+  // The shell's rail switches parts by message, never by renavigating this frame:
+  // WKWebView suspends requestAnimationFrame in an iframe that was navigated in
+  // place, which freezes the picture while the rest of the page stays live. A
+  // message runs the same path as a click on the viewer's own part list.
+  window.addEventListener('message', e => {
+    if (e.source !== window.parent || !e.data || e.data.type !== 'nurb:part') return;
+    const name = String(e.data.name);
+    if (name === current) return;
+    want = null; wantVariant = null;
+    const entry = parts.get(name);
+    if (!entry) { want = name; return; }   // still building; sync or rebuilt finishes the switch
+    current = name;
+    if (activeVariant(entry)) applyVariant(name, { params: {} });
+    render(); show(name, { keepCamera: false }); setURL();
+  });
 }
 
 // ---- scene (Z-up, matching CAD) ----


### PR DESCRIPTION
Clicking a part in the desktop app's sidebar never changed the preview: the shell followed the selection by rewriting the viewer iframe's `src`, and WKWebView suspends `requestAnimationFrame` in an iframe navigated in place, so the new document never painted and the release build kept compositing the old part's last frame (verified with an in-viewer HUD showing `raf=0` with a live GL context and loaded mesh). The iframe now loads once per project and `App.tsx` posts the selected part to the viewer, repeating the message on iframe load so a click during startup is not dropped; only a project switch replaces the iframe element, which paints fine. The viewer, in embed mode, handles the message with the same code path as a click on its own part list, including variant reset and the deep-link path for parts still building. Part switches are also instant now, since the viewer page and its WebGL context are no longer torn down per click. Verified by driving selection in a live dev build (each part renders, render loop stays alive); `tsc --noEmit` and the full pytest suite pass.