### PR TITLE
Point Codex sign-in at the bundled Codex CLI

### DIFF
--- a/desktop/src-tauri/src/agents.rs
+++ b/desktop/src-tauri/src/agents.rs
@@ -287,6 +287,17 @@ pub async fn agent_login(app: tauri::AppHandle, agent: String) -> Result<(), Str
     let launcher = app.state::<crate::env::Launcher>();
     let (program, mut args) = launcher.adapter(kind);
     let adapter_path = launcher.adapter_path();
+    // codex-acp's login spawns `codex app-server` off PATH, unlike the rest of
+    // the adapter, which falls back to the copy npm installed beside it. On a
+    // user's machine nothing but node is on that PATH, so the spawn fails with
+    // ENOENT and the login reports only its exit code. Point it at the
+    // bundled CLI. (Dev checkouts run the adapter through npx, which puts that
+    // same CLI on PATH itself, which is why this only ever broke the shipped
+    // app.)
+    let codex_cli = match kind {
+        AgentKind::Codex => launcher.paths().map(crate::env::Paths::codex_cli),
+        _ => None,
+    };
     match kind {
         AgentKind::Claude => {
             args.extend(["--cli", "auth", "login", "--claudeai"].map(String::from))
@@ -302,6 +313,9 @@ pub async fn agent_login(app: tauri::AppHandle, agent: String) -> Result<(), Str
         let mut command = Command::new(program);
         if let Some(path) = adapter_path {
             command.env("PATH", path);
+        }
+        if let Some(cli) = codex_cli {
+            command.env("CODEX_PATH", cli);
         }
         let mut child = command
             .args(&args)
@@ -321,7 +335,9 @@ pub async fn agent_login(app: tauri::AppHandle, agent: String) -> Result<(), Str
         if status.success() {
             Ok(())
         } else {
-            Err("The sign-in did not finish. Try again, or sign in from a terminal.".into())
+            // No terminal advice: the audience is hobbyists, and the usual
+            // cause is a browser tab closed before the login landed.
+            Err("The sign-in did not finish. Try again, and complete the sign-in in the browser tab that opens.".into())
         }
     });
     // A human in a browser sets the pace; ten minutes is generous. On timeout
@@ -377,5 +393,17 @@ mod tests {
             assert_eq!(manifest["dependencies"][package], version);
             assert_eq!(locked[package], version);
         }
+    }
+
+    /// `agent_login` hands Codex a CODEX_PATH pointing at `.bin/codex`, which
+    /// only exists because the adapter depends on a Codex CLI that installs
+    /// under that name. An adapter bump that dropped it would put the login
+    /// back on the bare PATH lookup that broke it.
+    #[test]
+    fn the_codex_adapter_installs_the_cli_its_login_is_pointed_at() {
+        let lock: serde_json::Value =
+            serde_json::from_str(include_str!("../../adapter-runtime/package-lock.json")).unwrap();
+        let codex = &lock["packages"]["node_modules/@openai/codex"];
+        assert!(codex["bin"]["codex"].is_string(), "no codex bin: {codex}");
     }
 }

--- a/desktop/src-tauri/src/env.rs
+++ b/desktop/src-tauri/src/env.rs
@@ -178,6 +178,14 @@ impl Paths {
             .join(kind.adapter_bin().expect("adapter-hosted"))
     }
 
+    /// The Codex CLI npm installs as a dependency of the Codex adapter.
+    /// codex-acp's ACP server falls back to this copy on its own, but its
+    /// login path spawns a bare `codex` off PATH instead, so the app has to
+    /// name it. See `CODEX_PATH` in agents.rs.
+    pub fn codex_cli(&self) -> PathBuf {
+        self.adapters().join("node_modules/.bin/codex")
+    }
+
     pub fn stamp(&self) -> PathBuf {
         self.data.join("provisioned.json")
     }


### PR DESCRIPTION
Codex sign-in failed for every user of the shipped app with "The sign-in did not finish", because codex-acp's login path spawns a bare `codex app-server` off PATH instead of falling back to the copy npm installed beside it, and a GUI app inherits launchd's PATH, which has no `codex` on it. This sets `CODEX_PATH` on the login child to the CLI the app already installs, and adds a test that the adapter's lockfile still ships that binary, so a future adapter bump cannot silently return the login to the bare PATH lookup. Dev checkouts run the adapter through npx, which puts that same CLI on PATH itself, which is why this never showed up in development.

Also drops "or sign in from a terminal" from the failure message, since the audience is hobbyists who cannot act on it and the usual cause is a browser tab closed before the login landed.

Verified by driving the real app in provisioned mode with an empty `CODEX_HOME`: pressing the sign-in button now spawns the bundled `.bin/codex app-server` and reaches the live `auth.openai.com` OAuth URL.