### PR TITLE
Release 0.18.1

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.18.0"
+version = "0.18.1"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.18.0"
+version = "0.18.1"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,14 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.18.1">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.18.1">v0.18.1</a></span><time datetime="2026-08-12">August 12, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>One-paste bug reports.</b> The About window has a copy debug info button that puts the app and system versions on your clipboard together, and the report links now open a form that asks for what someone needs to see the problem you saw.</span></li>
+      <li><b class="tag">fixed</b><span>A sign-in that expired on the server left the Mac app on an error note with nothing to click. It shows the sign-in button now, so you can sign back in and keep working.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.18.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.18.0">v0.18.0</a></span><time datetime="2026-08-12">August 12, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.18.0"
+  version: "0.18.1"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.18.0"
+  version: "0.18.1"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.18.0"
+version = "0.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
A patch release: one fix and one support surface, no changes to how parts are designed.

- **Copy debug info.** The About window gains a button that copies the app, engine, and macOS versions in one paste, the in-app report links point at structured GitHub issue forms, and `nurb --version` now exists for terminal users (answered by a lightweight entry point that never loads OCCT).
- **Expired sign-in.** A token revoked server-side wrapped as an internal error, so the app showed a dead-end note instead of the sign-in button. It routes to the button now.

Bumps all four version strings, relocks `evals/uv.lock` against 0.18.1, and adds the changelog entry to `site/changelog.html`.

https://claude.ai/code/session_01CNFQ8TbmEQVrFFARTQJuqW