### PR TITLE
Release 0.15.1

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.15.0"
+version = "0.15.1"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,14 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.15.1">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.15.1">v0.15.1</a></span><time datetime="2026-08-10">August 10, 2026</time></div>
+    <ul>
+      <li><b class="tag">improved</b><span>The columns in the Mac app resize. Drag the seam beside the parts list or the chat to give the part more room, and double-click a seam to put it back. The widths are remembered.</span></li>
+      <li><b class="tag">fixed</b><span>The list of problems folds away now. In a narrow window it used to cover the buttons above it with no way past. Fold it and you keep the count and the pins on the part, and it stays folded through a save and a reload.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.15.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.15.0">v0.15.0</a></span><time datetime="2026-08-08">August 8, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.15.0"
+  version: "0.15.1"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.15.0"
+  version: "0.15.1"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
A patch release over 0.15.0, collecting #104.

**The checks panel folds away.** In a narrow window the list of problems covered the buttons above it with no way past (#103). The header now folds the findings out of sight while keeping the count and the pins on the part, and the fold survives a save and a reload.

**The desktop columns resize.** The parts rail and the chat column get draggable seams with remembered widths and double-click to reset, so the viewer can be given the room it needs.

Bumps the four version strings that the tests hold together, relocks `evals/uv.lock`, and writes the v0.15.1 changelog entry. Merging this publishes the package, the tag, and the release that the desktop build uploads into.