### PR TITLE
Release 0.13.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.12.0"
+version = "0.13.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,16 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.13.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.13.0">v0.13.0</a></span><time datetime="2026-08-06">August 6, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Phone scans.</b> Scan an object with your phone, hand nurb the file, and it reads the shape in millimeters. Your AI can slice a cross-section to trace the profile you need to fit, and it tells you when to print a small test piece to prove the fit before you commit to the whole part.</span></li>
+      <li><b class="tag new">new</b><span><b>Downloaded models.</b> A model you downloaded now comes in as a real solid, so you can cut holes in it, chamfer its edges, and build around it. Files that can't be one, like a scan or a hollow surface, are turned away with the reason instead of taking the preview down.</span></li>
+      <li><b class="tag">improved</b><span>Your AI offers a scan when it needs the shape of something and a number won't do, and walks you through the capture the first time.</span></li>
+      <li><b class="tag">improved</b><span>The Mac app stops asking permission for each command. Your AI now runs inside a sandbox that can read anything but only write inside your project.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.12.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.12.0">v0.12.0</a></span><time datetime="2026-08-04">August 4, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.12.0"
+  version: "0.13.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.12.0"
+  version: "0.13.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Cuts 0.13.0 across the engine and the desktop app: the four version strings, the relocked evals project, and the changelog entry.

## What ships

**Phone scans.** `nurb scan` reads a phone-scanned mesh (STL/OBJ/GLB or triangulated PLY) in millimeters, says which units it assumed, and `--section` slices a cross-section into profile polylines to sketch against. Splat and point-cloud exports are refused with the fix named. The doctrine and the shipped skill gain the capture ladder: a photo identifies a shape but never a dimension, a phone scan measures it loosely, and a printed fit coupon proves the fit.

**Downloaded models become real solids.** `import_stl` returns a cleaned B-rep solid for a closed, flat-faced STL, so a downloaded model can be cut, chamfered, and built against. Everything else is refused by name rather than segfaulting the rebuild loop: open surfaces, inverted meshes, degenerate triangles, invalid multi-shell results, unreadable formats, and quarter-million-triangle downloads.

**The Mac app stops asking permission.** Desktop agents now spawn under a Seatbelt sandbox that reads anything but writes only the project, the engine root, and tool caches, so the permission dialogs are gone and the kernel is the guard.

## Verification

`uv run pytest tests/test_cli.py -q` passes, which is what enforces the four version strings agreeing. The changelog entry was checked in a browser against its neighbors.