### PR TITLE
Fold the checks panel out of the way, and give the desktop columns seams

### DIFF
--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -72,10 +72,46 @@ textarea {
   -webkit-user-select: text;
 }
 
+/* The columns come from App state, inline: the rail and chat widths are draggable
+   at their seams and remembered, and the viewer takes whatever is left, because
+   the canvas is what a bigger window is for. */
 .shell {
   display: grid;
-  grid-template-columns: 220px minmax(280px, 1fr) minmax(0, 2.2fr);
   height: 100vh;
+  position: relative;
+}
+
+/* A seam sits astride its column border: a 9px grab strip around the 1px line the
+   columns already draw. Invisible until touched, so the chrome gains nothing at
+   rest; the delay keeps a pointer just passing through from flashing it. */
+.seam {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 9px;
+  margin-left: -5px;
+  cursor: col-resize;
+  z-index: 5;
+}
+
+.seam::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: transparent;
+  transition: background 0.1s 0.15s;
+}
+
+.seam:hover::after {
+  background: var(--dim);
+}
+
+.seam.dragging::after {
+  background: var(--accent);
+  transition: none;
 }
 
 .rail {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,4 +1,4 @@
-import { Fragment, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, FormEvent, PointerEvent as ReactPointerEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -10,6 +10,8 @@ import About from "./About";
 import AgentsHelp from "./AgentsHelp";
 import Chat, { AGENT_LABEL } from "./Chat";
 import { IconCheck, IconCube, IconCubes, IconFolder, IconFolderPlus } from "./Icons";
+import { COLUMNS, fitColumns, initialColumns, resizedColumn } from "./layout";
+import type { Column } from "./layout";
 import Setup from "./Setup";
 import "./App.css";
 
@@ -105,6 +107,11 @@ function placedInMap(parts: Part[]) {
   return map;
 }
 
+// The sidebar columns, draggable at their seams (issue #103: overlays in the viewer
+// had nowhere to go). Clamped so neither the labels nor the canvas can be crushed
+// into uselessness; a width that keeps a column workable is the whole point of one.
+const viewportWidth = () => document.documentElement.clientWidth;
+
 function App() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [servers, setServers] = useState<Record<string, Server>>({});
@@ -129,6 +136,67 @@ function App() {
   const [busyParts, setBusyParts] = useState<Record<string, boolean>>({});
   const [agentStatuses, setAgentStatuses] = useState<AgentStatus[]>([]);
   const [signingIn, setSigningIn] = useState<string | null>(null);
+  // A UI preference like the agent below, so it persists the same way.
+  const [columnWidths, setColumnWidths] = useState(() =>
+    initialColumns(
+      {
+        rail: Number(localStorage.getItem(COLUMNS.rail.key)),
+        chat: Number(localStorage.getItem(COLUMNS.chat.key)),
+      },
+      viewportWidth(),
+    ),
+  );
+  const { rail: railW, chat: chatW } = columnWidths;
+  useEffect(() => {
+    const fit = () =>
+      setColumnWidths((current) => {
+        const next = fitColumns(current, viewportWidth());
+        if (next.rail === current.rail && next.chat === current.chat) return current;
+        localStorage.setItem(COLUMNS.rail.key, String(next.rail));
+        localStorage.setItem(COLUMNS.chat.key, String(next.chat));
+        return next;
+      });
+    window.addEventListener("resize", fit);
+    return () => window.removeEventListener("resize", fit);
+  }, []);
+  // Pointer capture, not a mousemove listener on the window: the drag crosses the
+  // viewer iframe, and capture is what keeps the moves coming once it does.
+  const dragSeam = (e: ReactPointerEvent<HTMLDivElement>, which: Column) => {
+    const handle = e.currentTarget;
+    const startX = e.clientX;
+    const from = columnWidths[which];
+    let last = from;
+    handle.setPointerCapture(e.pointerId);
+    handle.classList.add("dragging");
+    const move = (ev: PointerEvent) => {
+      last = resizedColumn(
+        which,
+        from + ev.clientX - startX,
+        columnWidths,
+        viewportWidth(),
+      );
+      setColumnWidths((current) => ({ ...current, [which]: last }));
+    };
+    const up = () => {
+      handle.classList.remove("dragging");
+      handle.removeEventListener("pointermove", move);
+      localStorage.setItem(COLUMNS[which].key, String(last));
+    };
+    handle.addEventListener("pointermove", move);
+    handle.addEventListener("pointerup", up, { once: true });
+  };
+  const resetSeam = (which: Column) => {
+    localStorage.removeItem(COLUMNS[which].key);
+    setColumnWidths((current) => ({
+      ...current,
+      [which]: resizedColumn(
+        which,
+        COLUMNS[which].fallback,
+        current,
+        viewportWidth(),
+      ),
+    }));
+  };
   // Fresh conversations use this agent; existing ones keep the agent that ran
   // them. Persisted locally: it is a UI preference, not project state.
   const [defaultAgent, setDefaultAgent] = useState(
@@ -648,7 +716,10 @@ function App() {
   }
 
   return (
-    <div className="shell">
+    <div
+      className="shell"
+      style={{ gridTemplateColumns: `${railW}px ${chatW}px minmax(0, 1fr)` }}
+    >
       <aside className="rail">
         <div className="rail-title" data-tauri-drag-region />
         <div className="rail-heading">
@@ -978,6 +1049,20 @@ function App() {
           <div className="viewer-status">open a project to start</div>
         )}
       </main>
+      <div
+        className="seam"
+        style={{ left: railW }}
+        title="drag to resize; double-click to reset"
+        onPointerDown={(e) => dragSeam(e, "rail")}
+        onDoubleClick={() => resetSeam("rail")}
+      />
+      <div
+        className="seam"
+        style={{ left: railW + chatW }}
+        title="drag to resize; double-click to reset"
+        onPointerDown={(e) => dragSeam(e, "chat")}
+        onDoubleClick={() => resetSeam("chat")}
+      />
     </div>
   );
 }

--- a/desktop/src/layout.ts
+++ b/desktop/src/layout.ts
@@ -1,0 +1,53 @@
+export const VIEWER_MIN = 240;
+
+export const COLUMNS = {
+  rail: { min: 160, max: 400, fallback: 220, key: "nurb-rail-width" },
+  chat: { min: 240, max: 720, fallback: 300, key: "nurb-chat-width" },
+} as const;
+
+export type Column = keyof typeof COLUMNS;
+export type ColumnWidths = Record<Column, number>;
+
+function clampColumn(which: Column, width: number) {
+  const { min, max } = COLUMNS[which];
+  return Math.min(max, Math.max(min, width));
+}
+
+function savedColumn(which: Column, width: number) {
+  return Number.isFinite(width) && width > 0
+    ? clampColumn(which, width)
+    : COLUMNS[which].fallback;
+}
+
+export function resizedColumn(
+  which: Column,
+  width: number,
+  current: ColumnWidths,
+  viewport: number,
+) {
+  const other = which === "rail" ? current.chat : current.rail;
+  const available = viewport - VIEWER_MIN - other;
+  const max = Math.max(COLUMNS[which].min, Math.min(COLUMNS[which].max, available));
+  return Math.min(max, Math.max(COLUMNS[which].min, width));
+}
+
+export function fitColumns(widths: ColumnWidths, viewport: number): ColumnWidths {
+  let rail = clampColumn("rail", widths.rail);
+  let chat = clampColumn("chat", widths.chat);
+
+  // Keep the seam nearest the viewer on-screen, then reduce the rail only when both
+  // sidebars at their preferred widths still leave too little canvas.
+  chat = resizedColumn("chat", chat, { rail, chat }, viewport);
+  rail = resizedColumn("rail", rail, { rail, chat }, viewport);
+  return { rail, chat };
+}
+
+export function initialColumns(saved: ColumnWidths, viewport: number): ColumnWidths {
+  return fitColumns(
+    {
+      rail: savedColumn("rail", saved.rail),
+      chat: savedColumn("chat", saved.chat),
+    },
+    viewport,
+  );
+}

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -172,8 +172,16 @@
     box-shadow: 0 4px 16px rgba(0,0,0,.35); backdrop-filter: blur(10px);
   }
   #checks h2 { display: flex; align-items: center; gap: 6px; font-size: 11px;
-               font-weight: 600; color: var(--dim); margin-bottom: 5px; letter-spacing: .04em; }
+               font-weight: 600; color: var(--dim); margin-bottom: 5px; letter-spacing: .04em;
+               cursor: pointer; user-select: none; }
+  #checks h2:hover { color: var(--text); }
   #checks h2 .n { background: #262b34; border-radius: 8px; padding: 0 7px; }
+  #checks h2 .chev { width: 10px; height: 10px; margin-left: 2px; transition: transform .12s; }
+  /* Folded, the card is its header: the count still says whether there is anything to
+     look at, and the toolbar it was burying is clickable again (issue #103). */
+  #checks.min .f, #checks.min .ok { display: none; }
+  #checks.min h2 { margin-bottom: 0; }
+  #checks.min h2 .chev { transform: rotate(-90deg); }
   #checks .f { display: flex; gap: 7px; padding: 2px 0; cursor: default; }
   #checks .f:hover { color: #fff; }
   #checks .ic { flex: none; width: 12px; height: 12px; margin-top: 2.5px; }
@@ -400,6 +408,7 @@
   <symbol id="i-cube" viewBox="0 0 18 18"><path d="m7.997,2.332l-4.25,2.465c-.617.358-.997,1.017-.997,1.73v4.946c0,.713.38,1.372.997,1.73l4.25,2.465c.621.36,1.386.36,2.007,0l4.25-2.465c.617-.358.997-1.017.997-1.73v-4.946c0-.713-.38-1.372-.997-1.73l-4.25-2.465c-.621-.36-1.386-.36-2.007,0Z" fill="currentColor" opacity=".3" stroke-width="0"/><path d="m7.997,2.332l-4.25,2.465c-.617.358-.997,1.017-.997,1.73v4.946c0,.713.38,1.372.997,1.73l4.25,2.465c.621.36,1.386.36,2.007,0l4.25-2.465c.617-.358.997-1.017.997-1.73v-4.946c0-.713-.38-1.372-.997-1.73l-4.25-2.465c-.621-.36-1.386-.36-2.007,0Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><polyline points="12.251 7.1035 9 9 5.75 7.1035" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><line x1="9.0005" y1="12.7817" x2="9" y2="9" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
   <symbol id="i-variant" viewBox="0 0 12 12"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><line x1="11.25" y1="8.75" x2="6.25" y2="8.75"/><circle cx="4.25" cy="8.75" r="2"/><line x1="2.25" y1="8.75" x2=".75" y2="8.75"/><line x1=".75" y1="3.25" x2="5.75" y2="3.25"/><circle cx="7.75" cy="3.25" r="2"/><line x1="9.75" y1="3.25" x2="11.25" y2="3.25"/></g></symbol>
   <symbol id="i-cubes" viewBox="0 0 18 18"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><path d="M4.648,8.086l-2.55,1.479c-.37,.215-.598,.61-.598,1.038v2.968c0,.428,.228,.823,.598,1.038l2.55,1.479c.372,.216,.832,.216,1.204,0l2.55-1.479c.37-.215,.598-.61,.598-1.038v-2.968c0-.428-.228-.823-.598-1.038l-2.55-1.479c-.372-.216-.832-.216-1.204,0Z"/><polyline points="8.84 10.005 5.25 12.087 1.66 10.005"/><line x1="5.25" y1="16.25" x2="5.25" y2="12.087"/><path d="M12.148,8.086l-2.55,1.479c-.37,.215-.598,.61-.598,1.038v2.968c0,.428,.228,.823,.598,1.038l2.55,1.479c.372,.216,.832,.216,1.204,0l2.55-1.479c.37-.215,.598-.61,.598-1.038v-2.968c0-.428-.228-.823-.598-1.038l-2.55-1.479c-.372-.216-.832-.216-1.204,0Z"/><polyline points="16.34 10.005 12.75 12.087 9.16 10.005"/><line x1="12.75" y1="16.25" x2="12.75" y2="12.087"/><path d="M8.398,1.586l-2.55,1.479c-.37,.215-.598,.61-.598,1.038v2.968c0,.428,.228,.823,.598,1.038l2.55,1.479c.372,.216,.832,.216,1.204,0l2.55-1.479c.37-.215,.598-.61,.598-1.038v-2.968c0-.428-.228-.823-.598-1.038l-2.55-1.479c-.372-.216-.832-.216-1.204,0Z"/><polyline points="12.59 3.505 9 5.587 5.41 3.505"/><line x1="9" y1="9.75" x2="9" y2="5.587"/></g></symbol>
+  <symbol id="i-chev" viewBox="0 0 12 12"><polyline points="3 4.75 6 7.75 9 4.75" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
   <symbol id="i-pin" viewBox="0 0 12 12"><path d="M6 .75c-2.35 0-4.25 1.87-4.25 4.18 0 3.07 4.25 6.32 4.25 6.32s4.25-3.25 4.25-6.32C10.25 2.62 8.35.75 6 .75Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><circle cx="6" cy="4.9" r="1.4" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
   <symbol id="i-clock" viewBox="0 0 12 12"><circle cx="6" cy="6" r="5.25" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><polyline points="6 3 6 6 8.25 7.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></symbol>
   <symbol id="i-reset" viewBox="0 0 18 18"><path d="M5.25 9.5L3 7.25L0.75 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13.495 13.345C12.3587 14.5226 10.7641 15.25 9 15.25C5.548 15.25 2.75 12.45 2.75 9C2.75 8.4 2.834 7.83003 2.99 7.28003" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M12.75 8.5L15 10.75L17.25 8.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M4.50629 4.65564C5.64249 3.48544 7.23658 2.75 8.99998 2.75C12.452 2.75 15.25 5.55 15.25 9C15.25 9.58 15.171 10.14 15.024 10.67" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
@@ -1424,7 +1433,8 @@ function checks(name) {
   box.dataset.for = name;
   box.style.display = 'block';
   if (!found.length) {
-    box.innerHTML = '<h2>checks</h2><div class="ok"><svg class="ic"><use href="#i-ok"/></svg>clean</div>';
+    box.innerHTML = `<h2 title="${FOLD_HINT}">checks<svg class="chev"><use href="#i-chev"/></svg></h2>`
+      + '<div class="ok"><svg class="ic"><use href="#i-ok"/></svg>clean</div>';
     return;
   }
   // The icon is the severity tag: shape and color both carry it, the title spells it out.
@@ -1435,7 +1445,8 @@ function checks(name) {
     `<div class="f ${f.severity}" title="${f.severity}: ${f.rule}">`
     + `<svg class="ic"><use href="#i-${f.severity === 'fail' ? 'fail' : 'warn'}"/></svg>`
     + `<span class="rule">${f.label || f.rule}</span><span>${f.message}</span></div>`).join('');
-  box.innerHTML = `<h2>checks <span class="n">${found.length}</span></h2>${rows}`;
+  box.innerHTML = `<h2 title="${FOLD_HINT}">checks <span class="n">${found.length}</span>`
+    + `<svg class="chev"><use href="#i-chev"/></svg></h2>${rows}`;
   const shift = mesh ? mesh.position : new THREE.Vector3();
   for (const f of found) {
     if (f.face && f.face.length) {
@@ -1453,6 +1464,20 @@ function checks(name) {
                             // reaches its children in some three.js versions
     pins.add(pin);
   }
+}
+
+// The header is also the dismiss: on a narrow viewer the card buried the toolbar with
+// no way past it (issue #103). Folding keeps the count and the pins, and the choice
+// sticks across rebuilds and reloads so a save does not unfold it back over the buttons.
+const FOLD_HINT = 'fold the findings out of the way; the count and the pins stay';
+{
+  const box = document.getElementById('checks');
+  if (localStorage.getItem('nurb.checks.min')) box.classList.add('min');
+  box.addEventListener('click', ev => {
+    if (!ev.target.closest('h2')) return;
+    if (box.classList.toggle('min')) localStorage.setItem('nurb.checks.min', '1');
+    else localStorage.removeItem('nurb.checks.min');
+  });
 }
 
 // A refusal (reject() in the part) may name the parameter it is about. The panel

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -985,3 +985,19 @@ def test_the_print_row_cannot_reach_the_checks_panel():
     viewer = server_mod.VIEWER.read_text(encoding="utf-8")
     assert "max-width: 46%" in viewer  # checks
     assert "max-width: 54%" in viewer  # the print row
+
+
+def test_the_checks_panel_folds_and_stays_folded():
+    """On a narrow viewer the card buried the toolbar with no way past it (issue #103).
+    The header is the dismiss, and the choice has to persist: the panel repaints on
+    every rebuild, so an unfolded default would climb back over the buttons on save."""
+    from nurb import server as server_mod
+
+    viewer = server_mod.VIEWER.read_text(encoding="utf-8")
+    # Folded, the rows go and the header stays, count included.
+    assert "#checks.min .f, #checks.min .ok { display: none; }" in viewer
+    # Both paints carry the fold handle: findings and clean alike.
+    assert viewer.count('<use href="#i-chev"/>') >= 2
+    # The fold outlives the repaint and the reload.
+    assert "localStorage.getItem('nurb.checks.min')" in viewer
+    assert "localStorage.setItem('nurb.checks.min', '1')" in viewer


### PR DESCRIPTION
Fixes #103. On a narrow viewer the checks card buried the toolbar with no way to dismiss it, so the header now folds the findings away while keeping the count and the face pins, and the fold persists across rebuilds and reloads so a save does not climb back over the buttons. The desktop app also gets draggable seams on the rail and chat columns, with widths remembered and double-click to reset, so the viewer can be given more room in the first place. A test pins the fold, its presence in both paints, and its persistence.