### PR TITLE
Add a project-wide chat and surface cross-part duplication in the viewer

### DIFF
--- a/desktop/src-tauri/src/acp.rs
+++ b/desktop/src-tauri/src/acp.rs
@@ -31,6 +31,10 @@ use crate::prefs::{ConfigChoice, ConfigRow, PrefStore};
 pub(crate) use events::ChatEvent;
 use events::{forward, permission_choice, permission_title, wire_string};
 
+/// The whole-project conversation rides the per-part session plumbing under a
+/// name no part file can have. The twin constant lives in desktop/src/Chat.tsx.
+const PROJECT_CHAT: &str = "//project";
+
 type Pending = Arc<Mutex<HashMap<u32, oneshot::Sender<RequestPermissionOutcome>>>>;
 
 pub struct Chats {
@@ -315,10 +319,12 @@ pub async fn send_prompt(
             )
         })
         .unwrap_or_default();
-    let selected = part
-        .as_ref()
-        .map(|part| format!(" This conversation is about the part \"{part}\", which is on screen beside the chat."))
-        .unwrap_or_default();
+    let selected = match part.as_deref() {
+        // The rail's project row; the twin constant lives in Chat.tsx.
+        Some(PROJECT_CHAT) => " This conversation is about the whole project rather than one part. You can create parts with `nurb new`, edit any part, and lift design the parts share into system.py at the project root; the app notices new and rebuilt parts on its own.".to_string(),
+        Some(part) => format!(" This conversation is about the part \"{part}\", which is on screen beside the chat."),
+        None => String::new(),
+    };
     let context = format!(
         "Context: nurb project \"{project_name}\".{selected}{server} \
         The user is a 3D-printing hobbyist, not a programmer, and the app hides all files and code: \

--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -369,6 +369,15 @@ textarea {
   color: var(--dim);
 }
 
+/* The whole-project conversation sits above the parts it spans. A hairline under it
+   keeps it from reading as the first part of the list. */
+.part-row.project-chat {
+  margin-bottom: 3px;
+  padding-bottom: 5px;
+  border-bottom: 1px solid var(--line);
+  border-radius: 0 5px 0 0;
+}
+
 /* The accent left edge is the viewer's own "this one is live" mark. */
 .part-row.selected {
   color: var(--text);
@@ -1072,10 +1081,15 @@ textarea {
   border-color: rgba(110, 231, 168, 0.65);
 }
 
+/* The column can be dragged to 240px, narrower than attach + the model summary +
+   send in one line. Wrapping beats clipping: send drops under the box, and the
+   auto margin keeps it on the right edge of its own row. */
 .chat-composer-controls {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 2px 8px;
 }
 
 .chat-attach {
@@ -1238,6 +1252,8 @@ textarea {
   color: #10281b;
   cursor: pointer;
   flex: none;
+  /* Wrapped onto its own line in a narrow column, it stays on the right edge. */
+  margin-left: auto;
 }
 
 .chat-send:hover {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -8,7 +8,7 @@ import { check, Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import About from "./About";
 import AgentsHelp from "./AgentsHelp";
-import Chat, { AGENT_LABEL } from "./Chat";
+import Chat, { AGENT_LABEL, PROJECT_CHAT } from "./Chat";
 import { IconCheck, IconCube, IconCubes, IconFolder, IconFolderPlus } from "./Icons";
 import { COLUMNS, fitColumns, initialColumns, resizedColumn } from "./layout";
 import type { Column } from "./layout";
@@ -136,6 +136,12 @@ function App() {
   // background; only the selected part's column is visible.
   const [mountedParts, setMountedParts] = useState<string[]>([]);
   const [busyParts, setBusyParts] = useState<Record<string, boolean>>({});
+  // The project row's conversation covers the whole project; while it is focused
+  // the viewer keeps showing the selected part, so this is chat focus, not selection.
+  const [projectChatFocused, setProjectChatFocused] = useState(false);
+  // Composer text waiting for the project chat, from the viewer's "unify in chat"
+  // nudge. Prefilled, never sent: the lift stays the user's call.
+  const [projectSeed, setProjectSeed] = useState<string | null>(null);
   const [agentStatuses, setAgentStatuses] = useState<AgentStatus[]>([]);
   const [signingIn, setSigningIn] = useState<string | null>(null);
   // A UI preference like the agent below, so it persists the same way.
@@ -306,16 +312,36 @@ function App() {
   // And its STL/STEP buttons write into the project's build folder, then hand
   // over the path: a webview ignores an <a download>, so the file is revealed in
   // Finder instead of downloaded.
+  const focusProjectChat = useCallback((seed?: string) => {
+    setMountedParts((list) =>
+      list.includes(PROJECT_CHAT) ? list : [...list, PROJECT_CHAT],
+    );
+    setProjectChatFocused(true);
+    if (seed) setProjectSeed(seed);
+  }, []);
+
   useEffect(() => {
     const onMessage = (event: MessageEvent) => {
       if (!/^http:\/\/(127\.0\.0\.1|localhost):\d+$/.test(event.origin)) return;
       if (event.data === "nurb:drag") getCurrentWindow().startDragging().catch(() => {});
       if (event.data?.type === "nurb:saved" && typeof event.data.path === "string")
         revealItemInDir(event.data.path).catch(() => {});
+      // The viewer's "unify in chat" nudge: parts repeating the same construction
+      // are a project-wide matter, so it lands in the project conversation.
+      if (
+        event.data?.type === "nurb:shared" &&
+        Array.isArray(event.data.parts) &&
+        event.data.parts.every((p: unknown) => typeof p === "string")
+      ) {
+        const names = event.data.parts as string[];
+        focusProjectChat(
+          `The parts ${names.join(", ")} repeat the same construction. If it is genuinely shared, unify it so they stay in step.`,
+        );
+      }
     };
     window.addEventListener("message", onMessage);
     return () => window.removeEventListener("message", onMessage);
-  }, []);
+  }, [focusProjectChat]);
 
   const refreshAgents = useCallback(async () => {
     setAgentStatuses(await invoke<AgentStatus[]>("agent_statuses"));
@@ -455,6 +481,8 @@ function App() {
     setMountedParts([]);
     setBusyParts({});
     setPartNaming(false);
+    setProjectChatFocused(false);
+    setProjectSeed(null);
     if (!active) return;
     let stale = false;
     invoke<ChatInfo[]>("list_sessions", { path: active })
@@ -505,6 +533,7 @@ function App() {
   useEffect(() => {
     if (!active || partState?.path !== active) return;
     const live = new Set(partState.parts.map((part) => part.name));
+    live.add(PROJECT_CHAT); // no rail part backs it, but its row never goes away
     setMountedParts((list) => {
       const kept = list.filter((part) => live.has(part));
       return kept.length === list.length ? list : kept;
@@ -594,6 +623,7 @@ function App() {
 
   const selectPart = (name: string) => {
     if (!active) return;
+    setProjectChatFocused(false);
     setProjects((list) =>
       list.map((p) => (p.path === active ? { ...p, selectedPart: name } : p)),
     );
@@ -801,6 +831,20 @@ function App() {
               </div>
               {project.path === active && partsReady && (
                 <ul className="parts">
+                  {/* The whole-project conversation: spawn parts, set what the
+                      family shares, act on the duplication nudge. Chat focus, not
+                      part selection, so the viewer stays on the selected part. */}
+                  <li
+                    className={`part-row project-chat ${projectChatFocused ? "selected" : ""}`}
+                    title="a conversation about the whole project"
+                    onClick={() => focusProjectChat()}
+                  >
+                    <IconCubes label="the whole project" />
+                    <span className="part-name">project</span>
+                    {busyParts[PROJECT_CHAT] && (
+                      <span className="part-busy" title="the agent is working on the project" />
+                    )}
+                  </li>
                   {parts.map((part) => (
                     <Fragment key={part.name}>
                       <li
@@ -1050,6 +1094,7 @@ function App() {
         mountedParts.map((part) => {
           const chat = resumeState.byPart[part];
           const agent = chat?.agent ?? defaultAgent;
+          const isProject = part === PROJECT_CHAT;
           return (
             <Chat
               key={`${active}:${part}:${chat?.gen ?? 0}:${agent}`}
@@ -1065,7 +1110,9 @@ function App() {
                   label: AGENT_LABEL[status.id] ?? status.label,
                 }))}
               resume={chat?.id ?? null}
-              hidden={part !== selectedPart}
+              hidden={isProject ? !projectChatFocused : part !== selectedPart || projectChatFocused}
+              seed={isProject ? projectSeed : null}
+              onSeed={isProject ? () => setProjectSeed(null) : undefined}
               onSession={(id) => chatStarted(active, part, id, agent)}
               onFresh={() => startFresh(part)}
               onAgent={(id) => startFresh(part, id)}

--- a/desktop/src/Chat.tsx
+++ b/desktop/src/Chat.tsx
@@ -13,6 +13,10 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { IconChevronDown, IconMessagePlus, IconPaperclip } from "./Icons";
 import Markdown from "./Markdown";
 
+// The whole-project conversation rides the per-part plumbing under a name no part
+// file can have. Twins live in App.tsx's mount and acp.rs's context line.
+export const PROJECT_CHAT = "//project";
+
 // Mirrors ChatEvent in src-tauri/src/acp.rs.
 type ChatEvent =
   | { type: "user_text"; text: string }
@@ -129,6 +133,8 @@ function Chat({
   agents,
   resume,
   hidden,
+  seed,
+  onSeed,
   onSession,
   onFresh,
   onAgent,
@@ -146,6 +152,10 @@ function Chat({
   agents: { id: string; label: string }[];
   resume: string | null;
   hidden: boolean;
+  // Text waiting for the composer, from a viewer nudge. Prefilled when the column
+  // is visible, never sent; onSeed reports it landed so the owner clears it.
+  seed?: string | null;
+  onSeed?: () => void;
   onSession: (id: string) => void;
   onFresh: () => void;
   // Switching agents cannot move a conversation across two different session
@@ -155,6 +165,9 @@ function Chat({
   onSignedIn: () => Promise<void>;
 }) {
   const label = AGENT_LABEL[agent] ?? agent;
+  // The sentinel never reaches copy: everywhere the column says its name, the
+  // project conversation speaks of the project.
+  const isProject = part === PROJECT_CHAT;
   const [items, setItems] = useState<Item[]>([]);
   const [busy, setBusy] = useState(false);
   // A resumed transcript starts loading after the first paint, so treat it as
@@ -226,6 +239,22 @@ function Chat({
       unlisten.then((stop) => stop());
     };
   }, []);
+
+  useEffect(() => {
+    // A seed lands once the column is visible. Below any half-typed draft rather
+    // than over it; the user's own words outrank a nudge's.
+    if (hidden || !seed) return;
+    const box = inputRef.current;
+    if (box) {
+      // Idempotent: StrictMode double-runs mount effects, and the clearing of
+      // the seed above only lands after this commit.
+      if (box.value !== seed && !box.value.endsWith(`\n${seed}`)) {
+        box.value = box.value.trim() ? `${box.value}\n${seed}` : seed;
+      }
+      box.focus();
+    }
+    onSeed?.();
+  }, [hidden, seed, onSeed]);
 
   useEffect(() => {
     // OS file drags arrive as Tauri window events with paths, not HTML5 drops.
@@ -558,7 +587,7 @@ function Chat({
         {/* The part name is the only thing here allowed to truncate, so the
             switcher lives beside it rather than inside it. */}
         <span className="chat-header-left">
-          <span className="chat-header-label">{part}</span>
+          <span className="chat-header-label">{isProject ? "project" : part}</span>
           <span aria-hidden="true">·</span>
           {agents.length > 1 ? (
             <span className="chat-switcher">
@@ -624,8 +653,9 @@ function Chat({
       <div className="chat-transcript" ref={scrollRef}>
         {items.length === 0 && !busy && (
           <div className="chat-empty">
-            You're chatting with {part}. Describe it or ask for changes, and{" "}
-            {label} will model it in the viewer.
+            {isProject
+              ? `This conversation covers the whole project. Ask ${label} for new parts, or for changes every part should share.`
+              : `You're chatting with ${part}. Describe it or ask for changes, and ${label} will model it in the viewer.`}
           </div>
         )}
         {items.map((item, index) => {
@@ -794,7 +824,7 @@ function Chat({
                 ? restoringRef.current
                   ? "Restoring conversation…"
                   : `Starting ${label}…`
-                : `Describe or change ${part}…`
+                : `Describe or change ${isProject ? "the project" : part}…`
           }
           rows={2}
           disabled={busy || starting}

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -20,6 +20,7 @@ A part is a Python function and its keyword defaults are its parameters. A proje
     "allow": [
       "Bash(nurb:*)",
       "Edit(parts/**)",
+      "Edit(system.py)",
       "Edit(measurements.toml)",
       "Edit(printer.toml)"
     ]
@@ -27,7 +28,7 @@ A part is a Python function and its keyword defaults are its parameters. A proje
 }
 ```
 
-Other harnesses take the same two grants, the `nurb` prefix and edits under `parts/`, in their own file: Codex a `prefix_rule` in `.codex/rules/`, Gemini `tools.allowed` in `.gemini/settings.json`, Cursor's CLI a `Shell(nurb)` entry in `.cursor/cli.json`, OpenCode a `permission` block in `opencode.json`. Amp never prompts, so there is nothing to offer.
+Other harnesses take the same grants, the `nurb` prefix and edits under `parts/` plus `system.py`, in their own file: Codex a `prefix_rule` in `.codex/rules/`, Gemini `tools.allowed` in `.gemini/settings.json`, Cursor's CLI a `Shell(nurb)` entry in `.cursor/cli.json`, OpenCode a `permission` block in `opencode.json`. Amp never prompts, so there is nothing to offer.
 
 **Run `nurb rules` before you design.** It prints the doctrine: printability, load paths, aesthetics, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
 
@@ -50,6 +51,8 @@ Other harnesses take the same two grants, the `nurb` prefix and edits under `par
 **`import_stl` is for a shape you would otherwise retype, not for a model you found.** It returns a real solid, but only from a closed mesh under a couple of thousand triangles, and only flat faces survive: a box comes back as six faces at its exact size and each of them chamfers, while a cylinder comes back as a 126-sided prism whose rim no selector can find. So it earns its place on a plate, a bracket, a wedge, a machined blank someone exported for you, and it refuses a model site's download by name rather than letting you discover the problem later. Even where it works you have geometry and no parameters, so prefer rebuilding whenever the user might want to change a dimension, which is nearly always. STEP is the exception worth asking about: if the listing offers one, take it, because it imports as real B-rep with its curves intact and chamfers like anything you modelled.
 
 **When parts have to work together, assemble them before printing either.** A part that mounts to another, or moves against one, gets an `@assembly`: a function in `parts/` that returns placed solids, with `use()` building the siblings, `hinge()` declaring how one moves, and `obstacle()` standing in for the machine or wall they mount into. `nurb check` then sweeps each joint through its declared range and reports the angle where it jams and where the contact is, which is the one failure no per-part check can see: a door that builds clean, checks clean, prints beautifully and will not open. The joint angle is a keyword default, so the viewer's slider swings the assembly live for the user. Model obstacles from the user's measurements, and say on the assembly's card how rough they are.
+
+**A family of parts keeps its shared design in one file.** When siblings are meant to match, the shared wall, chamfer, corner radius or label geometry lives in `system.py` at the project root, imported by every part; saving it rebuilds the whole project, so one edit moves the family together. But a system is extracted, never scaffolded: build the first two or three parts plainly, then run `nurb extract`, which reports the constructions the files already say twice. Lift what is genuinely shared and leave the rest, because two parts saying the same thing is not yet a system; two parts that would both have to change is. The viewer runs the same scan and quietly folds a "shared with siblings" note under the parameters when three or more parts repeat a construction.
 
 **Finish with the polish pass.** Chamfered edges are what make a print feel designed rather than extruded, so the doctrine's last step (`polish`, 1mm on exposed edges) stays in the part through every edit; the template `nurb new` emits already ends with it. When the user asks for a rounded rim on a closed wall, that is `crown(wall)`, the bead that survives a roofline rising and falling; hand-rolling it instead is how issue #55 spent 689 lines. Never round a rim unprompted: chamfer stays the default on every edge, rims included. Say so when you hand the part over, because the user can only ask for sharp edges if they know the chamfers are there on purpose. The viewer builds polished by default, and its polish button flips to the faster draft build.
 

--- a/src/nurb/agents.md
+++ b/src/nurb/agents.md
@@ -14,6 +14,7 @@ A part is a Python function and its keyword defaults are its parameters. A proje
     "allow": [
       "Bash(nurb:*)",
       "Edit(parts/**)",
+      "Edit(system.py)",
       "Edit(measurements.toml)",
       "Edit(printer.toml)"
     ]
@@ -21,7 +22,7 @@ A part is a Python function and its keyword defaults are its parameters. A proje
 }
 ```
 
-Other harnesses take the same two grants, the `nurb` prefix and edits under `parts/`, in their own file: Codex a `prefix_rule` in `.codex/rules/`, Gemini `tools.allowed` in `.gemini/settings.json`, Cursor's CLI a `Shell(nurb)` entry in `.cursor/cli.json`, OpenCode a `permission` block in `opencode.json`. Amp never prompts, so there is nothing to offer.
+Other harnesses take the same grants, the `nurb` prefix and edits under `parts/` plus `system.py`, in their own file: Codex a `prefix_rule` in `.codex/rules/`, Gemini `tools.allowed` in `.gemini/settings.json`, Cursor's CLI a `Shell(nurb)` entry in `.cursor/cli.json`, OpenCode a `permission` block in `opencode.json`. Amp never prompts, so there is nothing to offer.
 
 **Run `nurb rules` before you design.** It prints the doctrine: printability, load paths, aesthetics, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
 
@@ -44,6 +45,8 @@ Other harnesses take the same two grants, the `nurb` prefix and edits under `par
 **`import_stl` is for a shape you would otherwise retype, not for a model you found.** It returns a real solid, but only from a closed mesh under a couple of thousand triangles, and only flat faces survive: a box comes back as six faces at its exact size and each of them chamfers, while a cylinder comes back as a 126-sided prism whose rim no selector can find. So it earns its place on a plate, a bracket, a wedge, a machined blank someone exported for you, and it refuses a model site's download by name rather than letting you discover the problem later. Even where it works you have geometry and no parameters, so prefer rebuilding whenever the user might want to change a dimension, which is nearly always. STEP is the exception worth asking about: if the listing offers one, take it, because it imports as real B-rep with its curves intact and chamfers like anything you modelled.
 
 **When parts have to work together, assemble them before printing either.** A part that mounts to another, or moves against one, gets an `@assembly`: a function in `parts/` that returns placed solids, with `use()` building the siblings, `hinge()` declaring how one moves, and `obstacle()` standing in for the machine or wall they mount into. `nurb check` then sweeps each joint through its declared range and reports the angle where it jams and where the contact is, which is the one failure no per-part check can see: a door that builds clean, checks clean, prints beautifully and will not open. The joint angle is a keyword default, so the viewer's slider swings the assembly live for the user. Model obstacles from the user's measurements, and say on the assembly's card how rough they are.
+
+**A family of parts keeps its shared design in one file.** When siblings are meant to match, the shared wall, chamfer, corner radius or label geometry lives in `system.py` at the project root, imported by every part; saving it rebuilds the whole project, so one edit moves the family together. But a system is extracted, never scaffolded: build the first two or three parts plainly, then run `nurb extract`, which reports the constructions the files already say twice. Lift what is genuinely shared and leave the rest, because two parts saying the same thing is not yet a system; two parts that would both have to change is. The viewer runs the same scan and quietly folds a "shared with siblings" note under the parameters when three or more parts repeat a construction.
 
 **Finish with the polish pass.** Chamfered edges are what make a print feel designed rather than extruded, so the doctrine's last step (`polish`, 1mm on exposed edges) stays in the part through every edit; the template `nurb new` emits already ends with it. When the user asks for a rounded rim on a closed wall, that is `crown(wall)`, the bead that survives a roofline rising and falling; hand-rolling it instead is how issue #55 spent 689 lines. Never round a rim unprompted: chamfer stays the default on every edge, rims included. Say so when you hand the part over, because the user can only ask for sharp edges if they know the chamfers are there on purpose. The viewer builds polished by default, and its polish button flips to the faster draft build.
 

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -20,7 +20,7 @@ from websockets.asyncio.server import serve
 from websockets.http11 import Response
 from websockets.datastructures import Headers
 
-from . import __version__, builder, registry
+from . import __version__, builder, extract, registry
 
 VIEWER = pathlib.Path(__file__).parent / "viewer.html"
 VENDOR = (pathlib.Path(__file__).parent / "vendor").resolve()
@@ -186,6 +186,9 @@ class Server:
         # What the sliders are holding, per part, and only where it differs from the
         # file. Empty means the part is exactly what its source says.
         self.overrides = {}
+        # Constructions the parts say twice, recomputed after every rebuild burst so
+        # the viewer's nudge never outlives the geometry it described.
+        self.shared = []
         self.clients = set()
         self.loop = None
         self.queue = None
@@ -919,6 +922,32 @@ class Server:
         )
         return {name for (name, _), n in seen.items() if n > len(built) / 2}
 
+    def _shared(self):
+        """Constructions repeated across enough parts to be worth a nudge.
+
+        `nurb extract`'s full report is the agent's; the viewer only needs enough to
+        say "these parts repeat themselves". The bar is higher than the report's:
+        three or more parts (same "too few to tell from a coincidence" line _family
+        draws) and at least four statements, calibrated on the notch examples, whose
+        finished extraction still shares short residue runs on purpose. Wired as part
+        names and a count only; the agent rediscovers lines itself, and the panel's
+        audience never sees files.
+        """
+        try:
+            runs = extract.duplication(builder.find_parts(self.root))
+        except (OSError, SyntaxError, UnicodeError):
+            # A part mid-edit may not parse, may briefly disappear during an atomic
+            # save, or may not be UTF-8. No nudge beats a dead rebuild loop.
+            return []
+        return [
+            {
+                "parts": sorted({site[0].stem for site in run["sites"]}),
+                "statements": run["statements"],
+            }
+            for run in runs
+            if len({site[0] for site in run["sites"]}) >= 3 and run["statements"] >= 4
+        ]
+
     def _wire(self, entry):
         """`_meta`, with each parameter told whether the whole family shares it."""
         out = self._meta(entry)
@@ -959,6 +988,7 @@ class Server:
             # deleted or misspelled one.
             "sources": [p.stem for p in builder.find_parts(self.root)],
             "parts": [self._wire(e) for e in self.state.values()],
+            "shared": self.shared,
         }
         if include_token:
             # HTTP fallback is intentionally read-only. Only the origin-checked socket
@@ -1258,6 +1288,13 @@ class Server:
                             f"    {len(entry['findings'])} finding(s), {bad} to fix",
                             flush=True,
                         )
+            # The duplication scan reads every part file, so once per settled burst,
+            # not per path; a burst still queuing gets it on its last round instead.
+            if self.queue.empty():
+                shared = await asyncio.to_thread(self._shared)
+                if shared != self.shared:
+                    self.shared = shared
+                    await self.send({"type": "shared", "runs": shared})
 
     # ---------- run ----------
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -20,6 +20,7 @@ A part is a Python function and its keyword defaults are its parameters. A proje
     "allow": [
       "Bash(nurb:*)",
       "Edit(parts/**)",
+      "Edit(system.py)",
       "Edit(measurements.toml)",
       "Edit(printer.toml)"
     ]
@@ -27,7 +28,7 @@ A part is a Python function and its keyword defaults are its parameters. A proje
 }
 ```
 
-Other harnesses take the same two grants, the `nurb` prefix and edits under `parts/`, in their own file: Codex a `prefix_rule` in `.codex/rules/`, Gemini `tools.allowed` in `.gemini/settings.json`, Cursor's CLI a `Shell(nurb)` entry in `.cursor/cli.json`, OpenCode a `permission` block in `opencode.json`. Amp never prompts, so there is nothing to offer.
+Other harnesses take the same grants, the `nurb` prefix and edits under `parts/` plus `system.py`, in their own file: Codex a `prefix_rule` in `.codex/rules/`, Gemini `tools.allowed` in `.gemini/settings.json`, Cursor's CLI a `Shell(nurb)` entry in `.cursor/cli.json`, OpenCode a `permission` block in `opencode.json`. Amp never prompts, so there is nothing to offer.
 
 **Run `nurb rules` before you design.** It prints the doctrine: printability, load paths, aesthetics, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
 
@@ -50,6 +51,8 @@ Other harnesses take the same two grants, the `nurb` prefix and edits under `par
 **`import_stl` is for a shape you would otherwise retype, not for a model you found.** It returns a real solid, but only from a closed mesh under a couple of thousand triangles, and only flat faces survive: a box comes back as six faces at its exact size and each of them chamfers, while a cylinder comes back as a 126-sided prism whose rim no selector can find. So it earns its place on a plate, a bracket, a wedge, a machined blank someone exported for you, and it refuses a model site's download by name rather than letting you discover the problem later. Even where it works you have geometry and no parameters, so prefer rebuilding whenever the user might want to change a dimension, which is nearly always. STEP is the exception worth asking about: if the listing offers one, take it, because it imports as real B-rep with its curves intact and chamfers like anything you modelled.
 
 **When parts have to work together, assemble them before printing either.** A part that mounts to another, or moves against one, gets an `@assembly`: a function in `parts/` that returns placed solids, with `use()` building the siblings, `hinge()` declaring how one moves, and `obstacle()` standing in for the machine or wall they mount into. `nurb check` then sweeps each joint through its declared range and reports the angle where it jams and where the contact is, which is the one failure no per-part check can see: a door that builds clean, checks clean, prints beautifully and will not open. The joint angle is a keyword default, so the viewer's slider swings the assembly live for the user. Model obstacles from the user's measurements, and say on the assembly's card how rough they are.
+
+**A family of parts keeps its shared design in one file.** When siblings are meant to match, the shared wall, chamfer, corner radius or label geometry lives in `system.py` at the project root, imported by every part; saving it rebuilds the whole project, so one edit moves the family together. But a system is extracted, never scaffolded: build the first two or three parts plainly, then run `nurb extract`, which reports the constructions the files already say twice. Lift what is genuinely shared and leave the rest, because two parts saying the same thing is not yet a system; two parts that would both have to change is. The viewer runs the same scan and quietly folds a "shared with siblings" note under the parameters when three or more parts repeat a construction.
 
 **Finish with the polish pass.** Chamfered edges are what make a print feel designed rather than extruded, so the doctrine's last step (`polish`, 1mm on exposed edges) stays in the part through every edit; the template `nurb new` emits already ends with it. When the user asks for a rounded rim on a closed wall, that is `crown(wall)`, the bead that survives a roofline rising and falling; hand-rolling it instead is how issue #55 spent 689 lines. Never round a rim unprompted: chamfer stays the default on every edge, rims included. Say so when you hand the part over, because the user can only ask for sharp edges if they know the chamfers are there on purpose. The viewer builds polished by default, and its polish button flips to the faster draft build.
 

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -341,6 +341,26 @@
   #family[open] summary::before { content: '\25be  '; }
   #family summary:hover { color: var(--text); }
   #family:has(.p.dirty) summary { color: var(--accent); }
+  /* Constructions this part repeats with its siblings, from the server's duplication
+     scan. A nudge, not a finding: the parts build fine, they just say the same thing
+     twice, and the fold offers the lift without nagging from the checks panel. */
+  #sharedbox details { border-top: 1px dashed var(--line); margin-top: 6px; }
+  #sharedbox summary {
+    cursor: pointer; color: var(--dim); font-size: 11px; padding: 9px 0 5px;
+    list-style: none; letter-spacing: .04em;
+  }
+  #sharedbox summary::-webkit-details-marker { display: none; }
+  #sharedbox summary::before { content: '\25b8  '; }
+  #sharedbox details[open] summary::before { content: '\25be  '; }
+  #sharedbox summary:hover { color: var(--text); }
+  #sharedbox .run { color: var(--dim); font-size: 11px; padding: 3px 0 3px 7px; line-height: 1.5; }
+  #sharedbox .run b { color: var(--text); font-weight: 500; }
+  #sharedbox button {
+    display: block; margin: 4px 0 6px 7px; padding: 3px 8px; font: inherit; font-size: 11px;
+    color: var(--dim); background: none; border: 1px solid var(--line); border-radius: 4px;
+    cursor: pointer;
+  }
+  #sharedbox button:hover { color: var(--text); border-color: var(--dim); }
   .p { padding: 5px 0 7px 7px; border-left: 2px solid transparent; }
   .p.dirty { border-left-color: var(--accent); }
   .p .top { display: flex; align-items: center; }
@@ -448,6 +468,7 @@
   <h1><svg><use href="#i-cube"/></svg><b>nurb</b><span id="project"></span><span id="conn">connecting</span></h1>
   <div id="list"></div>
   <div id="params" class="empty"></div>
+  <div id="sharedbox"></div>
   <div id="foot">
     <span id="version"></span>
     <span id="links">
@@ -540,6 +561,9 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
 const parts = new Map();
+// Constructions the project's parts repeat, from the server's duplication scan.
+// Project-wide, so it rides sync and its own message rather than any part's entry.
+let sharedRuns = [];
 // `framed` is the part the camera is currently pointed at, which is not `current`: a
 // part becomes current the moment it is selected and only gets a camera once its
 // geometry lands. Nothing is framed until the first mesh paints.
@@ -1998,7 +2022,42 @@ function showTip(row) {
   box.addEventListener('pointerdown', hideTip);
 }
 
+function sharedPanel(name) {
+  const box = document.getElementById('sharedbox');
+  const mine = name ? sharedRuns.filter(r => r.parts.includes(name)) : [];
+  if (!mine.length) { box.innerHTML = ''; return; }
+  const fold = document.createElement('details');
+  fold.innerHTML =
+    '<summary title="The same steps appear in three or more parts. Lifted into the '
+    + 'project&#39;s shared design, the parts stay in step.">'
+    + `shared with siblings (${mine.length})</summary>`;
+  for (const run of mine) {
+    const others = run.parts.filter(p => p !== name);
+    const row = document.createElement('div');
+    row.className = 'run';
+    row.innerHTML = `builds the same construction as <b></b>`;
+    row.querySelector('b').textContent = others.join(', ');
+    fold.appendChild(row);
+    if (embed) {
+      // The shell routes this to the project conversation with a prefilled ask;
+      // prefilled, never sent, so the lift stays the user's call.
+      const btn = document.createElement('button');
+      btn.textContent = 'unify in chat';
+      btn.title = 'ask the project chat to lift what these parts share';
+      btn.onclick = () => window.parent.postMessage({ type: 'nurb:shared', parts: run.parts }, '*');
+      fold.appendChild(btn);
+    } else {
+      const hint = document.createElement('div');
+      hint.className = 'run';
+      hint.innerHTML = '<code>nurb extract</code> shows the details';
+      fold.appendChild(hint);
+    }
+  }
+  box.replaceChildren(fold);
+}
+
 function params(e) {
+  sharedPanel(e.name);
   const box = document.getElementById('params');
   // A failed build reports no parameters, and clearing the panel here would take the
   // sliders away at the one moment they are needed: a value that breaks the build has
@@ -2390,7 +2449,9 @@ async function fallback() {
     const msg = await (await fetch('/api/sync')).json();
     const rows = msg.parts || [];
     bedUpdate(msg.bed);
-    if (parts.size || !rows.length) return;  // a sync won the race, or truly empty
+    if (parts.size) return;  // a socket sync won the race
+    sharedRuns = msg.shared || [];
+    if (!rows.length) return;  // truly empty
     rows.forEach(p => parts.set(p.name, p));
     current = parts.has(want) ? want : rows[0].name;
     render();
@@ -2432,6 +2493,7 @@ function connect() {
       checkUpdate(msg.version);
       parts.clear();
       msg.parts.forEach(p => parts.set(p.name, p));
+      sharedRuns = msg.shared || [];
       if (want && !msg.sources.includes(want)) { want = null; wantVariant = null; }
       // A fallback render may have filled `current` while the socket was down.
       // The still-pending deep link outranks that temporary choice.
@@ -2498,6 +2560,10 @@ function connect() {
       }
       bedUpdate(msg.bed);
       estimate();
+    }
+    if (msg.type === 'shared') {
+      sharedRuns = msg.runs || [];
+      sharedPanel(current);
     }
     if (msg.type === 'stressed') stressLanded(msg);
     if (msg.type === 'checked') {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -617,6 +617,11 @@ def test_the_skill_is_the_shim_with_a_trigger_on_top():
             assert ": " not in value, f"strict-YAML trap in: {line}"
 
 
+def test_skill_allowlist_covers_the_shared_project_module():
+    skill = (pathlib.Path(cli.__file__).parent / "skill.md").read_text(encoding="utf-8")
+    assert '"Edit(system.py)"' in skill
+
+
 def test_skill_frontmatter_version_is_the_package_version():
     """The frontmatter version is what `nurb dev` compares an installed copy against,
     so a release that bumps pyproject.toml without regenerating the skill files must

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1090,3 +1090,92 @@ def test_the_checks_panel_folds_and_stays_folded():
     # The fold outlives the repaint and the reload.
     assert "localStorage.getItem('nurb.checks.min')" in viewer
     assert "localStorage.setItem('nurb.checks.min', '1')" in viewer
+
+
+# A construction long enough for the shared-runs nudge: six statements, well past
+# the four the scan requires before calling repetition a family matter.
+BIN_BODY = """from nurb import *
+
+@part
+def {name}(width=60.0, depth=40.0, height=30.0, wall=2.0):
+    body = Box(width, depth, height)
+    lip = Box(width - 2 * wall, depth - 2 * wall, height)
+    body = body - Pos(0, 0, wall) * lip
+    label = Box(width * 0.6, wall, 8.0)
+    body = body + Pos(0, -depth / 2, height * 0.3) * label
+    return body
+"""
+
+
+def bins(tmp_path, names):
+    (tmp_path / "parts").mkdir()
+    for name in names:
+        (tmp_path / "parts" / f"{name}.py").write_text(BIN_BODY.format(name=name))
+    return Server(tmp_path)
+
+
+def test_shared_wires_a_construction_three_parts_repeat(tmp_path):
+    server = bins(tmp_path, ["bin_large", "bin_medium", "bin_small"])
+    runs = server._shared()
+    assert len(runs) == 1
+    assert runs[0]["parts"] == ["bin_large", "bin_medium", "bin_small"]
+    assert runs[0]["statements"] >= 4
+    # Names and a count only: the panel's audience never sees files or lines.
+    assert set(runs[0]) == {"parts", "statements"}
+
+
+def test_shared_stays_quiet_for_two_parts(tmp_path):
+    """Two parts saying the same thing is not yet a system."""
+    server = bins(tmp_path, ["bin_large", "bin_small"])
+    assert server._shared() == []
+
+
+def test_shared_ignores_short_residue(tmp_path):
+    """A finished extraction still shares a couple of lines on purpose; the notch
+    examples are full of them. The nudge is for whole constructions."""
+    (tmp_path / "parts").mkdir()
+    residue = (
+        "from nurb import *\n\n"
+        "@part\n"
+        "def {name}(width={w}, wall=2.0):\n"
+        "    body = Box(width, width * 0.8, wall * 4.0) - Box(width - 2 * wall, width, wall)\n"
+        "    return polish(body, body.edges(), wall / 2.0)\n"
+    )
+    for name, w in (("a", "30.0"), ("b", "40.0"), ("c", "50.0")):
+        (tmp_path / "parts" / f"{name}.py").write_text(residue.format(name=name, w=w))
+    assert Server(tmp_path)._shared() == []
+
+
+def test_shared_reports_nothing_over_a_part_that_does_not_parse(tmp_path):
+    """No nudge beats a stale one: a part mid-edit blanks the scan honestly."""
+    server = bins(tmp_path, ["bin_large", "bin_medium", "bin_small"])
+    (tmp_path / "parts" / "broken.py").write_text("def oops(:\n")
+    assert server._shared() == []
+
+
+def test_shared_read_failure_cannot_kill_the_rebuild_loop(tmp_path, monkeypatch):
+    """A file can disappear between the directory scan and the read during an
+    atomic save. The optional nudge must fail closed instead of escaping drain()."""
+    from nurb import server as server_mod
+
+    missing = tmp_path / "parts" / "gone.py"
+    monkeypatch.setattr(server_mod.builder, "find_parts", lambda _root: [missing])
+    assert Server(tmp_path)._shared() == []
+
+
+def test_sync_carries_the_shared_runs(tmp_path):
+    server = bins(tmp_path, ["bin_large", "bin_medium", "bin_small"])
+    server.shared = server._shared()
+    payload = server._sync()
+    assert payload["shared"] == server.shared
+    assert payload["shared"][0]["parts"] == ["bin_large", "bin_medium", "bin_small"]
+
+
+def test_http_fallback_carries_shared_runs_into_the_panel():
+    from nurb import server as server_mod
+
+    viewer = server_mod.VIEWER.read_text(encoding="utf-8")
+    fallback = viewer[
+        viewer.index("async function fallback()") : viewer.index("function connect()")
+    ]
+    assert "sharedRuns = msg.shared || [];" in fallback


### PR DESCRIPTION
The desktop rail gets a project row above the parts: a whole-project conversation on the existing per-part session plumbing, whose context line lets the agent spawn parts and lift shared design into system.py. The dev server runs the extract scan after every rebuild burst and wires constructions repeated across three or more parts with four or more statements, thresholds calibrated so the finished notch examples stay quiet. The viewer folds these as "shared with siblings" under the parameters; in the app the fold carries a unify button that opens the project chat with a prefilled, never auto-sent ask. The shipped skill gains the system.py convention with Edit(system.py) pinned in its allowlist, and the chat composer wraps its send button under the box in a narrow column instead of clipping it. Verified live: browser screenshots of the fold appearing and clearing on rebuild, and a driven desktop session proving the project row, context line, and part switching.