### PR TITLE
Speed up motion sweeps and cancel stale checks

### DIFF
--- a/src/nurb/assembly.py
+++ b/src/nurb/assembly.py
@@ -46,6 +46,16 @@ from .registry import PartDef, declared, param_docs
 RULE = "motion"
 
 
+class Interrupted(Exception):
+    """Raised between poses when the sweep's `stop` callable turns true.
+
+    A sweep is the one check that can run for seconds, and OCCT cannot be preempted
+    mid-boolean, so this is how a caller who no longer wants the answer gets out: the
+    dev server passes a `stop` that turns true when another rebuild is queued, because
+    findings about a solid the next build replaces are worthless either way.
+    """
+
+
 @dataclass
 class Hinge:
     solid: object
@@ -218,7 +228,10 @@ def hinge(solid, axis, through, at=0.0, name=None, step=3.0):
     axis direction, so the axis is also how you pick which way is opening.
 
     `step` is the coarse sweep resolution; the jam angle itself is bisected to a tenth
-    of a degree regardless.
+    of a degree regardless. It is also the sweep's price: every step is a kernel
+    boolean against the scene, so a full circle at the default 3.0 walks 120 poses and
+    can take seconds on real geometry. A free spinner that only needs a gross clearance
+    audit should declare a larger step; the 3-degree walk is for doors hunting a jam.
     """
     rec = _recorder("hinge()")
     lo, hi = float(through[0]), float(through[1])
@@ -339,10 +352,27 @@ def _inside(bb, outer, slack=0.5):
     )
 
 
+def _apart(a, b):
+    return (
+        a.max.X < b.min.X
+        or b.max.X < a.min.X
+        or a.max.Y < b.min.Y
+        or b.max.Y < a.min.Y
+        or a.max.Z < b.min.Z
+        or b.max.Z < a.min.Z
+    )
+
+
 def _hits(moved, others):
     """The overlap volume and where it is, or (0, None)."""
     worst, where = 0.0, None
+    box = moved.bounding_box()
     for other in others:
+        # Disjoint boxes cannot intersect, and this reject is what keeps a clean
+        # sweep of a real scene affordable: at most poses the mover is nowhere near
+        # most of the scene, and an OCCT boolean is the expensive way to learn that.
+        if _apart(box, other.bounding_box()):
+            continue
         try:
             common = moved & other
             vol = common.volume if common else 0.0
@@ -371,7 +401,7 @@ def _hits(moved, others):
     return worst, where
 
 
-def _limit(h, others, direction):
+def _limit(h, others, direction, stop=None):
     """The last clear angle sweeping from the pose toward one end of the range.
 
     Coarse steps find the first collision, bisection then pins the boundary to under
@@ -384,6 +414,8 @@ def _limit(h, others, direction):
     clear, hit, contact = h.at, None, None
     steps = int(span // h.step) + 1
     for i in range(1, steps + 1):
+        if stop and stop():
+            raise Interrupted
         t = h.at + direction * min(i * h.step, span)
         moved = h.solid.rotate(h.axis, t - h.at)
         vol, where = _hits(moved, others)
@@ -394,6 +426,8 @@ def _limit(h, others, direction):
     if hit is None:
         return end, None
     while abs(hit - clear) > 0.1:
+        if stop and stop():
+            raise Interrupted
         mid = (hit + clear) / 2
         moved = h.solid.rotate(h.axis, mid - h.at)
         vol, where = _hits(moved, others)
@@ -404,11 +438,14 @@ def _limit(h, others, direction):
     return clear, contact
 
 
-def sweep(scene):
+def sweep(scene, stop=None):
     """Findings for every declared joint, in checks.py's own vocabulary.
 
     Each hinge sweeps alone; other hinged solids stand frozen at their pose, which is
     the conservative reading of a mechanism you can only move one hand at a time.
+
+    `stop` is polled between poses; when it turns true the sweep raises Interrupted
+    instead of finishing an answer nobody wants anymore.
     """
     from .checks import FAIL, Finding
 
@@ -435,7 +472,7 @@ def sweep(scene):
             )
             continue
         for direction, end in ((+1, h.hi), (-1, h.lo)):
-            reached, contact = _limit(h, others, direction)
+            reached, contact = _limit(h, others, direction, stop)
             if contact is None:
                 continue
             found.append(

--- a/src/nurb/assembly.py
+++ b/src/nurb/assembly.py
@@ -51,8 +51,8 @@ class Interrupted(Exception):
 
     A sweep is the one check that can run for seconds, and OCCT cannot be preempted
     mid-boolean, so this is how a caller who no longer wants the answer gets out: the
-    dev server passes a `stop` that turns true when another rebuild is queued, because
-    findings about a solid the next build replaces are worthless either way.
+    dev server passes a `stop` that turns true when another rebuild is queued, so the
+    queued geometry can land first and this sweep can retry once the project settles.
     """
 
 

--- a/src/nurb/checks.py
+++ b/src/nurb/checks.py
@@ -122,7 +122,7 @@ def rule(name):
     return register
 
 
-def run(shape, ctx=None, only=None):
+def run(shape, ctx=None, only=None, stop=None):
     # An assembly's compound carries its recorded joints, and motion is the only
     # thing worth judging about it: overhang and min_wall on an assembled scene
     # would report confident nonsense about parts that each checked clean alone.
@@ -130,7 +130,7 @@ def run(shape, ctx=None, only=None):
     if scene is not None:
         from .assembly import sweep
 
-        return sweep(scene)
+        return sweep(scene, stop)
     ctx = ctx or Context()
     found = []
     for name, fn in RULES.items():

--- a/src/nurb/doctrine.md
+++ b/src/nurb/doctrine.md
@@ -446,10 +446,9 @@ motivated all of this rests open at 240 degrees against the back of its own moun
 held there by gravity, and that contact is a feature with a card entry, not a finding
 to engineer away. Read a jam before redesigning around it.
 
-**Never trust a swing worked out by hand.** The same hinge was hand-modelled three
-times and gave three answers, one of them "impossible"; the wrong one ran a convex
-test against a non-convex profile, which is exactly the kind of quiet modelling error
-a kernel boolean cannot make. The sweep is the authority, and it is cheap.
+**Never trust a swing worked out by hand.** The same hinge was hand-modelled three times and gave three answers, one of them "impossible"; the wrong one ran a convex test against a non-convex profile, which is exactly the kind of quiet modelling error a kernel boolean cannot make. The sweep is the authority.
+
+**The sweep is priced per pose, and the declaration sets the pose count.** Every step is a kernel boolean against the rest of the scene, so a door walking 90 degrees at the default 3-degree step is cheap, while a full-circle rotor at the same step is 120 poses and can hold the check for seconds on real geometry. A clean sweep pays the whole walk, since only a jam stops it early. `through=(0, 360)` at the default step is a fine-grained jam audit, not a formality: a free spinner that only needs a gross clearance check should declare a larger `step`, and a range wider than the design actually claims buys nothing but poses.
 
 One hinge sweeps at a time; the others hold their pose, which is the conservative
 reading of a mechanism you can only move one hand at a time. Printability rules stay

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -427,9 +427,8 @@ class Server:
                 for f, row in zip(found, rows)
             ]
         except Interrupted:
-            # A rebuild is already queued, so these findings describe a solid the
-            # next build replaces. Returning None keeps drain from broadcasting
-            # anything; the last build in the burst still gets a full check.
+            # A rebuild is queued, so let its geometry land before spending more time
+            # here. None tells drain to keep this path pending and retry it afterward.
             return None
         except Exception as exc:
             entry["findings"] = [
@@ -1261,8 +1260,27 @@ class Server:
                     grew = True
         return found - set(paths)
 
+    async def _finish_check(self, path):
+        """Check one settled build; False means a newer rebuild interrupted it."""
+        async with self.building:
+            entry = await asyncio.to_thread(
+                self.check, path, lambda: not self.queue.empty()
+            )
+        if entry is None:
+            return False
+        if entry.get("findings") is not None:
+            await self.broadcast(entry, kind="checked")
+            bad = sum(1 for f in entry["findings"] if f["severity"] == "fail")
+            if entry["findings"]:
+                print(
+                    f"    {len(entry['findings'])} finding(s), {bad} to fix",
+                    flush=True,
+                )
+        return True
+
     async def drain(self):
         """Rebuild on file change, coalescing the burst an editor save produces."""
+        pending_checks = set()
         while True:
             paths = {await self.queue.get()}
             await asyncio.sleep(0.05)
@@ -1277,6 +1295,7 @@ class Server:
                     name = pathlib.Path(path).stem
                     existed = self.state.pop(name, None) is not None
                     self.overrides.pop(name, None)
+                    pending_checks.discard(path)
                     if existed:
                         print(f"  {name}: gone", flush=True)
                     # Also notify for a source deleted before its first build. A
@@ -1289,29 +1308,19 @@ class Server:
                 status = entry["error"] or f"{entry['ms']}ms"
                 print(f"  {entry['name']}: {status}", flush=True)
                 await self.broadcast(entry)
-                # Geometry has landed, so the rules can take their time. Not the lock,
-                # though: with another rebuild already waiting, these findings describe
-                # a solid the next build is about to replace, and the slider that
-                # queued it would sit behind them. The last build in a burst still
-                # gets its checks.
-                if not self.queue.empty():
+                pending_checks.add(path)
+            # Every geometry update in the burst lands before its checks start. If a
+            # new rebuild arrives during a motion sweep, leave that check pending,
+            # service the rebuild, then retry against the latest settled state.
+            while pending_checks and self.queue.empty():
+                path = min(pending_checks)
+                if not pathlib.Path(path).exists():
+                    pending_checks.discard(path)
                     continue
-                async with self.building:
-                    # The same reasoning mid-flight: a motion sweep can hold this lock
-                    # for seconds, and a save that lands during it should not wait out
-                    # findings about a solid it is replacing. The sweep polls the
-                    # queue between poses and bails.
-                    entry = await asyncio.to_thread(
-                        self.check, path, lambda: not self.queue.empty()
-                    )
-                if entry and entry.get("findings") is not None:
-                    await self.broadcast(entry, kind="checked")
-                    bad = sum(1 for f in entry["findings"] if f["severity"] == "fail")
-                    if entry["findings"]:
-                        print(
-                            f"    {len(entry['findings'])} finding(s), {bad} to fix",
-                            flush=True,
-                        )
+                if await self._finish_check(path):
+                    pending_checks.discard(path)
+                else:
+                    break
             # The duplication scan reads every part file, so once per settled burst,
             # not per path; a burst still queuing gets it on its last round instead.
             if self.queue.empty():

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -375,14 +375,16 @@ class Server:
                 return variant_ctx
         return ctx
 
-    def check(self, path):
+    def check(self, path, stop=None):
         """Run the rules on the last good build.
 
         Separate from `rebuild` and broadcast separately, because checking the shelf
         costs about as much again as building it. Geometry should land at the speed it
-        always did and the findings can arrive a beat later.
+        always did and the findings can arrive a beat later. `stop` reaches the motion
+        sweep, the one check that can hold the build lock for seconds.
         """
         from . import checks
+        from .assembly import Interrupted
 
         entry = self.state.get(pathlib.Path(path).stem)
         if not entry or entry.get("shape") is None:
@@ -393,7 +395,7 @@ class Server:
             # base part's 18. Matched on the built values, never on a mode flag, so
             # one slider drag off the variant honestly puts the base rules back.
             ctx = self._context(path, entry["variant"])
-            found = checks.run(entry["shape"], ctx)
+            found = checks.run(entry["shape"], ctx, stop=stop)
             # Each finding carries the triangles of the face it fired on, so the viewer
             # can paint the face itself instead of dropping a pin near it. Rounded to
             # 0.01mm, which is display precision, not geometry.
@@ -424,6 +426,11 @@ class Server:
                 }
                 for f, row in zip(found, rows)
             ]
+        except Interrupted:
+            # A rebuild is already queued, so these findings describe a solid the
+            # next build replaces. Returning None keeps drain from broadcasting
+            # anything; the last build in the burst still gets a full check.
+            return None
         except Exception as exc:
             entry["findings"] = [
                 {
@@ -1290,7 +1297,13 @@ class Server:
                 if not self.queue.empty():
                     continue
                 async with self.building:
-                    entry = await asyncio.to_thread(self.check, path)
+                    # The same reasoning mid-flight: a motion sweep can hold this lock
+                    # for seconds, and a save that lands during it should not wait out
+                    # findings about a solid it is replacing. The sweep polls the
+                    # queue between poses and bails.
+                    entry = await asyncio.to_thread(
+                        self.check, path, lambda: not self.queue.empty()
+                    )
                 if entry and entry.get("findings") is not None:
                     await self.broadcast(entry, kind="checked")
                     bad = sum(1 for f in entry["findings"] if f["severity"] == "fail")

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -267,3 +267,42 @@ def test_an_assembly_glb_keeps_its_movers_as_named_nodes(project):
     solid, _, _ = builder.build(project / "parts" / "plate.py")
     plain = trimesh.load(io.BytesIO(builder.to_glb(solid)), file_type="glb")
     assert len(plain.geometry) == 1
+
+
+def test_solids_whose_boxes_are_apart_never_reach_a_kernel_boolean():
+    """The AABB reject is what keeps a clean full-circle sweep affordable: most
+    poses of a real rotor are nowhere near most of the scene (#127)."""
+    from build123d import Box, Pos
+
+    from nurb.assembly import _hits
+
+    booleans = []
+
+    class Spy:
+        def __init__(self, solid):
+            self._solid = solid
+
+        def bounding_box(self):
+            return self._solid.bounding_box()
+
+        def __and__(self, other):
+            booleans.append(other)
+            return self._solid & other
+
+    near, far = Pos(1, 0, 0) * Box(2, 2, 2), Pos(100, 0, 0) * Box(2, 2, 2)
+    vol, where = _hits(Spy(Box(2, 2, 2)), [far, near])
+    assert booleans == [near]  # far was rejected on boxes alone
+    assert vol == pytest.approx(1 * 2 * 2, rel=1e-6)
+
+
+def test_a_stop_that_turns_true_interrupts_the_sweep_between_poses(project):
+    """The dev server aborts a sweep when a rebuild is queued; findings about a
+    solid the next build replaces are worthless (#127)."""
+    from nurb.assembly import Interrupted
+
+    path = write(project, "rig", FLAP_ASM)
+    shape, _, _ = builder.build(path)
+    with pytest.raises(Interrupted):
+        checks.run(shape, stop=lambda: True)
+    # A stop that stays false changes nothing.
+    assert [f.rule for f in checks.run(shape, stop=lambda: False)] == ["motion"] * 2

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -296,8 +296,8 @@ def test_solids_whose_boxes_are_apart_never_reach_a_kernel_boolean():
 
 
 def test_a_stop_that_turns_true_interrupts_the_sweep_between_poses(project):
-    """The dev server aborts a sweep when a rebuild is queued; findings about a
-    solid the next build replaces are worthless (#127)."""
+    """The dev server aborts a sweep when a rebuild is queued, then drain retries
+    it after the queued geometry lands (#127)."""
     from nurb.assembly import Interrupted
 
     path = write(project, "rig", FLAP_ASM)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1196,6 +1196,78 @@ def test_shared_read_failure_cannot_kill_the_rebuild_loop(tmp_path, monkeypatch)
     assert Server(tmp_path)._shared() == []
 
 
+def test_an_interrupted_check_retries_after_the_queued_sibling_rebuild(tmp_path):
+    """A sibling save aborts a slow sweep, but must not leave its checks pending."""
+    parts = tmp_path / "parts"
+    parts.mkdir()
+    first, sibling = parts / "a.py", parts / "b.py"
+    first.write_text("")
+    sibling.write_text("")
+
+    async def go():
+        server = Server(tmp_path)
+        server.queue = asyncio.Queue()
+        server._shared = lambda: []
+        loop = asyncio.get_running_loop()
+        events = []
+        attempts = {"a": 0, "b": 0}
+        complete = asyncio.Event()
+
+        def rebuild(path):
+            name = pathlib.Path(path).stem
+            entry = {
+                "name": name,
+                "error": None,
+                "ms": 0,
+                "findings": None,
+            }
+            server.state[name] = entry
+            return entry
+
+        def check(path, stop=None):
+            name = pathlib.Path(path).stem
+            attempts[name] += 1
+            if name == "a" and attempts[name] == 1:
+                loop.call_soon_threadsafe(server.queue.put_nowait, str(sibling))
+                deadline = time.monotonic() + 1
+                while not stop():
+                    if time.monotonic() > deadline:
+                        raise AssertionError("queued rebuild never reached the sweep")
+                    time.sleep(0.001)
+                return None
+            entry = server.state[name]
+            entry["findings"] = []
+            return entry
+
+        async def broadcast(entry, kind="rebuilt"):
+            events.append((kind, entry["name"]))
+            if events[-2:] == [("checked", "a"), ("checked", "b")]:
+                complete.set()
+
+        server.rebuild = rebuild
+        server.check = check
+        server.broadcast = broadcast
+        server.queue.put_nowait(str(first))
+        task = asyncio.create_task(server.drain())
+        try:
+            await asyncio.wait_for(complete.wait(), timeout=2)
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        assert events == [
+            ("rebuilt", "a"),
+            ("rebuilt", "b"),
+            ("checked", "a"),
+            ("checked", "b"),
+        ]
+        assert attempts == {"a": 2, "b": 1}
+
+    asyncio.run(go())
+
+
 def test_sync_carries_the_shared_runs(tmp_path):
     server = bins(tmp_path, ["bin_large", "bin_medium", "bin_small"])
     server.shared = server._shared()


### PR DESCRIPTION
## Summary

Assembly motion checks ran a full OCCT boolean for every pose and held the global build lock, so a 360° rotor could block sibling rebuilds for roughly 14 seconds.

This adds AABB rejection and cooperative cancellation, documents pose-count costs, and defers interrupted checks until queued geometry has landed so Checks never remains pending.

Includes regression coverage for broad-phase rejection, cancellation, and cross-part retry.

Fixes #127.

## Testing

- `uv run pytest -q` — 547 passed, 2 skipped