### PR TITLE
Release 0.17.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.16.0"
+version = "0.17.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,17 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.17.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.17.0">v0.17.0</a></span><time datetime="2026-08-12">August 12, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Corners lift.</b> A wide flat part pulls its corners off the bed as it cools, and nurb catches it before you print. It measures how sharp the corners are looking down at the part, names the worst one, and says what to do: round the corners, rib the floor instead of leaving it solid, print with a brim. Tell nurb you print in ABS and it expects the lift on smaller parts, because that plastic pulls harder.</span></li>
+      <li><b class="tag new">new</b><span><b>Thin posts.</b> A skinny post standing straight up off the bed breaks along the layers. Under 3mm across it fails, under 5mm it warns, and a post lying down or merged into a wall is left alone.</span></li>
+      <li><b class="tag new">new</b><span><b>Your projects folder.</b> The Mac app keeps projects in Documents/nurb, and Settings now lets you keep them anywhere. Point it at a folder that already holds nurb projects and it offers to load them where they are, without moving anything.</span></li>
+      <li><b class="tag">improved</b><span>Your AI knows more about what survives a print. New rules cover parts meant to flex, how much room two printed parts need to fit together, hole sizes and the vertical bores that come out undersized, and what it takes to put a screw into plastic. There is an aesthetics section too, so the dimensions that nothing else decides get chosen on purpose rather than left to chance.</span></li>
+      <li><b class="tag">fixed</b><span>One viewer tab per project. An AI that lost track of the viewer it already started used to open another tab every time it looked. A second start on a project that is already open now hands back the window that is running.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.16.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.16.0">v0.16.0</a></span><time datetime="2026-08-10">August 10, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.16.0"
+  version: "0.17.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.16.0"
+  version: "0.17.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Cuts 0.17.0 across the package, both skill files, and the desktop app, and adds the changelog entry.

## What ships

**Two new checks.** `warp_risk` catches a wide flat part whose first layer will pull its corners off the bed, measured as sharpness of the plan corners so a small polish chamfer still counts as a corner while a real round clears it. A `printer.toml` that declares `material = "abs"` gets a lower threshold, because that plastic contracts harder. `pin` fails a free-standing vertical post under 3mm across and warns under 5mm, staying quiet for stubs, beads merged into walls, and pins printed lying down.

**More design rules for the agent.** The doctrine gains a flexure section, a clearance table for printed-part fits, a holes section, fastener rules for threads and bosses, and an aesthetics section covering the dimensions that fit does not decide.

**A projects folder setting.** The Mac app still defaults to `~/Documents/nurb`, and Settings now points it anywhere. Choosing a folder that already holds nurb projects offers to load them in place.

**One viewer tab per project.** A `nurb dev` that finds its port taken now asks who holds it, and hands back the running URL when the same project is already being served instead of opening another tab.

## Verification

`uv run pytest tests/test_cli.py -q` passes, which is what enforces the four version strings agreeing. The changelog entry was rendered in a browser and matches its neighbors.