### PR TITLE
Release 0.18.2

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.18.1"
+version = "0.18.2"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.18.1"
+version = "0.18.2"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,14 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.18.2">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.18.2">v0.18.2</a></span><time datetime="2026-08-13">August 13, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Chats keep going.</b> Your AI now keeps working when you switch to another project, so a long run no longer stops the moment you look somewhere else. The project list shows an amber dot while an agent is busy there, and a green dot when a reply is waiting for you.</span></li>
+      <li><b class="tag">fixed</b><span>Picking Grok in the Mac app failed straight away with a permission error, and Cursor would have hit the same wall. Both can save their own sign-in now, so they start like the rest.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.18.1">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.18.1">v0.18.1</a></span><time datetime="2026-08-12">August 12, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.18.1"
+  version: "0.18.2"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.18.1"
+  version: "0.18.2"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.18.1"
+version = "0.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
A patch release: two desktop fixes, no new engine capability.

**Chats keep going across project switches.** Switching projects used to unmount every chat column and kill the agent's adapter mid-turn, so making a new project while an agent was working ended a long run with "Request interrupted by user". Columns whose agent is mid-turn, or whose finished reply has not been seen, now stay alive in the background. The project rail shows an amber dot while an agent works there and a green dot once an unseen result is waiting. (#122)

**Grok and Cursor can start in the Mac app.** The Seatbelt profile allowed writes only under `~/.claude` and `~/.codex`, so picking Grok failed immediately with a permission error and Cursor had the same latent miss. Both agent homes are on the allowlist now. (#121)

Bumps the four version strings, relocks `evals/uv.lock`, and adds the v0.18.2 changelog entry dated today.

https://claude.ai/code/session_01Q5rDUrGtj8AjDLLWMFYbAB