### PR TITLE
Add flexure, fits, hole and pin rules, and a material-aware warp_risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,13 @@ sliver            faces too small to print as anything but a smear
 concave_cosmetic  polish laid into an inside corner
 bed_bevel         polish laid on the edges that meet the build plate
 warp_risk         large first layers with corners likely to lift as they cool
+pin               a free-standing pin too thin to be more than perimeters
 stability         center of mass outside the footprint
 projection_ratio  reach over height, for a part cantilevered off a wall
 build_volume      does it fit the printer at all
 ```
 
-Name your machine once in `printer.toml` (`profile = "bambu_a1_mini"`), or try another with `nurb check --printer prusa_mk4s`. The viewer's print time row will also ask you for it the first time you use it, and write the answer here. Better: a printer is a fact about your workshop, not your project, so `~/.config/nurb/config.toml` takes the same schema and answers for every project on the machine; `printer.toml` wins where they disagree, and `nurb check` says which file supplied the profile. Either file carries the export preference too: an `[export]` table with `formats = ["stl", "step"]` adds STEP to every `nurb export`, and `--formats` still wins for one run. A part records what it has already justified on its card, so known findings stay silent and new ones are regressions:
+Name your machine once in `printer.toml` (`profile = "bambu_a1_mini"`), or try another with `nurb check --printer prusa_mk4s`. The viewer's print time row will also ask you for it the first time you use it, and write the answer here. Better: a printer is a fact about your workshop, not your project, so `~/.config/nurb/config.toml` takes the same schema and answers for every project on the machine; `printer.toml` wins where they disagree, and `nurb check` says which file supplied the profile. Either file can also name what you print in (`material = "abs"`), and `warp_risk` tightens to match how hard that plastic shrinks. Either file carries the export preference too: an `[export]` table with `formats = ["stl", "step"]` adds STEP to every `nurb export`, and `--formats` still wins for one run. A part records what it has already justified on its card, so known findings stay silent and new ones are regressions:
 
 ```toml
 [part]

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -36,6 +36,7 @@ LABELS = {
     "concave_cosmetic": "inside corner",
     "bed_bevel": "poor bed grip",
     "warp_risk": "corners lift",
+    "pin": "skinny pin",
     "stability": "tips over",
     "projection_ratio": "long reach",
     "build_volume": "too big",
@@ -106,6 +107,7 @@ class Context:
     sliver_area: float = 1.0
     warp_area: float = 20000.0  # first-layer mm2 past which contraction peels sharp corners
     warp_radius: float = 8.0  # a plan corner rounded under this is still a peel point
+    material: str | None = None  # what this prints in; scales warp_area, see SHRINK
     accepted: dict = field(default_factory=dict)  # rule -> how many are already known
 
 
@@ -942,6 +944,21 @@ def _sharp_plan_corners(face, up, radius):
     return out
 
 
+# Cooling contraction by material, in percent. `warp_area` was calibrated on a PLA
+# plate, so PLA is the unit: a plastic that contracts five times as much peels the same
+# corners off a fifth of the area. The figures are the guides' (Prusa's material pages
+# put ABS at 1-2% shrink and flatly refuse bed-covering ABS, ASA or PC parts; Hubs
+# gives 0.2-1% across materials), rounded to one calibration point per family.
+SHRINK = {
+    "pla": 0.3,
+    "petg": 0.3,
+    "abs": 1.5,
+    "asa": 1.5,
+    "pc": 2.0,
+    "pp": 2.0,
+}
+
+
 @rule("warp_risk")
 def warp_risk(shape, ctx):
     """A first layer big enough for cooling contraction to peel its corners.
@@ -964,12 +981,13 @@ def warp_risk(shape, ctx):
     bed, _ = _span(shape, up)
     footing = [f for f in shape.faces() if _span(f, up)[1] <= bed + 1e-4]
     area = sum(f.area for f in footing)
-    if area <= ctx.warp_area:
+    pull = SHRINK[(ctx.material or "pla").lower()] / SHRINK["pla"]
+    if area * pull <= ctx.warp_area:
         return []
     sharp = [
         point
         for face in footing
-        if face.area >= ctx.warp_area / 2
+        if face.area * pull >= ctx.warp_area / 2
         for point in _sharp_plan_corners(face, up, ctx.warp_radius)
     ]
     if not sharp:
@@ -977,20 +995,119 @@ def warp_risk(shape, ctx):
     centre = sum((f.center() * f.area for f in footing), Vector(0, 0, 0)) / area
     worst = max(sharp, key=lambda point: (point - centre).length)
     count = len(sharp)
+    made_of = f" in {ctx.material.upper()}, which contracts {pull:.0f}x what PLA does" if pull > 1 else ""
+    plastic = ctx.material.upper() if pull > 1 else "The plastic"
     return [
         Finding(
             "warp_risk",
             WARN,
             f"{count} sharp corner{'' if count == 1 else 's'} on a {area:.0f}mm2 "
-            f"first layer; contraction peels them as the print cools. Round plan "
-            f"corners past {ctx.warp_radius:.0f}mm, rib the floor instead of a "
+            f"first layer{made_of}; contraction peels them as the print cools. Round "
+            f"plan corners past {ctx.warp_radius:.0f}mm, rib the floor instead of a "
             f"solid slab, and print with a brim",
-            plain="a big flat base with sharp corners. The plastic shrinks as it "
+            plain=f"a big flat base with sharp corners. {plastic} shrinks as it "
             "cools and curls them off the bed; rounded corners and a brim keep it down",
             value=count,
             where=tuple(round(v, 2) for v in worst),
         )
     ]
+
+
+def _pins(shape, up):
+    """Free-standing vertical cylinders, as (diameter, height, top_centre) each.
+
+    Faces are grouped by axis and radius because a boolean routinely splits one
+    cylinder into two half faces, and only a group whose faces close the full circle
+    is a pin: anything merged into a wall loses part of its wrap to the join, and a
+    fillet or a rounded corner never had it. A hole is the same surface with its
+    normal pointing inward, so a group with any inward face is not a pin either.
+    """
+    from OCP.BRepAdaptor import BRepAdaptor_Surface
+
+    groups = {}
+    for face in shape.faces():
+        if face.geom_type != GeomType.CYLINDER:
+            continue
+        surf = BRepAdaptor_Surface(face.wrapped)
+        cyl = surf.Cylinder()
+        axis = Vector(cyl.Axis().Direction().X(), cyl.Axis().Direction().Y(), cyl.Axis().Direction().Z())
+        if abs(axis.dot(up)) < 0.99:
+            continue  # lying down, printed as solid strands rather than stacked rings
+        spot = cyl.Location()
+        point = Vector(spot.X(), spot.Y(), spot.Z())
+        foot = point - up * point.dot(up)
+        key = (round(foot.X, 2), round(foot.Y, 2), round(foot.Z, 2), round(cyl.Radius(), 3))
+        sample = face.position_at(0.5, 0.5)
+        radial = sample - foot - up * sample.dot(up)
+        low, high = _span(face, up)
+        wrap = abs(surf.LastUParameter() - surf.FirstUParameter())
+        entry = groups.setdefault(
+            key,
+            {
+                "wrap": 0.0,
+                "low": low,
+                "high": high,
+                "out": True,
+                "foot": foot,
+                "radius": cyl.Radius(),
+            },
+        )
+        entry["wrap"] += wrap
+        entry["low"] = min(entry["low"], low)
+        entry["high"] = max(entry["high"], high)
+        entry["out"] &= face.normal_at(sample).dot(radial) > 0
+    first, second = _bed_axes(up)
+    out = []
+    for entry in groups.values():
+        if not entry["out"] or entry["wrap"] < 2 * pi - 0.05:
+            continue
+        radius = entry["radius"]
+        top = entry["foot"] + up * entry["high"]
+        # A standoff between two bodies has the same full cylindrical wrap as a pin,
+        # but opens into material beyond its radius instead of ending in a free tip.
+        above = top + up * PROBE
+        if any(
+            shape.is_inside(above + across * (radius + PROBE))
+            for across in (first, -first, second, -second)
+        ):
+            continue
+        out.append((2 * radius, entry["high"] - entry["low"], top))
+    return out
+
+
+@rule("pin")
+def pin(shape, ctx):
+    """A free-standing pin too thin to be more than perimeters.
+
+    Under 5mm across there is no room inside the perimeters for infill, so a pin is
+    walls with nothing between them, loaded in bending at the one place FDM is
+    weakest, its base weld. Under 3mm the nozzle is re-melting what it laid one ring
+    ago and the pin may not survive its own printing. Only slender pins are the
+    problem: a stub no taller than twice its diameter has nothing to lever with,
+    which is why a chamfered boss or a locating nub never fires this.
+    """
+    up = Vector(*ctx.up).normalized()
+    found = []
+    for dia, height, top in _pins(shape, up):
+        if dia >= 5.0 or height < 2 * dia:
+            continue
+        if dia < 3.0:
+            severity, because = FAIL, "under 3mm it may not print at all"
+        else:
+            severity, because = WARN, "perimeter-only, weakest at its base weld"
+        found.append(
+            Finding(
+                "pin",
+                severity,
+                f"a {dia:.1f}mm pin standing {height:.0f}mm, {because}. Thicken it "
+                f"past 5mm, or model the hole and press in a metal pin",
+                plain=f"a printed peg only {dia:.1f}mm across. It prints as a thin "
+                "tube and snaps off at the base",
+                value=round(dia, 1),
+                where=tuple(round(v, 2) for v in top),
+            )
+        )
+    return found
 
 
 # --- printer profiles --------------------------------------------------------
@@ -1172,6 +1289,13 @@ def _apply(ctx, block, where):
                 f"have: {', '.join(sorted(vars(Context())))}"
             )
         setattr(ctx, field_name, tuple(value) if isinstance(value, list) else value)
+    if ctx.material is not None:
+        ctx.material = str(ctx.material).lower()
+        if ctx.material not in SHRINK:
+            raise ValueError(
+                f"{where}: no material called {ctx.material!r}. "
+                f"have: {', '.join(sorted(SHRINK))}"
+            )
     return ctx
 
 

--- a/src/nurb/doctrine.md
+++ b/src/nurb/doctrine.md
@@ -61,8 +61,15 @@ bounding box and still exports, so nothing downstream catches it.
   steepen one or match it to a ratio. Let the landing point fall where 45 degrees puts
   it. Mismatched facet angles are a veto: every facet on the part, cosmetic or
   structural or corbel, has to read as one system.
-- **A large first layer peels its corners as it cools.** Every layer shrinks as it cools and pulls toward the middle of the part, and the pull lands hardest on a sharp plan corner, farthest from the middle and holding on at a point. Past about 20,000mm2 of first layer the accumulated pull beats corner adhesion, and `warp_risk` names the corners that will lift. The fixes are in the outline, which is what makes this a CAD problem where elephant's foot is not: round the vertical corners at 8mm or more, so the peel front is a curve instead of a point, and give a big plate a ribbed floor rather than a solid slab, which is stiffer per gram and halves what contracts. A 1mm polish chamfer is not relief here; it moves the point half a millimetre. The brim and the clean bed are the slicer's share, and they treat the symptom the outline caused.
+- **A large first layer peels its corners as it cools.** Every layer shrinks as it cools and pulls toward the middle of the part, and the pull lands hardest on a sharp plan corner, farthest from the middle and holding on at a point. Past about 20,000mm2 of first layer the accumulated pull beats corner adhesion, and `warp_risk` names the corners that will lift. The fixes are in the outline, which is what makes this a CAD problem where elephant's foot is not: round the vertical corners at 8mm or more, so the peel front is a curve instead of a point, and give a big plate a ribbed floor rather than a solid slab, which is stiffer per gram and halves what contracts. A 1mm polish chamfer is not relief here; it moves the point half a millimetre. The brim and the clean bed are the slicer's share, and they treat the symptom the outline caused. Material multiplies the pull: the threshold is calibrated on PLA, and naming what the machine prints in `printer.toml`, `material = "abs"` next to the profile line, tightens it fivefold, because ABS contracts 1 to 2% as it cools where PLA holds under half a percent. PETG judges as PLA, ASA as ABS, and PC and PP tighter still. At the far end the rule stops being about corners: a bed-covering part in ABS, ASA or PC is the wrong material, and the fix is PETG or PLA, not a wider brim.
 - **Elephant's foot is a slicer setting**, not a CAD problem. Do not model around it.
+- **A pin under 5mm across is perimeters with nothing inside.** There is no room between the walls for infill, so a thin printed pin is a tube, loaded in bending at the weakest weld it has, its base. Under 3mm the nozzle is re-melting each ring as it lays the next, and the pin may not survive its own printing. `pin` fires on a free-standing vertical cylinder taller than twice its diameter; a stub or a locating nub has nothing to lever with and stays silent. The fixes, in order: thicken it past 5mm, give its base a structural chamfer sized like any other loaded junction, or model the hole instead and press in a metal pin, the same trade the fastener rules already make, because off-the-shelf steel beats printed plastic everywhere they compete.
+
+### Holes
+
+- **No hole under 2mm across.** Below that the perimeters converge and the bore prints as a smear or closes outright. A locating hole that small is a drill's job: model a 1mm dimple to centre the bit and let steel cut the diameter.
+- **Every vertical bore prints small**, by the same few tenths the fastener table's medium column already absorbs for screws, and the physics does not care that a dowel or a shaft is not a screw. Any bore gets the medium column's slack against its rod's true diameter, and when the diameter genuinely matters, printing is the wrong finisher: model half a millimetre under and drill to size, because a drill holds a tolerance no printer does.
+- **A horizontal hole's crown is a bridge.** Under the printer's span limit no rule minds it, but the crown sags into the bore and prints out of round exactly where a fit would bear. Prefer standing the hole vertical; the orientation rules usually allow it. When the axis cannot move and roundness matters, roof the bore with two 45 degree chords meeting in a point above the crown, a teardrop, which is the counterbore's idea turned sideways: every layer leans on the one before instead of spanning air.
 
 ### Fasteners
 
@@ -87,6 +94,23 @@ Clearance is ISO 273, cap head is ISO 4762 socket head, nut is ISO 4032 hex. In 
 **A nut pocket is a hex prism, and `counterbore` cannot cut one.** It cuts a cylinder, so the pocket is modelled by hand: `extrude(RegularPolygon(across_corners / 2, 6), thickness + 0.2)` sized on the across-corners column, or a round pocket at across-corners plus 0.2 if the nut is free to spin. A hex takes about 0.2 of slack across the flats, and rotating the prism so a flat rather than a point faces up prints a cleaner socket. It floats its own ceiling exactly the way a screw head does and earns the same `hole_ceiling` finding, so the two sacrificial bridge layers still apply; that trick is the part of `counterbore` worth copying, and the cylinder is not.
 
 **Heat-set inserts are the exception that proves the rule.** Their boss diameter is set by the insert a particular vendor ships and not by any standard, the same nominal thread differs by half a millimetre between brands, and the number that matters is the one on the bag in the user's drawer. Ask, or measure one, and record it with `measured()`.
+
+**Never model a thread under M5.** A printed thread below that is slivers arranged in a helix: the crests print as smears, and what does print strips the first time it is torqued. The hardware above is the answer, a nut in its pocket or a heat-set insert, and even past M5 a modelled thread is a choice the card justifies, never a default.
+
+**A loaded hole earns a fastener diameter of wall.** An M5 screw wants 5mm of material around its bore. Thinner, and the boss bulges as the screw seats, then splits along a layer weld, which is the one direction a boss cannot spare. The clearance columns say where the hole is; this says how much part has to be around it.
+
+### Fits between printed parts
+
+The fastener table covers steel meeting plastic. Two printed faces that work together get a designed gap of their own, sized by what the pair does, and stated as the total extra on the opening: a bore over its shaft, a pocket over its tongue, whatever dimension the pair shares.
+
+| Fit | Extra on the opening | What it feels like |
+| --- | --- | --- |
+| press | 0.1 | driven together once, holds by friction |
+| snug | 0.2 | slides on by hand, no rattle |
+| moving | 0.3 | swings and slides through its whole travel, the hinge floor |
+| free | 0.5 | drops in every time, on any printer, in any material |
+
+In mm. The table is where a fit starts, never what lets it skip the coupon: anything fit-critical is still measured, printed as a coupon, and corrected before the part prints. Two limits: below 0.1 is not a tighter press, it is a bind that varies by machine, and a moving pair never ships at less than 0.3, because the 0.2 that swings freely on the printer that made it seizes on the next one.
 
 ## Print orientation
 
@@ -146,6 +170,15 @@ a short vertical face of about 6mm, drawn in the profile. Do not chamfer thin-we
 afterwards: slope chamfers leave runout slivers and tip chamfers make compound-angle
 artifacts where they meet the platform. **Shape problems on a thin web get fixed in the
 profile, not with a dress-up feature.**
+
+### Features that flex
+
+Everything above stiffens. A clip or a snap arm works by bending instead, and bending is the load layer welds carry worst, so flexure gets one veto and a few numbers.
+
+- **Flex lies in the layer plane, never across it.** A snap arm built standing up bends around a layer weld and peels on the first deflection, or the fiftieth, and both are failures. Printed lying down, the same bend stretches continuous strands and the arm is as good as the plastic. This is the anisotropy rule with the load reversed: a static part carries load across welds badly, a flexing one not at all, so orientation is decided by the flexing feature before anything else gets a vote.
+- **A snap arm is at least 5mm wide, relieved at the root by half its own thickness, and tapered toward the tip.** The root relief is structural, sized with the load and cut before polish like the 3mm inside-corner rule it echoes, because the root is where every snap arm breaks. The taper spreads strain along the arm instead of parking it all at the root.
+- **A clip deflects during assembly and never while engaged.** Plastic creeps: an arm parked under bend is an arm slowly letting go. Give the engaged position 0.5mm of clearance so holding on costs the arm nothing.
+- **A living hinge is a proof of concept, not a part.** A printed one lasts tens of flexes, not thousands: the web is one or two beads thick, and every flex works the weld between them. A hinge that has to live is two parts and a pin, which the assemblies rules already know how to swing.
 
 ## Aesthetics
 
@@ -401,7 +434,9 @@ obstacle as something with honest volume in the first place.
 **Tangent is clear, and clear is not clearance.** Collision is intersection volume, so
 two faces that kiss at zero volume pass, the closed door resting on its stop included.
 In plastic a zero-clearance pass is already a bind. The declared range should carry
-the same honesty about clearance that a tongue's `fit` carries about width.
+the same honesty about clearance that a tongue's `fit` carries about width. The fits
+table puts numbers to that honesty: 0.3mm is the least a moving pair carries through
+its whole travel, and 0.5mm is what never binds.
 
 **The stop the sweep finds can be the detent the design wants.** The door that
 motivated all of this rests open at 240 degrees against the back of its own mount,

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -63,6 +63,18 @@ def test_an_unknown_profile_says_what_exists(tmp_path):
         printer(tmp_path)
 
 
+def test_an_unknown_material_says_what_exists(tmp_path):
+    project(tmp_path, 'material = "wood"\n')
+    with pytest.raises(ValueError, match="petg"):
+        printer(tmp_path)
+
+
+def test_the_material_reaches_the_context_lowercased(tmp_path):
+    """The file can say ABS; the SHRINK table speaks lowercase."""
+    project(tmp_path, 'material = "ABS"\n')
+    assert printer(tmp_path).material == "abs"
+
+
 def test_the_export_table_is_not_a_printer_setting(tmp_path):
     """`[export]` belongs to `nurb export`; a check must walk past it, not choke."""
     project(tmp_path, 'profile = "bambu_a1_mini"\n\n[export]\nformats = ["stl"]\n')

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -237,6 +237,90 @@ def test_a_ribbed_floor_contracts_too_little_to_peel():
     assert only(ribbed, "warp_risk") == []
 
 
+def test_a_shrinky_material_tightens_the_warp_threshold():
+    """The 100mm plate that PLA holds down: ABS contracts five times as much, so
+    the same pull arrives off a fifth of the area, and the finding says which
+    plastic to blame."""
+    plate = Box(100, 100, 5)
+    assert only(plate, "warp_risk") == []
+    found = only(plate, "warp_risk", Context(material="abs"))
+    assert len(found) == 1
+    assert "ABS" in found[0].message
+
+
+def test_a_shrinky_material_scales_the_face_threshold_too():
+    """An 8,100mm2 ABS plate is past its 4,000mm2 threshold even though it is
+    smaller than half the unscaled PLA threshold."""
+    found = only(Box(90, 90, 5), "warp_risk", Context(material="abs"))
+    assert len(found) == 1
+    assert found[0].value == 4
+
+
+def test_petg_judges_as_pla():
+    assert only(Box(100, 100, 5), "warp_risk", Context(material="petg")) == []
+
+
+# --- pin ---------------------------------------------------------------------
+
+SEAT = (Align.CENTER, Align.CENTER, Align.MIN)
+
+
+def test_a_thin_pin_may_not_print_at_all():
+    """2.5mm across: the nozzle re-melts each ring as it lays the next."""
+    shape = Box(20, 20, 4) + Pos(0, 0, 2) * Cylinder(1.25, 10, align=SEAT)
+    found = only(shape, "pin")
+    assert len(found) == 1
+    assert found[0].severity == FAIL
+    assert found[0].value == 2.5
+
+
+def test_a_pin_under_5mm_is_perimeter_only():
+    """4mm across prints, but as a tube with nothing inside, weakest at its base."""
+    shape = Box(20, 20, 4) + Pos(0, 0, 2) * Cylinder(2, 12, align=SEAT)
+    found = only(shape, "pin")
+    assert len(found) == 1
+    assert found[0].severity == WARN
+
+
+def test_a_5mm_pin_has_room_for_infill():
+    shape = Box(20, 20, 4) + Pos(0, 0, 2) * Cylinder(3, 15, align=SEAT)
+    assert only(shape, "pin") == []
+
+
+def test_a_stub_has_nothing_to_lever_with():
+    """The same 4mm diameter, under twice its height: a locating nub, not a pin."""
+    shape = Box(20, 20, 4) + Pos(0, 0, 2) * Cylinder(2, 7, align=SEAT)
+    assert only(shape, "pin") == []
+
+
+def test_a_pin_lying_down_is_strands_not_rings():
+    """Printed horizontal, bending loads continuous strands, not stacked welds."""
+    shape = Box(4, 20, 20) + Pos(2, 0, 0) * Cylinder(1.25, 10, rotation=(0, 90, 0), align=SEAT)
+    assert only(shape, "pin") == []
+
+
+def test_a_bead_merged_into_a_wall_is_not_a_pin():
+    """A half-round hugging a wall for its whole height loses part of its wrap to
+    the join, and the wall carries the bending the rule worries about."""
+    wall = Pos(0, 0, 2) * Box(2, 20, 10, align=SEAT)
+    shape = Box(20, 20, 4) + wall + Pos(2, 0, 2) * Cylinder(1.25, 10, align=SEAT)
+    assert only(shape, "pin") == []
+
+
+def test_a_column_connected_at_both_ends_is_not_a_pin():
+    """A narrow standoff between two plates has no free tip to lever at its base."""
+    post = Pos(0, 0, 2) * Cylinder(2, 12, align=SEAT)
+    cap = Pos(0, 0, 14) * Box(20, 20, 4)
+    shape = Box(20, 20, 4) + post + cap
+    assert len(shape.solids()) == 1
+    assert only(shape, "pin") == []
+
+
+def test_a_hole_is_the_same_surface_facing_inward():
+    shape = Box(20, 20, 10) - Cylinder(1.25, 20)
+    assert only(shape, "pin") == []
+
+
 # --- sliver ------------------------------------------------------------------
 
 


### PR DESCRIPTION
A deep dive on the Prusa and Hubs FDM design guides against the existing doctrine surfaced six gaps, imported here in the doctrine's own voice. The doctrine gains a flexure section (bending lies in the layer plane, snap-arm numbers, a living hinge refusal), a clearance table for printed-part fits, a holes section (2mm floor, undersized vertical bores, teardrop crowns), and fastener rules for threads under M5 and boss walls.

A new `pin` check fails free-standing vertical cylinders under 3mm and warns under 5mm, staying silent for stubs, beads merged into walls, holes, and pins printed lying down. `printer.toml` can now declare `material = "abs"`, and `warp_risk` scales its first-layer threshold by how hard that plastic contracts, naming the material in the finding. Both rules are covered in tests both ways, and the full suite passes including every example part.