### PR TITLE
Release 0.12.0

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -20,6 +20,8 @@ gh release list --limit 20
 
 Every tagged release newer than the high-water mark needs an entry. If the user describes a feature in free text instead, write that one entry into the version it shipped in (or the pending version if it hasn't shipped yet) and skip the sweep.
 
+When /release invokes this before the bump PR merges, the newest version has no tag or GitHub release yet. Write its entry anyway: source it from the PRs merged since the last release (`gh pr list --state merged --base main --json title,number,mergedAt`) plus whatever the release branch itself ships, date it today, and keep the tag link, which goes live when the release publishes. The entry lands as part of the release PR, so commit it there instead of leaving it uncommitted.
+
 For each missing version:
 
 ```bash
@@ -63,7 +65,7 @@ Insert the new `<article class="release" id="vX.Y.Z">` at the **top** of `<main>
 </article>
 ```
 
-The date is the release's `publishedAt` date, not today. Never reword or delete an already-published entry; its `id` is a live anchor.
+The date is the release's `publishedAt` date, not today (a pre-merge entry uses today, which becomes the publish date when the PR merges). Never reword or delete an already-published entry; its `id` is a live anchor.
 
 ## Step 5: Verify
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Cut a full nurb release, one version across the engine and the desktop app. Bumps the four version strings, opens the release PR, and after the merge runs the desktop build, the update feed, and the changelog. Use when the user says "release", "cut a release", "ship it as X.Y.Z", or "push a release".
+description: Cut a full nurb release, one version across the engine and the desktop app. Bumps the four version strings and writes the changelog into one release PR, riding the current branch when work is in flight, then after the merge runs the desktop build and the update feed. Use when the user says "release", "cut a release", "ship it as X.Y.Z", or "push a release".
 ---
 
 # Releasing nurb
@@ -21,7 +21,7 @@ git fetch origin main
 
 The updater key check matters most: without `~/.tauri/nurb-desktop.key` shipped apps cannot update, and generating a fresh key would strand every existing install. If it is missing, stop and tell the user; never regenerate it.
 
-Release from a branch cut off up-to-date origin/main. A release PR carries the version bumps and nothing else; if the workspace has unrelated changes, those ship in their own PRs first.
+Start from up-to-date origin/main. One PR is the release: if the current branch has work in flight, the bump and changelog ride that branch and its PR becomes the release PR. Only cut a fresh branch when the workspace is clean and the release is just collecting already-merged work.
 
 ## Step 1: Pick the version
 
@@ -32,7 +32,7 @@ gh release list --limit 5
 gh pr list --state merged --base main --limit 50 --json title,mergedAt
 ```
 
-## Step 2: The bump PR
+## Step 2: The release PR
 
 Four version strings move together, and tests enforce every pairing:
 
@@ -48,7 +48,9 @@ The bump also stales `evals/uv.lock`, because evals is its own uv project with n
 cd evals && uv lock && cd ..
 ```
 
-Prove the agreement before pushing: `uv run pytest tests/test_cli.py -q`. Commit with a plain-sentence message, push, and open the PR against main with the release summary as the body (what shipped, in user-visible terms). Then stop and hand the merge to the user.
+Then write the changelog into the same PR: run /changelog for the pending version. Pre-merge there is no tag or GitHub release yet, so it draws from the PRs merged since the last release plus this branch's own changes, dated today.
+
+Prove the agreement before pushing: `uv run pytest tests/test_cli.py -q`. Commit the bump and the changelog together with a plain-sentence message, push, and open the PR against main with the release summary as the body (what shipped, in user-visible terms). Then stop and hand the merge to the user.
 
 ## Step 3: After the merge
 
@@ -62,11 +64,7 @@ A fresh worktree has no `desktop/node_modules`, and the script dies immediately 
 
 About ten minutes: signed build, notarization, stapling, chain verification, upload of `nurb.dmg` plus the updater archive into the `vX.Y.Z` release, and the `desktop-latest` feed refresh. It refuses to double-upload, so re-running after a failure is safe. It needs this Mac; the signing cert and updater key live here by design.
 
-## Step 4: Changelog
-
-Run /changelog. It writes the `vX.Y.Z` entry into `site/changelog.html` from the release's merged PRs, filtered to what a user would notice. Land it as its own small PR.
-
-## Step 5: Verify, then report
+## Step 4: Verify, then report
 
 Three probes, all of which must say X.Y.Z (the DMG check must return a redirect or 200):
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.11.0"
+version = "0.12.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,15 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.12.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.12.0">v0.12.0</a></span><time datetime="2026-08-04">August 4, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Design limits.</b> A part can now refuse a configuration it knows can't work, like a hole narrower than the tool it holds. Instead of an error, the viewer shows a plain message, marks the slider that went too far, and keeps the last good shape on screen.</span></li>
+      <li><b class="tag">improved</b><span>The Mac app checks for updates every six hours and downloads them in the background, so updating is one click when the prompt appears. A Check for Updates item in the app menu answers on demand either way.</span></li>
+      <li><b class="tag">fixed</b><span>Clicking a part in the Mac app's sidebar now switches the preview. It used to keep showing the previous part.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.11.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.11.0">v0.11.0</a></span><time datetime="2026-08-04">August 4, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.11.0"
+  version: "0.12.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.11.0"
+  version: "0.12.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
One version across the engine and the desktop app: 0.12.0 in pyproject, both skill files, and the Tauri config, with evals relocked to match.

What ships, in user-visible terms:

- **Design limits.** A part can refuse a configuration it knows can't work. The viewer shows a plain message, marks the offending slider, and keeps the last good shape on screen (#90).
- The Mac app checks for updates every six hours, downloads them in the background, and gains a Check for Updates menu item (#88).
- Clicking a part in the Mac app's sidebar now actually switches the preview (#89).

The v0.12.0 changelog entry rides this PR, dated today, which becomes the publish date on merge. Also included: the release and changelog skill edits that describe this one-PR ceremony.

Merging this PR is the release: publish.yml uploads to PyPI, tags v0.12.0, and creates the GitHub release; the desktop build and update feed follow from this Mac.