### PR TITLE
Add a warp_risk check for large first layers with sharp corners

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ min_wall          thinnest section, ray cast corrected by an inscribed sphere
 sliver            faces too small to print as anything but a smear
 concave_cosmetic  polish laid into an inside corner
 bed_bevel         polish laid on the edges that meet the build plate
+warp_risk         large first layers with corners likely to lift as they cool
 stability         center of mass outside the footprint
 projection_ratio  reach over height, for a part cantilevered off a wall
 build_volume      does it fit the printer at all

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -11,7 +11,7 @@ import pathlib
 from dataclasses import dataclass, field, replace
 from math import asin, atan2, cos, degrees, pi, sin
 
-from build123d import Axis, CenterOf, GeomType, Vector
+from build123d import Axis, CenterOf, GeomType, Plane, Vector
 
 FAIL = "fail"  # this will not print, or will not work
 WARN = "warn"  # this needs attention, most often support
@@ -35,6 +35,7 @@ LABELS = {
     "sliver": "tiny detail",
     "concave_cosmetic": "inside corner",
     "bed_bevel": "poor bed grip",
+    "warp_risk": "corners lift",
     "stability": "tips over",
     "projection_ratio": "long reach",
     "build_volume": "too big",
@@ -103,6 +104,8 @@ class Context:
     cosmetic_chamfer: float = 1.0  # the size the polish pass uses
     min_wall: float = 1.0  # what this printer lays down reliably; per part, per card
     sliver_area: float = 1.0
+    warp_area: float = 20000.0  # first-layer mm2 past which contraction peels sharp corners
+    warp_radius: float = 8.0  # a plan corner rounded under this is still a peel point
     accepted: dict = field(default_factory=dict)  # rule -> how many are already known
 
 
@@ -347,9 +350,15 @@ def _span(shape, up):
     vertices put the bed 8mm above the actual bottom of a cylinder, marked every face
     grounded, and turned the overhang rule off without any sign that it had happened.
 
-    Exact for an axis-aligned build direction, which is what a part placed on a bed
-    has. Conservative otherwise.
+    A bounding box only answers exactly along its own axes. For any other build
+    direction, first put the shape into a coordinate system whose Z is `up`; its local
+    Z bounds are then the exact projection rather than the conservative projection of
+    the world-axis box.
     """
+    if max(abs(up.X), abs(up.Y), abs(up.Z)) < 1.0 - 1e-9:
+        local = Plane(origin=(0, 0, 0), z_dir=up).to_local_coords(shape)
+        box = local.bounding_box()
+        return box.min.Z, box.max.Z
     box = shape.bounding_box()
     corners = [
         Vector(x, y, z)
@@ -875,6 +884,113 @@ def stability(shape, ctx):
                 )
             ]
     return []
+
+
+def _sharp_plan_corners(face, up, radius):
+    """Where a face's outline turns a corner's worth too fast for a `radius` round.
+
+    Sharpness here is turn per length of perimeter, not vertex angle, because a 1mm
+    polish chamfer is still the corner it dresses: the outline turns its full 90
+    degrees within a couple of millimetres either way. Sampled as a polyline so a
+    true vertex, a chamfered corner and an undersized fillet all answer the same
+    question. The window is the perimeter a `radius` round spends turning 60
+    degrees, so anything rounded at least that generously stays under the bar
+    exactly. Concave corners turn against the outline's orientation and are
+    skipped: an inside corner has material outboard of it holding it down.
+    """
+    first, second = _bed_axes(up)
+    wire = face.outer_wire()
+    n = max(int(wire.length), 24)
+    pts = [wire.position_at(i / n) for i in range(n)]
+    flat = [(p.dot(first), p.dot(second)) for p in pts]
+    spacing = wire.length / n
+    turns = []
+    for i in range(n):
+        ax, ay = flat[i]
+        bx, by = flat[(i + 1) % n]
+        cx, cy = flat[(i + 2) % n]
+        ux, uy = bx - ax, by - ay
+        vx, vy = cx - bx, cy - by
+        turns.append(atan2(ux * vy - uy * vx, ux * vx + uy * vy))
+    orient = 1.0 if sum(turns) >= 0 else -1.0
+    corner = pi / 3
+    window = max(1, round(radius * corner / spacing))
+    hits = [
+        i
+        for i in range(n)
+        if orient * sum(turns[(i + j) % n] for j in range(window)) >= corner - 1e-9
+    ]
+    if not hits:
+        return []
+    # Consecutive windows over one corner are one corner. Clusters are gaps wider
+    # than the window itself, and the last cluster can wrap into the first.
+    clusters = [[hits[0]]]
+    for i in hits[1:]:
+        if i - clusters[-1][-1] <= window:
+            clusters[-1].append(i)
+        else:
+            clusters.append([i])
+    if len(clusters) > 1 and (hits[0] + n) - clusters[-1][-1] <= window:
+        clusters[0] = clusters.pop() + clusters[0]
+    out = []
+    for cluster in clusters:
+        peak = max(
+            (j % n for i in cluster for j in range(i, i + window)),
+            key=lambda j: orient * turns[j],
+        )
+        out.append(pts[(peak + 1) % n])
+    return out
+
+
+@rule("warp_risk")
+def warp_risk(shape, ctx):
+    """A first layer big enough for cooling contraction to peel its corners.
+
+    Every layer shrinks as it cools and pulls toward the middle of the part. On a
+    small part first-layer adhesion wins. On a big flat plate the accumulated pull
+    beats it, and it lets go where the pull concentrates: a sharp plan corner,
+    farthest from the middle and holding on at a point. The design-side fixes are in
+    the outline, which is why this is a CAD finding and elephant's foot is not:
+    round the vertical corners past `warp_radius` so the peel front is a curve, and
+    prefer a ribbed floor to a solid slab, which halves what contracts. The brim is
+    the slicer's share and the message says so, but a brim on sharp corners is
+    treating the symptom.
+
+    Only faces that are themselves plate-sized get their corners read: the ribs
+    under a properly ribbed floor are skinny rectangles full of sharp corners, and
+    each pulls far too little to peel.
+    """
+    up = Vector(*ctx.up).normalized()
+    bed, _ = _span(shape, up)
+    footing = [f for f in shape.faces() if _span(f, up)[1] <= bed + 1e-4]
+    area = sum(f.area for f in footing)
+    if area <= ctx.warp_area:
+        return []
+    sharp = [
+        point
+        for face in footing
+        if face.area >= ctx.warp_area / 2
+        for point in _sharp_plan_corners(face, up, ctx.warp_radius)
+    ]
+    if not sharp:
+        return []
+    centre = sum((f.center() * f.area for f in footing), Vector(0, 0, 0)) / area
+    worst = max(sharp, key=lambda point: (point - centre).length)
+    count = len(sharp)
+    return [
+        Finding(
+            "warp_risk",
+            WARN,
+            f"{count} sharp corner{'' if count == 1 else 's'} on a {area:.0f}mm2 "
+            f"first layer; contraction peels them as the print cools. Round plan "
+            f"corners past {ctx.warp_radius:.0f}mm, rib the floor instead of a "
+            f"solid slab, and print with a brim",
+            plain="a big flat base with sharp corners. The plastic shrinks as it "
+            "cools and curls them off the bed; rounded corners and a brim keep it down",
+            value=count,
+            where=tuple(round(v, 2) for v in worst),
+        )
+    ]
 
 
 # --- printer profiles --------------------------------------------------------

--- a/src/nurb/doctrine.md
+++ b/src/nurb/doctrine.md
@@ -61,6 +61,7 @@ bounding box and still exports, so nothing downstream catches it.
   steepen one or match it to a ratio. Let the landing point fall where 45 degrees puts
   it. Mismatched facet angles are a veto: every facet on the part, cosmetic or
   structural or corbel, has to read as one system.
+- **A large first layer peels its corners as it cools.** Every layer shrinks as it cools and pulls toward the middle of the part, and the pull lands hardest on a sharp plan corner, farthest from the middle and holding on at a point. Past about 20,000mm2 of first layer the accumulated pull beats corner adhesion, and `warp_risk` names the corners that will lift. The fixes are in the outline, which is what makes this a CAD problem where elephant's foot is not: round the vertical corners at 8mm or more, so the peel front is a curve instead of a point, and give a big plate a ribbed floor rather than a solid slab, which is stiffer per gram and halves what contracts. A 1mm polish chamfer is not relief here; it moves the point half a millimetre. The brim and the clean bed are the slicer's share, and they treat the symptom the outline caused.
 - **Elephant's foot is a slicer setting**, not a CAD problem. Do not model around it.
 
 ### Fasteners

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -6,7 +6,7 @@ finding is obvious from the geometry: a known angle, a known count, a known tip.
 
 from math import cos, radians, sin, tan
 
-from build123d import Align, Box, Cylinder, Plane, Pos, Rot, extrude, Polygon
+from build123d import Align, Axis, Box, Cylinder, Plane, Pos, Rot, extrude, Polygon
 import pytest
 
 from nurb.checks import FAIL, WARN, Context, run
@@ -178,6 +178,63 @@ def test_grown_fins_clear_the_stability_rule_on_a_tall_part():
 
     finned = stand(Box(4, 30, 160), tilt=45, facet=2.0)
     assert only(finned, "stability") == []
+
+
+# --- warp risk ---------------------------------------------------------------
+
+
+def test_a_big_plate_with_sharp_corners_will_curl():
+    """The 300 x 150 shelf that lifted all four corners off the bed: a 45,000mm2
+    first layer with each corner holding on at a point."""
+    found = only(Box(300, 150, 5), "warp_risk")
+    assert len(found) == 1
+    assert found[0].severity == WARN
+    assert found[0].value == 4
+
+
+def test_a_polish_chamfer_is_not_corner_relief():
+    """A 1mm chamfer moves the point half a millimetre; the outline still turns its
+    full 90 degrees within a couple of millimetres and still peels."""
+    from build123d import chamfer
+
+    plate = chamfer(Box(300, 150, 5).edges().filter_by(Axis.Z), 1.0)
+    assert len(only(plate, "warp_risk")) == 1
+
+
+def test_rounded_corners_spread_the_peel_and_clear_it():
+    from build123d import fillet
+
+    plate = fillet(Box(300, 150, 5).edges().filter_by(Axis.Z), 8.0)
+    assert only(plate, "warp_risk") == []
+
+
+def test_an_undersized_round_is_still_a_peel_point():
+    from build123d import fillet
+
+    plate = fillet(Box(300, 150, 5).edges().filter_by(Axis.Z), 6.0)
+    assert len(only(plate, "warp_risk")) == 1
+
+
+def test_warp_risk_uses_a_non_axis_aligned_build_direction():
+    """Changing coordinates does not change the plate or make its footing disappear."""
+    plate = Rot(0, 45, 0) * Box(300, 150, 5)
+    diagonal = sin(radians(45)), 0, cos(radians(45))
+    found = only(plate, "warp_risk", Context(up=diagonal))
+    assert len(found) == 1
+    assert found[0].value == 4
+
+
+def test_a_small_first_layer_never_warps():
+    """Sharp corners and all: 10,000mm2 is what adhesion holds without help."""
+    assert only(Box(100, 100, 5), "warp_risk") == []
+
+
+def test_a_ribbed_floor_contracts_too_little_to_peel():
+    """The same 300 x 150 plate lifted onto ribs: the first layer is the rib
+    bottoms, skinny rectangles full of sharp corners that each pull too little."""
+    floor = Pos(0, 0, 3.5) * Box(300, 150, 3)
+    ribbed = sum((Pos(x, 0, 1) * Box(3, 150, 2) for x in range(-135, 150, 30)), floor)
+    assert only(ribbed, "warp_risk") == []
 
 
 # --- sliver ------------------------------------------------------------------


### PR DESCRIPTION
A 300 x 150mm plate lifted all four corners off the bed, and nothing in the rules had an opinion about it. The new `warp_risk` rule fires when the first layer is past 20,000mm2 and its outline has sharp plan corners, measured as turn per length of perimeter so a 1mm polish chamfer still counts as the corner it is, while an 8mm round clears it. The finding names the worst corner and the fixes: round plan corners, rib the floor instead of a solid slab, and print with a brim; both thresholds are ordinary Context settings a card or printer.toml can tune. The doctrine gets the physics in a bullet next to the elephant's foot rule, the README's rule list gets the line, and the viewer's checks panel shows it as "corners lift". Along the way `_span` now projects exactly along a tilted build direction instead of conservatively, covered by a new test, with the whole suite at 513 passing.