### PR TITLE
Release 0.18.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.17.0"
+version = "0.18.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,14 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.18.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.18.0">v0.18.0</a></span><time datetime="2026-08-12">August 12, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Talk about the whole project.</b> The Mac app puts a project row above your parts, and it opens a conversation about everything you are making instead of one part. Ask there for a new part and it makes one, and it can move the shapes your parts have in common into one place they all share.</span></li>
+      <li><b class="tag new">new</b><span><b>Shared with siblings.</b> When three or more of your parts build the same thing the same way, the viewer says so under the parameters and shows you what repeats. In the Mac app, unify hands it to the project chat with the request already written, ready for you to send or change.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.17.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.17.0">v0.17.0</a></span><time datetime="2026-08-12">August 12, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.17.0"
+  version: "0.18.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.17.0"
+  version: "0.18.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Version 0.18.0 across the engine, the skill, and the desktop app, plus the changelog entry for what shipped since 0.17.0.

## What's in it

**Talk about the whole project.** The Mac app puts a project row above your parts, and it opens a conversation about everything you are making instead of one part. Ask there for a new part and it makes one, and it can move the shapes your parts have in common into one place they all share.

**Shared with siblings.** When three or more of your parts build the same thing the same way, the viewer says so under the parameters and shows you what repeats. In the Mac app, unify hands it to the project chat with the request already written, ready for you to send or change.

## The bump

`pyproject.toml`, `src/nurb/skill.md`, `skills/nurb/SKILL.md`, and `desktop/src-tauri/tauri.conf.json` all read 0.18.0, with `evals/uv.lock` relocked so CI's `--locked` sync still passes. `uv run pytest tests/test_cli.py -q` passes, which is what enforces the four strings agree.

https://claude.ai/code/session_01KS8H1WV9iFwrHpqy6w21gm