### PR TITLE
Release 0.19.1

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.19.0"
+version = "0.19.1"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.19.0"
+version = "0.19.1"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,15 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.19.1">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.19.1">v0.19.1</a></span><time datetime="2026-08-14">August 14, 2026</time></div>
+    <ul>
+      <li><b class="tag">improved</b><span><b>Faster motion checks.</b> A part that swings all the way round took about fourteen seconds to check, and nothing else in the project would rebuild while it ran. The check now skips the parts that are nowhere near the one that moves, and a save or a slider drag interrupts it instead of queueing behind it.</span></li>
+      <li><b class="tag">fixed</b><span>Saving several parts at once left all but the last one without check results.</span></li>
+      <li><b class="tag">improved</b><span>Your AI understands tapered shapes better. A shape that steps through three or more outlines used to bow inward between them, so a wall you asked to be 15mm across came out 12.5mm. Your AI now keeps those walls straight, and knows which tapered rims will refuse a rounded edge.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.19.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.19.0">v0.19.0</a></span><time datetime="2026-08-13">August 13, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.19.0"
+  version: "0.19.1"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.19.0"
+  version: "0.19.1"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.19.0"
+version = "0.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Patch release: the assembly motion sweep gets fast and interruptible, and the doctrine gains three measured loft rules.

## What ships

- **Faster motion checks.** A full-circle joint used to walk every pose through an OCCT boolean against every other solid, roughly fourteen seconds on real geometry, holding the build lock the whole time so no sibling part could rebuild. Bounding-box rejection skips the solids the mover is nowhere near, and a `stop` callable lets a queued rebuild interrupt the sweep. (#128)
- **Checks no longer go missing.** Saving several parts at once used to drop every check but the last one, with nothing to say they were skipped. Interrupted checks stay pending and retry once the geometry settles. (#128)
- **Measured loft rules in the doctrine.** A loft through three or more sections wanders off the straight line unless `ruled=True`, a smooth loft to a curved section refuses the chamfer a ruled polygonal one takes, and loft returns a silent sliver instead of raising when two sections land nearly coplanar. (#126)

## Release mechanics

Four version strings move to 0.19.1 (pyproject, both skill files, tauri.conf.json), `evals/uv.lock` is relocked, and the changelog entry lands on the site.

`uv run pytest tests/test_cli.py -q` — 53 passed. Changelog verified in a browser.

https://claude.ai/code/session_01M9DYbkWeYsHTtLtjHt5RNL