### PR TITLE
Release 0.19.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.18.2"
+version = "0.19.0"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.18.2"
+version = "0.19.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,15 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.19.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.19.0">v0.19.0</a></span><time datetime="2026-08-13">August 13, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>3MF downloads.</b> Download now gives you a 3mf file. It states its own units, so Bambu Studio and Orca open it at the right size instead of guessing. Stl and step are still one click away, behind the arrow beside the button.</span></li>
+      <li><b class="tag">fixed</b><span>Downloading a part that took more than ten seconds to build never finished, and the button sat there waiting.</span></li>
+      <li><b class="tag">fixed</b><span>When a download failed, the file from last time stayed on disk and looked like the new one.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.18.2">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.18.2">v0.18.2</a></span><time datetime="2026-08-13">August 13, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.18.2"
+  version: "0.19.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.18.2"
+  version: "0.19.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.18.2"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Downloads now default to 3MF. A 3mf file states its own units, so Bambu Studio and Orca open a part at the right size instead of guessing at the scale. Stl and step stay one click away, behind the chevron on the viewer's download button.

Two fixes that the new default surfaced. A part whose polished build ran past ten seconds never finished downloading, and the button waited on a reply that never came. And a failed save left the previous file in `build/`, where it looked like the new one.

Bumps the version across the package, both skill files, and the desktop app, relocks evals, and adds the changelog entry.

https://claude.ai/code/session_01NwbPb1YJjrsHXPYtX2yNMk