### PR TITLE
Release 0.15.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.14.0"
+version = "0.15.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,17 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.15.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.15.0">v0.15.0</a></span><time datetime="2026-08-08">August 8, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Match the original.</b> Point a part at the phone scan or downloaded model it is meant to replace, and nurb tells you how close you are. The original sits over your part as an amber ghost you can switch on and off, and two numbers refresh on every save: how far your part strays outside the original, and how much of the original it does not cover yet. They stay separate on purpose, because extra material and missing detail are different problems, and a single average would hide both.</span></li>
+      <li><b class="tag">improved</b><span>Print time is a button in the viewer now, instead of something you had to know to ask for. Press it and the estimate takes its place, with the filament weight in grams. Move a slider and the number clears, so you never read an estimate for a part you no longer have.</span></li>
+      <li><b class="tag">improved</b><span>If nurb does not know your printer yet, it asks you to pick one right there and remembers the answer, rather than telling you to go and set it up first. The Bambu H2 machines are in the list now.</span></li>
+      <li><b class="tag">improved</b><span>An assembly is priced as the sum of the parts it places, repeats and all.</span></li>
+      <li><b class="tag">fixed</b><span>A long list of parts in the sidebar scrolls on its own instead of painting over what sits below it.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.14.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.14.0">v0.14.0</a></span><time datetime="2026-08-07">August 7, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.14.0"
+  version: "0.15.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.14.0"
+  version: "0.15.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Cuts 0.15.0 across the engine and the desktop app: the four version strings, the relocked evals project, and the changelog entry for nurb.dev.

## What ships

**Match the original.** A part can name the phone scan or downloaded model it is remodelling, and nurb reports how close the rebuild is. The target renders as an amber ghost over the part with a toolbar toggle, and two numbers refresh on every save: how far the part strays outside the target, and how much of the target it does not cover yet. The two directions stay separate, because added material and missing detail are different faults and one average would hide both. `nurb compare` prints the same numbers, with `--against` for a one-off file.

**Print time reaches the app.** 0.14.0 shipped the estimate as a subcommand only, which meant it did not exist for anyone using the Mac app. It is now the viewer toolbar's second row. An unnamed printer gets a picker in place rather than an instruction to go and configure one, the Bambu H2 machines are in the shipped profiles, filament reads in grams, and a moved slider clears the number so an estimate never outlives its geometry. An assembly is priced as the sum of the parts it places, repeats included.

**Fixed.** A long parts list in the app's sidebar scrolls on its own instead of painting over the agents block below it.

## Verified

`uv run pytest tests/test_cli.py -q` passes, so all four version strings agree. The changelog entry was rendered in a browser at two widths and matches its neighbours.

https://claude.ai/code/session_01U5EwAkK9BcaZXdykijTC4D