### PR TITLE
Release 0.14.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.13.0"
+version = "0.14.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,20 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.14.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.14.0">v0.14.0</a></span><time datetime="2026-08-07">August 7, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Print time and filament.</b> Find out what a part costs before you print it. nurb hands it to the OrcaSlicer or Bambu Studio you already have, on the printer you already told it about, and reads back how long the print takes and how much filament it uses. It all happens on your machine, with no account to make.</span></li>
+      <li><b class="tag new">new</b><span><b>Parts in pieces.</b> A part that came out as two pieces touching looks like one part from every angle, and used to pass every check. Now it is caught and said first, ahead of the checks that would only have described one of the pieces.</span></li>
+      <li><b class="tag new">new</b><span><b>What changed.</b> Your AI can compare a part against the numbers nurb last recorded for it, so an edit that quietly dropped a chamfer or grew the part shows up as a difference instead of going unnoticed.</span></li>
+      <li><b class="tag">improved</b><span>Problems are named in plain words now. The viewer says "starts on air" or "inside corner" and follows it with a sentence you can act on, rather than the name the rule goes by inside nurb.</span></li>
+      <li><b class="tag">improved</b><span>Standard screw, nut and clearance hole sizes ship with nurb, so your AI sizes an M3 head pocket or an M4 nut socket from the table instead of asking you to measure hardware that has been standard for decades.</span></li>
+      <li><b class="tag">improved</b><span>An inspection report pictures the back and underside of the part as well as the front, so nothing hides on the far side.</span></li>
+      <li><b class="tag">fixed</b><span>Signing in to Codex in the Mac app failed for everyone with "The sign-in did not finish". The button now reaches the real login page.</span></li>
+      <li><b class="tag">fixed</b><span>A part that builds to nothing says so instead of failing with an internal error, and the viewer no longer leaves the previous part on screen under the new part's name.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.13.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.13.0">v0.13.0</a></span><time datetime="2026-08-06">August 6, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.13.0"
+  version: "0.14.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.13.0"
+  version: "0.14.0"
 ---
 # nurb
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Configuration-set validation happens before artifact writes."""
 
 import pathlib
+import re
 
 import pytest
 
@@ -663,7 +664,15 @@ def test_diff_catches_a_chamfer_that_stopped_landing(tmp_path, monkeypatch, caps
     part.write_text(RIBBED.replace("gap=8.0", "gap=3.2"))
     cli.cmd_diff(argparse.Namespace(part=None))
     out = capsys.readouterr().out
-    assert "faces: 44 -> 41" in out
+    # Not pinned to the counts themselves. How many chamfers a failing batch takes down
+    # with it is OCCT's call, and it answers differently on macOS and on Linux: the same
+    # part is 44 faces on one and something else on the other. What has to hold is that
+    # faces fell and that nothing else in the line would have raised a hand.
+    faces = re.search(r"faces: (\d+) -> (\d+)", out)
+    assert faces, out
+    assert int(faces[2]) < int(faces[1])
+    volume = re.search(r"volume: [\d.]+ -> [\d.]+ mm3, ([-+][\d.]+)%", out)
+    assert volume and abs(float(volume[1])) < 1.0, "volume barely moves, which is the point"
     assert "nurb card" in out, "the way to accept the new numbers is worth saying"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
0.14.0 collects two merged PRs into a release: the printability and pricing work from #97 and the Codex sign-in fix from #95.

**What ships**

- `nurb slice` hands a part to an installed OrcaSlicer or BambuStudio, on the machine `printer.toml` already names, and reads back print time and filament used. Local only, no account.
- A new `solids` rule catches a part that built in two pieces. It returns alone when it fires, because every other rule reads `solids()[0]` and would otherwise report symptoms of one fragment.
- `nurb diff` compares a build against the facts its card last recorded, so a silently dropped chamfer surfaces as a face count.
- Findings now speak to both audiences: the rule name stays the identifier the CLI prints, and the viewer shows a plain label and a plain sentence. Tests guard that a new rule cannot ship without either.
- A fastener table in the doctrine: ISO clearance holes, cap head sizes, and nut dimensions, so an M3 head pocket is taken from the table instead of measured.
- `verify --report` adds an opposing isometric, so the back and underside are pictured by construction.
- Fixed: Codex sign-in failed in the shipped app for every user, because the login path spawned a bare `codex` off a launchd PATH that has none. It now points at the bundled CLI.
- Fixed: an empty part tessellated to zero triangles and raised out of numpy, and the viewer returned bare on an empty GLB, leaving the previous part on screen under the new part's name.

**This PR**

Bumps the four version strings, relocks `evals/uv.lock` against 0.14.0, and adds the 0.14.0 changelog entry to the site.

Merging publishes: PyPI upload, tag `v0.14.0`, and the GitHub release. The desktop build and update feed follow from this Mac.

**Also fixes a red test on main**

`test_diff_catches_a_chamfer_that_stopped_landing` pinned `faces: 44 -> 41`, the count macOS builds. Linux drops a different batch of chamfers for the same part, so it has been failing on main since #97 landed. It now asserts what it is actually about: faces fell, and the volume moved under a percent, which is what makes the face count the only signal.