### PR TITLE
Add reject() so a part can refuse a configuration as a design limit

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -261,6 +261,12 @@ fn part_views(project: &std::path::Path, body: &str) -> Result<serde_json::Value
                     .and_then(|entry| entry.get("error"))
                     .cloned()
                     .unwrap_or(serde_json::Value::Null);
+                // A refusal (reject() in the part) sets error too, but it is the part
+                // declining a configuration, not breaking; the rail marks it amber
+                // rather than with the crash red.
+                let refused = entry
+                    .and_then(|entry| entry.get("refused"))
+                    .is_some_and(|value| !value.is_null());
                 // The joints payload is the marker the viewer already uses: only an
                 // assembly carries one, even empty. A source that has not built yet
                 // reads as a part and corrects itself on the next poll.
@@ -269,7 +275,7 @@ fn part_views(project: &std::path::Path, body: &str) -> Result<serde_json::Value
                     .and_then(|entry| entry.get("uses"))
                     .cloned()
                     .unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
-                serde_json::json!({ "name": name, "error": error, "assembly": assembly, "uses": uses })
+                serde_json::json!({ "name": name, "error": error, "refused": refused, "assembly": assembly, "uses": uses })
             })
             .collect(),
     ))
@@ -455,9 +461,12 @@ mod tests {
         std::fs::write(parts.join("rig.py"), "").unwrap();
         std::fs::write(parts.join("_helper.py"), "").unwrap();
 
+        std::fs::write(parts.join("held.py"), "").unwrap();
+
         let views = part_views(
             &root,
             r#"[{"name":"broken","error":"trace"},{"name":"gone","error":null},
+                {"name":"held","error":"hole too small","refused":"hole"},
                 {"name":"rig","error":null,"joints":[],"uses":["alpha"]}]"#,
         )
         .unwrap();
@@ -465,9 +474,10 @@ mod tests {
         assert_eq!(
             views,
             serde_json::json!([
-                { "name": "alpha", "error": null, "assembly": false, "uses": [] },
-                { "name": "broken", "error": "trace", "assembly": false, "uses": [] },
-                { "name": "rig", "error": null, "assembly": true, "uses": ["alpha"] }
+                { "name": "alpha", "error": null, "refused": false, "assembly": false, "uses": [] },
+                { "name": "broken", "error": "trace", "refused": false, "assembly": false, "uses": [] },
+                { "name": "held", "error": "hole too small", "refused": true, "assembly": false, "uses": [] },
+                { "name": "rig", "error": null, "refused": false, "assembly": true, "uses": ["alpha"] }
             ])
         );
         std::fs::remove_dir_all(root).unwrap();

--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -350,6 +350,11 @@ textarea {
   font-weight: 600;
 }
 
+.part-refused {
+  color: var(--amber);
+  font-weight: 600;
+}
+
 .part-busy {
   width: 6px;
   height: 6px;

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -24,7 +24,13 @@ type Project = {
 type Server = { url: string; port: number };
 // `assembly` and `uses` are the placed-parts pair: an assembly is not one printable
 // solid, and the rail says so rather than letting it pass as another part.
-type Part = { name: string; error: string | null; assembly: boolean; uses: string[] };
+type Part = {
+  name: string;
+  error: string | null;
+  refused: boolean;
+  assembly: boolean;
+  uses: string[];
+};
 type PartState = { path: string; parts: Part[] };
 type ChatInfo = {
   id: string;
@@ -269,7 +275,7 @@ function App() {
         setPartState({
           path: active,
           parts: entries
-            .map(({ name, error, assembly, uses }) => ({ name, error, assembly, uses }))
+            .map(({ name, error, refused, assembly, uses }) => ({ name, error, refused, assembly, uses }))
             .sort((a, b) => a.name.localeCompare(b.name)),
         });
       } catch {
@@ -449,7 +455,7 @@ function App() {
     for (let attempt = 0; ; attempt++) {
       const entries = await invoke<Part[]>("list_parts", { path });
       const listed = entries
-        .map(({ name, error, assembly, uses }) => ({ name, error, assembly, uses }))
+        .map(({ name, error, refused, assembly, uses }) => ({ name, error, refused, assembly, uses }))
         .sort((a, b) => a.name.localeCompare(b.name));
       if (settled(listed) || attempt >= 19) {
         setPartState({ path, parts: listed });
@@ -634,7 +640,12 @@ function App() {
                           <span className="part-busy" title="the agent is working on this part" />
                         )}
                         {part.error && (
-                          <span className="part-error" title={part.error}>
+                          // A refusal is the part declining a configuration, not
+                          // breaking, so it wears amber like the viewer's own mark.
+                          <span
+                            className={part.refused ? "part-refused" : "part-error"}
+                            title={part.error}
+                          >
                             !
                           </span>
                         )}

--- a/src/nurb/__init__.py
+++ b/src/nurb/__init__.py
@@ -21,7 +21,7 @@ from .holes import counterbore  # noqa: E402
 from .measurements import measured  # noqa: E402
 from .orient import stand  # noqa: E402
 from .polish import chamfer, polish  # noqa: E402  -- must win, see below
-from .registry import part  # noqa: E402  -- must win over any build123d name
+from .registry import part, reject  # noqa: E402  -- must win over any build123d name
 
 # `polish` is here because the doctrine prescribes the algorithm and every project
 # would otherwise write it: chamfer is all or nothing, so one edge that cannot land
@@ -41,6 +41,11 @@ from .registry import part  # noqa: E402  -- must win over any build123d name
 # `counterbore` is here because the naive alternative is two cylinders that build,
 # check as an ordinary bridge, and print a screw seat on sagging air: the stepped
 # bridging stack is fixed print-farm practice, not a judgement, so it is generated.
+# `reject` is here because a part that knows a configuration cannot work (a hole
+# narrower than the tool it holds) has to be able to say so, and the alternative is a
+# bare ValueError that the viewer can only present as a crash. A refusal through
+# `reject` keeps its message and the parameter it names, and is shown as a limit of
+# the design.
 # `chamfer` deliberately shadows build123d's. Same behaviour, same exception type;
 # what it adds is the doctrine's rule on the way out of a failure, because the kernel's
 # own advice is "try a smaller length value(s)" and following it is how a part ends up
@@ -51,6 +56,7 @@ from .registry import part  # noqa: E402  -- must win over any build123d name
 __all__ = [
     *getattr(_b3d, "__all__", [n for n in dir(_b3d) if not n.startswith("_")]),
     "part",
+    "reject",
     "is_convex",
     "concave_edges",
     "measured",

--- a/src/nurb/builder.py
+++ b/src/nurb/builder.py
@@ -8,6 +8,8 @@ import time
 import numpy as np
 import trimesh
 
+from .registry import Rejected
+
 
 class BuildError(Exception):
     pass
@@ -125,12 +127,6 @@ def build(path, overrides=None, draft=False):
     if defn.accepts_draft:
         call["draft"] = draft
 
-    started = time.perf_counter()
-    shape = fn(**call)
-    elapsed = (time.perf_counter() - started) * 1000
-    if shape is None:
-        raise BuildError(f"{defn.name}() returned None")
-
     params = [
         {
             "name": name,
@@ -141,6 +137,19 @@ def build(path, overrides=None, draft=False):
         }
         for name, default in defn.params.items()
     ]
+
+    started = time.perf_counter()
+    try:
+        shape = fn(**call)
+    except Rejected as exc:
+        # A refused build still needs to describe the attempted values: they are the
+        # controls the viewer offers to get back into the part's valid range.
+        exc.params = params
+        raise
+    elapsed = (time.perf_counter() - started) * 1000
+    if shape is None:
+        raise BuildError(f"{defn.name}() returned None")
+
     return shape, params, elapsed
 
 

--- a/src/nurb/cli.py
+++ b/src/nurb/cli.py
@@ -335,7 +335,7 @@ def _flex(path, problems):
     places to be wrong. A part is allowed to refuse, since a pocket row or a grid has to
     fit between the brackets, but it has to refuse in its own words.
     """
-    from . import builder
+    from . import builder, registry
 
     declared = builder.load(path)._nurb.params
     counts = [
@@ -347,10 +347,14 @@ def _flex(path, problems):
         for grown in (declared[name] + 1, declared[name] + 2):
             try:
                 shape, _, _ = builder.build(path, overrides={name: grown}, draft=False)
+            except registry.Rejected:
+                continue  # a guard in the part's own words is a decision, not a fault
             except ValueError as exc:
                 if any(k in str(exc) for k in KERNEL):
                     problems.append(f"{name}={grown} fails in the kernel: {exc}")
-                continue  # a guard in the part's own words is a decision, not a fault
+                else:
+                    problems.append(f"{name}={grown}: ValueError: {exc}")
+                continue
             except Exception as exc:
                 problems.append(f"{name}={grown}: {type(exc).__name__}: {exc}")
                 continue

--- a/src/nurb/doctrine.md
+++ b/src/nurb/doctrine.md
@@ -40,6 +40,8 @@ suggests.
 Return one solid. A function that returns two loose bodies still reports a plausible
 bounding box and still exports, so nothing downstream catches it.
 
+**When a configuration cannot work, refuse it with `reject`, never a bare raise.** A holder whose hole is narrower than the tool it holds should not build, and `reject("drill_hole_width 14 is under the 14.27mm pin vise plus print shrink: raise it above 14.77", param="drill_hole_width")` is how a part says so. The message states what is wrong and what value fixes it; `param` names the offending parameter so the viewer marks its slider. The viewer presents a refusal as a limit of the design, in amber with the last good geometry still on screen, where a bare `ValueError` arrives as a red traceback that reads as the part being broken. Guard only what would print wrong or not work at all; taste stays a slider.
+
 ## Printability
 
 - **Minimum wall 2 to 3mm**, except where fit geometry says otherwise. Fit-critical

--- a/src/nurb/registry.py
+++ b/src/nurb/registry.py
@@ -54,6 +54,32 @@ def param_docs(fn, params):
     return docs
 
 
+class Rejected(Exception):
+    """A part refusing a configuration, raised by `reject`.
+
+    Its own type, subclassing nothing that gets caught by accident, so the server
+    and the CLI can tell a designed refusal from a part that actually broke.
+    """
+
+    def __init__(self, message, param=None):
+        super().__init__(message)
+        self.param = param
+        # Filled by the builder before this crosses the server boundary. Keeping the
+        # attempted values lets a fresh viewer render the controls needed to recover.
+        self.params = None
+
+
+def reject(message, param=None):
+    """Refuse to build a configuration the part knows cannot work.
+
+    For guards on parameter values: a holder whose hole is narrower than the tool
+    it holds should refuse, not build. Say what is wrong and what value fixes it,
+    and pass `param` naming the offending parameter so the viewer can mark its
+    slider. A refusal is shown as a limit of the design, never as a crash.
+    """
+    raise Rejected(message, param)
+
+
 def part(fn):
     """Mark a function as a part.
 

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -19,7 +19,7 @@ from websockets.asyncio.server import serve
 from websockets.http11 import Response
 from websockets.datastructures import Headers
 
-from . import __version__, builder
+from . import __version__, builder, registry
 
 VIEWER = pathlib.Path(__file__).parent / "viewer.html"
 VENDOR = (pathlib.Path(__file__).parent / "vendor").resolve()
@@ -217,6 +217,7 @@ class Server:
 
     def rebuild(self, path):
         name = pathlib.Path(path).stem
+        previous = self.state.get(name) or {}
         entry = {
             "name": name,
             "token": secrets.token_hex(4),
@@ -245,6 +246,20 @@ class Server:
                 entry["joints"] = wire(scene)
                 # What the stl button downloads instead of the merged scene.
                 entry["uses"] = sorted(pathlib.Path(u).stem for u in scene.uses)
+        except registry.Rejected as exc:
+            # The part refusing this configuration via reject(). Not a crash, so no
+            # traceback: the message and the parameter it names are the whole story,
+            # and the viewer presents them as a limit of the design.
+            entry["glb"] = None
+            entry["shape"] = None
+            entry["error"] = str(exc)
+            entry["refused"] = exc.param or True
+            # Unlike a crash, a refusal is recoverable from the parameter panel. The
+            # builder carries the attempted values; the previous build covers a rare
+            # refusal during module loading, before a function signature was found.
+            entry["params"] = (
+                exc.params if exc.params is not None else previous.get("params", [])
+            )
         except Exception as exc:
             entry["glb"] = None
             entry["shape"] = None

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -12,7 +12,7 @@
   }
   :root {
     --bg: #16181d; --panel: #1d2027; --line: #2b2f38;
-    --text: #e6e8ec; --dim: #868d9b; --accent: #6ee7a8; --bad: #f87171;
+    --text: #e6e8ec; --dim: #868d9b; --accent: #6ee7a8; --bad: #f87171; --warn: #f0c274;
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body {
@@ -66,11 +66,14 @@
   .item.var.active .vic { color: var(--accent); }
   .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); flex: none; }
   .dot.bad { background: var(--bad); }
+  /* Amber for a refusal: the part declined these values on purpose, nothing broke. */
+  .dot.refused { background: var(--warn); }
   /* An assembly's status light is the cubes icon itself: same slot, same colors.
      The negative margins keep its flex footprint at the dot's 6px, so part and
      assembly names stay in one column. */
   .dot.asm { width: 13px; height: 13px; margin: 0 -3.5px; background: none; border-radius: 0; color: var(--accent); }
   .dot.asm.bad { color: var(--bad); }
+  .dot.asm.refused { color: var(--warn); }
   .dot.busy { animation: pulse .6s ease-in-out infinite; }
   @keyframes pulse { 50% { opacity: .25; } }
   main { position: relative; overflow: hidden; }
@@ -94,6 +97,9 @@
     font-size: 11px; display: none;
     box-shadow: 0 4px 16px rgba(0,0,0,.35); backdrop-filter: blur(10px);
   }
+  /* A refusal wears the checks' warn amber, not the crash red: the part declined
+     these values on purpose and the message says what to change. */
+  #err.refused { background: rgba(42,37,22,.94); border-color: #57481f; color: var(--warn); }
   #tools {
     position: absolute; top: 14px; right: 14px;
     display: flex; flex-direction: column; align-items: flex-end; gap: 8px;
@@ -257,6 +263,11 @@
   .p .k { color: var(--dim); font-size: 11px; cursor: default;
           overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .p.dirty .k { color: var(--text); }
+  /* The row a refusal names: the slider that has to move before the part builds.
+     After every .p.dirty rule, because the row that just caused a refusal is usually
+     dirty too, and the refusal is the signal that needs to win. */
+  .p.refused { border-left-color: var(--warn); }
+  .p.refused .k { color: var(--warn); }
   .p .v {
     width: 58px; margin-left: auto; text-align: right; background: none; border: none;
     color: var(--text); font: inherit; font-size: 11px; border-radius: 3px; padding: 1px 3px;
@@ -992,6 +1003,7 @@ async function paint(name, { keepCamera }) {
 
   if (entry.error) {
     err.style.display = 'block';
+    err.classList.toggle('refused', !!entry.refused);
     err.textContent = entry.traceback || entry.error;
     if (mesh) {                              // last good geometry stays, visibly stale
       mesh.traverse(o => {
@@ -1004,9 +1016,11 @@ async function paint(name, { keepCamera }) {
     hud(entry);
     checks(name);
     params(entry);
+    flagRefusal(entry);
     return;
   }
   err.style.display = 'none';
+  flagRefusal(entry);
 
   // Without GL there is no scene to feed, but the geometry is the only thing missing:
   // the hud, checks and params describe the build, not the picture of it.
@@ -1162,12 +1176,22 @@ function checks(name) {
   }
 }
 
+// A refusal (reject() in the part) may name the parameter it is about. The panel
+// survives a failed build, so the row is still there to mark; cleared on any paint
+// whose entry carries no refusal.
+function flagRefusal(e) {
+  for (const row of document.querySelectorAll('.p.refused')) row.classList.remove('refused');
+  if (typeof e.refused !== 'string') return;
+  const row = document.querySelector(`.p[data-name="${CSS.escape(e.refused)}"]`);
+  if (row) row.classList.add('refused');
+}
+
 function hud(e) {
   // With a variant on screen the HUD carries its card note, because the sidebar can
   // say which variant but never why it exists, and the why is the point of it.
   const v = e.error ? null : activeVariant(e);
   document.getElementById('hud').innerHTML = e.error
-    ? `<b>${e.name}</b><br>build failed`
+    ? `<b>${e.name}</b><br>${e.refused ? 'refused these values' : 'build failed'}`
     : `<b>${v ? v.name : e.name}</b>`
       + (v && v.note ? `<br><span class="note">${v.note}</span>` : '')
       + `<br>${e.bbox.join(' &times; ')} mm<br>${e.ms} ms`;
@@ -1542,11 +1566,12 @@ function render() {
     const row = document.createElement('div');
     row.className = 'item' + (e.name === current ? ' active' : '');
     // The joints payload is the marker: only an assembly carries one, even empty.
+    const light = e.error ? (e.refused ? 'refused' : 'bad') : '';
     row.innerHTML = (Array.isArray(e.joints)
-        ? `<svg class="dot asm ${e.error ? 'bad' : ''}"><title>assembly</title><use href="#i-cubes"/></svg>`
-        : `<span class="dot ${e.error ? 'bad' : ''}"></span>`)
+        ? `<svg class="dot asm ${light}"><title>assembly</title><use href="#i-cubes"/></svg>`
+        : `<span class="dot ${light}"></span>`)
       + `<span class="name">${e.name}</span>`
-      + `<span class="ms">${e.error ? 'err' : e.ms + 'ms'}</span>`;
+      + `<span class="ms">${e.error ? (e.refused ? '' : 'err') : e.ms + 'ms'}</span>`;
     row.onclick = () => {
       // A click supersedes a deep link whose part is still waiting to build.
       want = null; wantVariant = null;

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,6 +24,7 @@ def test_the_documented_vocabulary_is_the_exported_one():
     and the assembly four."""
     assert set(api.own_names()) == {
         "part",
+        "reject",
         "polish",
         "crown",
         "is_convex",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -318,6 +318,49 @@ def test_verify_names_the_counts_it_flexed(tmp_path, monkeypatch, capsys):
     assert "flexed rows" in capsys.readouterr().out
 
 
+def test_verify_accepts_a_designed_refusal_while_flexing_counts(
+    tmp_path, monkeypatch, capsys
+):
+    import argparse
+
+    monkeypatch.chdir(tmp_path)
+    _finished(
+        tmp_path,
+        "from nurb import *\n\n\n@part\n"
+        "def thing(rows=2):\n"
+        "    if rows > 2:\n"
+        "        reject('only two rows fit', param='rows')\n"
+        "    return Box(10, 10, 5 * rows)\n",
+    )
+    capsys.readouterr()
+
+    cli.cmd_verify(argparse.Namespace(part=None, report=False))
+
+    assert "ok," in capsys.readouterr().out
+
+
+def test_verify_reports_a_bare_value_error_while_flexing_counts(
+    tmp_path, monkeypatch, capsys
+):
+    import argparse
+
+    monkeypatch.chdir(tmp_path)
+    _finished(
+        tmp_path,
+        "from nurb import *\n\n\n@part\n"
+        "def thing(rows=2):\n"
+        "    if rows > 2:\n"
+        "        raise ValueError('only two rows fit')\n"
+        "    return Box(10, 10, 5 * rows)\n",
+    )
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit):
+        cli.cmd_verify(argparse.Namespace(part=None, report=False))
+
+    assert "rows=3: ValueError: only two rows fit" in capsys.readouterr().out
+
+
 def test_verify_says_so_when_a_part_has_no_counts_to_flex(tmp_path, monkeypatch, capsys):
     import argparse
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -139,6 +139,72 @@ def test_failed_build_has_no_active_variant(tmp_path):
     assert entry["variant"] is None
 
 
+REJECTING_PART = """from nurb import *
+
+@part
+def thing(hole=14.0):
+    if hole <= 14.77:
+        reject("hole must clear the 14.27mm tool: raise it above 14.77", param="hole")
+    return Box(hole + 5, 20.0, 10.0)
+"""
+
+
+def test_rebuild_reports_a_refusal_without_a_traceback(tmp_path):
+    """reject() is the part declining a configuration, not the part breaking, so the
+    entry carries the message and the parameter it names and no traceback at all."""
+    (tmp_path / "parts").mkdir()
+    server = Server(tmp_path)
+    part = tmp_path / "parts" / "thing.py"
+    part.write_text(REJECTING_PART)
+
+    entry = server.rebuild(part)
+
+    assert entry["error"] == "hole must clear the 14.27mm tool: raise it above 14.77"
+    assert entry["refused"] == "hole"
+    assert "traceback" not in entry
+    # A refusal at a slider value has to be draggable back out of, so the wire
+    # payload keeps both the refusal and the attempted parameter values, including
+    # when there has never been a successful build to seed the viewer's panel.
+    wired = server._wire(entry)
+    assert wired["refused"] == "hole"
+    assert wired["params"] == [
+        {
+            "name": "hole",
+            "default": 14.0,
+            "value": 14.0,
+            "kind": "float",
+            "doc": None,
+            "family": False,
+        }
+    ]
+
+
+def test_rebuild_marks_an_unattributed_refusal(tmp_path):
+    """reject() without param still travels as a refusal; there is just no slider
+    for the viewer to mark."""
+    server = project(tmp_path)
+    part = tmp_path / "parts" / "thing.py"
+    part.write_text(REJECTING_PART.replace(', param="hole"', ""))
+
+    entry = server.rebuild(part)
+
+    assert entry["refused"] is True
+    assert "traceback" not in entry
+
+
+def test_viewer_presents_a_refusal_as_a_limit_not_a_crash():
+    from nurb import server as server_mod
+
+    viewer = server_mod.VIEWER.read_text(encoding="utf-8")
+    # The message box turns amber, the named slider gets marked, and the sidebar
+    # light says held-on-purpose rather than broken.
+    assert "err.classList.toggle('refused', !!entry.refused)" in viewer
+    assert "#err.refused" in viewer
+    assert "function flagRefusal(e)" in viewer
+    assert ".p.refused" in viewer
+    assert "e.refused ? 'refused' : 'bad'" in viewer
+
+
 def test_check_judges_a_matching_variant_by_its_own_settings(tmp_path):
     """Sliders sitting exactly on a card variant get that variant's settings, and one
     step off puts the base part's rules back."""


### PR DESCRIPTION
A part that knows a configuration cannot work (a hole narrower than the tool it holds) can now call `reject(message, param=...)` instead of raising a bare `ValueError`, and the refusal travels as a designed limit rather than a crash. The server sends the message, the named parameter, and the attempted slider values with no traceback, and the viewer shows it in amber with the last good geometry still on screen and the offending slider marked. `nurb verify` treats a refusal while flexing counts as a decision, while a bare `ValueError` is now reported as a problem instead of silently skipped. The desktop app's part rail marks refused parts amber too, and the doctrine documents when to guard versus when to leave taste to a slider. Covered by new server, CLI, and Rust tests.