### PR TITLE
Add configurable projects folder

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -51,17 +51,39 @@ fn seed_part_name(project: &str) -> String {
     }
 }
 
+fn project_base(folder: Option<String>, default: PathBuf) -> PathBuf {
+    folder
+        .filter(|path| !path.trim().is_empty())
+        .map(PathBuf::from)
+        .unwrap_or(default)
+}
+
+fn default_projects_folder_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(app
+        .path()
+        .document_dir()
+        .map_err(|e| format!("no Documents folder: {e}"))?
+        .join("nurb"))
+}
+
 #[tauri::command]
-async fn create_project(app: AppHandle, name: String) -> Result<String, String> {
+fn default_projects_folder(app: AppHandle) -> Result<String, String> {
+    Ok(default_projects_folder_path(&app)?
+        .to_string_lossy()
+        .into_owned())
+}
+
+#[tauri::command]
+async fn create_project(
+    app: AppHandle,
+    name: String,
+    folder: Option<String>,
+) -> Result<String, String> {
     let name = name.trim().to_string();
     if name.is_empty() || name.contains('/') || name.starts_with('.') {
         return Err("project names cannot be empty or contain slashes".into());
     }
-    let base = app
-        .path()
-        .document_dir()
-        .map_err(|e| format!("no Documents folder: {e}"))?
-        .join("nurb");
+    let base = project_base(folder, default_projects_folder_path(&app)?);
     let dir = base.join(&name);
     if dir.exists() {
         return Err(format!(
@@ -115,8 +137,13 @@ fn seed(launcher: &env::Launcher, dir: &std::path::Path, part: &str) -> Result<(
 }
 
 #[tauri::command]
-fn add_project(app: AppHandle, path: String) -> Result<String, String> {
-    let dir = PathBuf::from(&path)
+fn add_project(registry: State<Registry>, path: String) -> Result<String, String> {
+    let dir = register_project(&registry, PathBuf::from(path))?;
+    Ok(dir.to_string_lossy().into_owned())
+}
+
+fn register_project(registry: &Registry, path: PathBuf) -> Result<PathBuf, String> {
+    let dir = path
         .canonicalize()
         .map_err(|e| format!("cannot read that folder: {e}"))?;
     if !dir.join("parts").is_dir() {
@@ -126,8 +153,39 @@ fn add_project(app: AppHandle, path: String) -> Result<String, String> {
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .ok_or("cannot use the filesystem root as a project")?;
-    app.state::<Registry>().upsert(&name, &dir, None);
-    Ok(dir.to_string_lossy().into_owned())
+    registry.upsert(&name, &dir, None);
+    Ok(dir)
+}
+
+fn register_projects_in_folder(
+    registry: &Registry,
+    folder: PathBuf,
+) -> Result<Vec<String>, String> {
+    let folder = folder
+        .canonicalize()
+        .map_err(|e| format!("cannot read that folder: {e}"))?;
+    let entries =
+        std::fs::read_dir(&folder).map_err(|e| format!("cannot read {}: {e}", folder.display()))?;
+    let mut projects = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.join("parts").is_dir() {
+            continue;
+        }
+        if let Ok(path) = register_project(registry, path) {
+            projects.push(path.to_string_lossy().into_owned());
+        }
+    }
+    projects.sort();
+    Ok(projects)
+}
+
+#[tauri::command]
+fn add_projects_from_folder(
+    registry: State<Registry>,
+    folder: String,
+) -> Result<Vec<String>, String> {
+    register_projects_in_folder(&registry, PathBuf::from(folder))
 }
 
 #[tauri::command]
@@ -407,8 +465,10 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             list_projects,
+            default_projects_folder,
             create_project,
             add_project,
+            add_projects_from_folder,
             remove_project,
             select_part,
             select_part_chat,
@@ -444,7 +504,9 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
-    use super::{part_views, seed_part_name};
+    use super::registry::Registry;
+    use super::{part_views, project_base, register_projects_in_folder, seed_part_name};
+    use std::path::PathBuf;
 
     #[test]
     fn seed_part_names_survive_becoming_identifiers() {
@@ -455,6 +517,54 @@ mod tests {
         assert_eq!(seed_part_name("_widget"), "part-_widget");
         assert_eq!(seed_part_name("émile"), "mile");
         assert_eq!(seed_part_name("支架"), "part");
+    }
+
+    #[test]
+    fn project_base_uses_the_custom_folder_or_the_documents_default() {
+        let documents = PathBuf::from("/Users/test/Documents");
+        assert_eq!(
+            project_base(Some("/Volumes/Work/nurb".into()), documents.join("nurb")),
+            PathBuf::from("/Volumes/Work/nurb")
+        );
+        assert_eq!(
+            project_base(None, documents.join("nurb")),
+            documents.join("nurb")
+        );
+        assert_eq!(
+            project_base(Some("  ".into()), documents.join("nurb")),
+            documents.join("nurb")
+        );
+    }
+
+    #[test]
+    fn a_projects_folder_loads_only_its_direct_nurb_projects() {
+        let root = std::env::temp_dir().join(format!(
+            "nurb-project-folder-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let folder = root.join("projects");
+        std::fs::create_dir_all(folder.join("alpha/parts")).unwrap();
+        std::fs::create_dir_all(folder.join("beta/parts")).unwrap();
+        std::fs::create_dir_all(folder.join("not-a-project")).unwrap();
+        std::fs::create_dir_all(folder.join("group/nested/parts")).unwrap();
+
+        let registry = Registry::load(&root);
+        let loaded = register_projects_in_folder(&registry, folder).unwrap();
+
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(
+            registry
+                .list()
+                .into_iter()
+                .map(|view| view.project.name)
+                .collect::<Vec<_>>(),
+            ["alpha", "beta"]
+        );
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -52,10 +52,14 @@ fn seed_part_name(project: &str) -> String {
 }
 
 fn project_base(folder: Option<String>, default: PathBuf) -> PathBuf {
-    folder
-        .filter(|path| !path.trim().is_empty())
-        .map(PathBuf::from)
-        .unwrap_or(default)
+    match folder
+        .as_deref()
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+    {
+        Some(path) => PathBuf::from(path),
+        None => default,
+    }
 }
 
 fn default_projects_folder_path(app: &AppHandle) -> Result<PathBuf, String> {
@@ -138,11 +142,12 @@ fn seed(launcher: &env::Launcher, dir: &std::path::Path, part: &str) -> Result<(
 
 #[tauri::command]
 fn add_project(registry: State<Registry>, path: String) -> Result<String, String> {
-    let dir = register_project(&registry, PathBuf::from(path))?;
+    let (name, dir) = validated_project(PathBuf::from(path))?;
+    registry.upsert(&name, &dir, None);
     Ok(dir.to_string_lossy().into_owned())
 }
 
-fn register_project(registry: &Registry, path: PathBuf) -> Result<PathBuf, String> {
+fn validated_project(path: PathBuf) -> Result<(String, PathBuf), String> {
     let dir = path
         .canonicalize()
         .map_err(|e| format!("cannot read that folder: {e}"))?;
@@ -153,8 +158,7 @@ fn register_project(registry: &Registry, path: PathBuf) -> Result<PathBuf, Strin
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .ok_or("cannot use the filesystem root as a project")?;
-    registry.upsert(&name, &dir, None);
-    Ok(dir)
+    Ok((name, dir))
 }
 
 fn register_projects_in_folder(
@@ -172,8 +176,9 @@ fn register_projects_in_folder(
         if !path.join("parts").is_dir() {
             continue;
         }
-        if let Ok(path) = register_project(registry, path) {
-            projects.push(path.to_string_lossy().into_owned());
+        if let Ok((name, dir)) = validated_project(path) {
+            registry.adopt(&name, &dir);
+            projects.push(dir.to_string_lossy().into_owned());
         }
     }
     projects.sort();
@@ -564,6 +569,12 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["alpha", "beta"]
         );
+        // Swept-in projects were never opened, so none of them may win the
+        // launch-time "most recently opened" restore.
+        assert!(registry
+            .list()
+            .iter()
+            .all(|view| view.project.last_opened == 0));
         std::fs::remove_dir_all(root).unwrap();
     }
 

--- a/desktop/src-tauri/src/registry.rs
+++ b/desktop/src-tauri/src/registry.rs
@@ -79,6 +79,23 @@ impl Registry {
         self.save(&projects);
     }
 
+    /// Insert an entry without claiming recency. A project swept in from a
+    /// folder was never opened, so it must not win the launch-time
+    /// "most recently opened" restore over the one the user was actually in.
+    pub fn adopt(&self, name: &str, path: &Path) {
+        let mut projects = self.projects.lock().unwrap();
+        if projects.iter().any(|p| p.path == path) {
+            return;
+        }
+        projects.push(Project {
+            name: name.to_string(),
+            path: path.to_path_buf(),
+            last_opened: 0,
+            selected_part: None,
+        });
+        self.save(&projects);
+    }
+
     pub fn touch(&self, path: &Path) {
         let mut projects = self.projects.lock().unwrap();
         if let Some(project) = projects.iter_mut().find(|p| p.path == path) {

--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -1529,6 +1529,54 @@ textarea {
   overflow-x: auto;
 }
 
+/* ---- settings ---- */
+
+.about-card.settings {
+  width: min(480px, calc(100vw - 80px));
+}
+
+.settings-folder {
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--dim);
+  font: 12px/1.5 var(--mono);
+  overflow-wrap: anywhere;
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+.settings-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.settings-action {
+  border: 1px solid rgba(110, 231, 168, 0.35);
+  border-radius: 6px;
+  background: none;
+  color: var(--accent);
+  padding: 6px 12px;
+  font: 12px var(--mono);
+  cursor: pointer;
+}
+
+.settings-action:hover {
+  background: rgba(110, 231, 168, 0.1);
+}
+
+.settings-action.secondary {
+  border-color: var(--line);
+  color: var(--dim);
+}
+
+.settings-action.secondary:hover {
+  background: var(--active);
+  color: var(--text);
+}
+
 /* ---- the "need another agent?" help ---- */
 
 .about-card.agents-help {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -13,6 +13,7 @@ import { IconCheck, IconCube, IconCubes, IconFolder, IconFolderPlus } from "./Ic
 import { COLUMNS, fitColumns, initialColumns, resizedColumn } from "./layout";
 import type { Column } from "./layout";
 import Setup from "./Setup";
+import Settings from "./Settings";
 import "./App.css";
 
 type Project = {
@@ -69,6 +70,7 @@ type PartChat = { id: string | null; agent: string | null; gen: number };
 type ResumeState = { path: string; byPart: Record<string, PartChat> };
 
 const NO_PARTS: Part[] = [];
+const PROJECTS_FOLDER_KEY = "nurb-projects-folder";
 
 // What the rail says about an assembly, or nothing for an ordinary part. An
 // assembly that places nothing is still an assembly; it just has no list.
@@ -209,6 +211,11 @@ function App() {
   const [about, setAbout] = useState<AboutInfo | null>(null);
   const [showAbout, setShowAbout] = useState(false);
   const [showAgentsHelp, setShowAgentsHelp] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const [defaultProjectsFolder, setDefaultProjectsFolder] = useState<string | null>(null);
+  const [projectsFolder, setProjectsFolder] = useState<string | null>(
+    () => localStorage.getItem(PROJECTS_FOLDER_KEY),
+  );
   const [update, setUpdate] = useState<Update | null>(null);
   const [updating, setUpdating] = useState(false);
   // The one update this run acts on: found once, downloaded eagerly so the
@@ -246,6 +253,7 @@ function App() {
   useEffect(() => {
     if (ready !== true) return;
     invoke<AboutInfo>("about_info").then(setAbout).catch(() => {});
+    invoke<string>("default_projects_folder").then(setDefaultProjectsFolder).catch(() => {});
   }, [ready]);
 
   const installUpdate = useCallback(async () => {
@@ -340,6 +348,35 @@ function App() {
     setProjects(list);
     return list;
   }, []);
+
+  const changeProjectsFolder = async (folder: string | null) => {
+    setProjectsFolder(folder);
+    if (folder) localStorage.setItem(PROJECTS_FOLDER_KEY, folder);
+    else localStorage.removeItem(PROJECTS_FOLDER_KEY);
+
+    const selected =
+      folder ?? defaultProjectsFolder ?? await invoke<string>("default_projects_folder");
+    if (!defaultProjectsFolder && !folder) setDefaultProjectsFolder(selected);
+    if (
+      !(await ask("Load existing nurb projects directly inside this folder?", {
+        title: "Projects folder changed",
+        okLabel: "Load Projects",
+        cancelLabel: "Not Now",
+      }))
+    ) return;
+
+    try {
+      const loaded = await invoke<string[]>("add_projects_from_folder", { folder: selected });
+      await refreshProjects();
+      if (loaded.length === 0) {
+        await message("No nurb projects were found directly inside that folder.", {
+          title: "Projects folder",
+        });
+      }
+    } catch (e) {
+      setError(String(e));
+    }
+  };
 
   const openProject = useCallback(
     async (path: string) => {
@@ -496,7 +533,7 @@ function App() {
       setCreating(true);
       setError(null);
       try {
-        const path = await invoke<string>("create_project", { name });
+        const path = await invoke<string>("create_project", { name, folder: projectsFolder });
         setNaming(false);
         await refreshProjects();
         openProject(path);
@@ -506,7 +543,7 @@ function App() {
         setCreating(false);
       }
     },
-    [creating, refreshProjects, openProject],
+    [creating, projectsFolder, refreshProjects, openProject],
   );
 
   const createProject = async (event: FormEvent<HTMLFormElement>) => {
@@ -911,6 +948,9 @@ function App() {
         )}
         {error && <div className="rail-error">{error}</div>}
         <div className="rail-foot">
+          <button className="rail-version" onClick={() => setShowSettings(true)}>
+            settings
+          </button>
           {about && (
             <button className="rail-version" onClick={() => setShowAbout(true)}>
               nurb {about.appVersion}
@@ -972,6 +1012,15 @@ function App() {
             )}
           </div>
         </div>
+      )}
+      {showSettings && (
+        <Settings
+          folder={projectsFolder ?? defaultProjectsFolder ?? "~/Documents/nurb"}
+          customized={projectsFolder !== null}
+          onChange={changeProjectsFolder}
+          onReset={() => changeProjectsFolder(null)}
+          onClose={() => setShowSettings(false)}
+        />
       )}
       {showAbout && about && (
         <About

--- a/desktop/src/Settings.tsx
+++ b/desktop/src/Settings.tsx
@@ -10,9 +10,11 @@ type Props = {
 
 export default function Settings({ folder, customized, onChange, onReset, onClose }: Props) {
   const changeFolder = async () => {
+    // Before the backend resolves the default, the folder shown is the
+    // literal "~/Documents/nurb" placeholder, which is not a path.
     const picked = await pickFolder({
       directory: true,
-      defaultPath: folder,
+      defaultPath: folder.startsWith("~") ? undefined : folder,
       title: "Choose where new nurb projects are created",
     });
     if (typeof picked === "string") await onChange(picked);

--- a/desktop/src/Settings.tsx
+++ b/desktop/src/Settings.tsx
@@ -1,0 +1,55 @@
+import { open as pickFolder } from "@tauri-apps/plugin-dialog";
+
+type Props = {
+  folder: string;
+  customized: boolean;
+  onChange: (folder: string) => void | Promise<void>;
+  onReset: () => void | Promise<void>;
+  onClose: () => void;
+};
+
+export default function Settings({ folder, customized, onChange, onReset, onClose }: Props) {
+  const changeFolder = async () => {
+    const picked = await pickFolder({
+      directory: true,
+      defaultPath: folder,
+      title: "Choose where new nurb projects are created",
+    });
+    if (typeof picked === "string") await onChange(picked);
+  };
+
+  return (
+    <div className="about" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div
+        className="about-card settings"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="settings-title"
+      >
+        <button className="about-close" title="close" onClick={onClose}>
+          ×
+        </button>
+        <div className="about-title" id="settings-title">
+          Settings
+        </div>
+        <div className="about-body">
+          <h3>Projects folder</h3>
+          <p>New projects are created here. Changing it never moves existing files.</p>
+          <div className="settings-folder" title={folder}>
+            {folder}
+          </div>
+          <div className="settings-actions">
+            <button className="settings-action" onClick={changeFolder}>
+              Change folder
+            </button>
+            {customized && (
+              <button className="settings-action secondary" onClick={onReset}>
+                Use default
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a Settings modal for configuring the projects folder.
- Keeps `~/Documents/nurb` as the default.
- Allows any directory to be selected and remembers the choice.
- Creates new projects in the selected folder.
- Asks whether to load existing nurb projects after changing folders.
- Loads direct child folders containing a `parts/` directory without moving existing files.

## Screenshots

### Settings modal
<img width="1472" height="972" alt="Screenshot 2026-08-10 at 23 15 40" src="https://github.com/user-attachments/assets/d8848344-52c5-4bc3-b7fe-8e24362e6115" />

### Prompt to load projects in that folder
<img width="1472" height="972" alt="Screenshot 2026-08-10 at 23 26 27" src="https://github.com/user-attachments/assets/38469ae9-c3ea-4c22-b4b2-9443c3607dc3" />

### Settings link at the bottom
<img width="1472" height="972" alt="Screenshot 2026-08-10 at 23 33 25" src="https://github.com/user-attachments/assets/8c16b63d-7bde-4a7a-93dd-e8407ef5bb82" />
