### PR TITLE
Release 0.16.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.15.1"
+version = "0.16.0"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.15.1"
+version = "0.16.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,13 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.16.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.16.0">v0.16.0</a></span><time datetime="2026-08-10">August 10, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Will it hold?</b> Press stress in the viewer, say how many kilos press on it and what plastic it prints in, then click where the weight lands and where the part is held. The part colors in where the stress gathers, and you get the peak stress, how far it sags, and how much is left before it breaks. Printed parts are weaker across the layers, and that is counted. Your AI can run the same check while it models, and a part can record the load it is meant to carry so the answer comes back the same every time.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.15.1">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.15.1">v0.15.1</a></span><time datetime="2026-08-10">August 10, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.15.1"
+  version: "0.16.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.15.1"
+  version: "0.16.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.15.1"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Stress analysis is the release. A part can now answer whether it holds the weight you plan to hang on it, both in the viewer and from the command line.

Press stress in the viewer, set the load in kilos and the plastic, then click where the weight lands and where the part is held. The part paints a heatmap where the stress gathers and reports the peak stress, the sag, and how much margin is left before it breaks, counting the weaker pull across the printed layers. Results clear when the part rebuilds. `nurb stress` runs the same analysis for an agent, taking its spots from the geometry or from a `[stress]` block in the part's card.

This PR carries the version bump and the changelog only; the feature merged in #106.

- 0.16.0 in `pyproject.toml`, `src/nurb/skill.md`, `skills/nurb/SKILL.md`, and `desktop/src-tauri/tauri.conf.json`
- `evals/uv.lock` relocked against the new version, so CI's `--locked` sync stays green
- One changelog entry on `site/changelog.html`, dated today

`uv run pytest tests/test_cli.py -q` passes, so the four version strings agree.