### PR TITLE
Play a completion chime when the agent finishes a long task

### DIFF
--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -1614,6 +1614,19 @@ textarea {
   color: var(--text);
 }
 
+.settings-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font: 13px var(--sans);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.settings-toggle input {
+  accent-color: var(--accent);
+}
+
 /* ---- the "need another agent?" help ---- */
 
 .about-card.agents-help {

--- a/desktop/src/Chat.tsx
+++ b/desktop/src/Chat.tsx
@@ -12,6 +12,7 @@ import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { open } from "@tauri-apps/plugin-dialog";
 import { IconChevronDown, IconMessagePlus, IconPaperclip } from "./Icons";
 import Markdown from "./Markdown";
+import { playChime, shouldPlayCompletionChime } from "./chime";
 
 // The whole-project conversation rides the per-part plumbing under a name no part
 // file can have. Twins live in App.tsx's mount and acp.rs's context line.
@@ -484,6 +485,7 @@ function Chat({
   const send = useCallback(
     async (text: string, files: string[]) => {
       sendingRef.current = true;
+      const startedAt = Date.now();
       const localId = nextLocalIdRef.current++;
       setItems((list) => [
         ...list,
@@ -497,6 +499,7 @@ function Chat({
       setBusy(true);
       onBusyRef.current(true);
       setAuthNeeded(false);
+      let completed = false;
       try {
         const session = await ensureSession();
         await invoke<string>("send_prompt", {
@@ -505,6 +508,7 @@ function Chat({
           part: part ?? null,
           attachments: files,
         });
+        completed = true;
       } catch (e) {
         const message = String(e);
         if (message.includes("auth_required")) {
@@ -524,6 +528,9 @@ function Chat({
         setBusy(false);
         onBusyRef.current(false);
         setPermissions([]);
+        // Only successful turns long enough to wander away from earn a chime;
+        // quick back-and-forth and failures should stay quiet.
+        if (shouldPlayCompletionChime(completed, Date.now() - startedAt)) playChime();
       }
     },
     [ensureSession, part],

--- a/desktop/src/Settings.tsx
+++ b/desktop/src/Settings.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { open as pickFolder } from "@tauri-apps/plugin-dialog";
+import { playChime, setSoundEnabled, soundEnabled } from "./chime";
 
 type Props = {
   folder: string;
@@ -9,6 +11,15 @@ type Props = {
 };
 
 export default function Settings({ folder, customized, onChange, onReset, onClose }: Props) {
+  const [sound, setSound] = useState(soundEnabled);
+
+  const toggleSound = (on: boolean) => {
+    setSoundEnabled(on);
+    setSound(on);
+    // Turning it on plays the chime once, so the choice is audible in place.
+    if (on) playChime();
+  };
+
   const changeFolder = async () => {
     // Before the backend resolves the default, the folder shown is the
     // literal "~/Documents/nurb" placeholder, which is not a path.
@@ -50,6 +61,15 @@ export default function Settings({ folder, customized, onChange, onReset, onClos
               </button>
             )}
           </div>
+          <h3>Sound</h3>
+          <label className="settings-toggle">
+            <input
+              type="checkbox"
+              checked={sound}
+              onChange={(e) => toggleSound(e.target.checked)}
+            />
+            Play a chime when the agent finishes a long task
+          </label>
         </div>
       </div>
     </div>

--- a/desktop/src/chime.ts
+++ b/desktop/src/chime.ts
@@ -1,0 +1,51 @@
+// A completion chime for turns long enough that the user has wandered off.
+// Synthesized with Web Audio so the app ships no audio asset and stays offline.
+
+const SOUND_KEY = "nurb-completion-sound";
+const LONG_TASK_MS = 8000;
+
+export function shouldPlayCompletionChime(completed: boolean, elapsedMs: number): boolean {
+  return completed && elapsedMs > LONG_TASK_MS;
+}
+
+export function soundEnabled(): boolean {
+  return localStorage.getItem(SOUND_KEY) !== "off";
+}
+
+export function setSoundEnabled(on: boolean) {
+  if (on) localStorage.removeItem(SOUND_KEY);
+  else localStorage.setItem(SOUND_KEY, "off");
+}
+
+let ctx: AudioContext | null = null;
+
+export function playChime() {
+  if (!soundEnabled()) return;
+  try {
+    ctx ??= new AudioContext();
+    // WKWebView leaves a context created outside a user gesture suspended.
+    if (ctx.state === "suspended") void ctx.resume();
+    const now = ctx.currentTime;
+    // A bouncy C-major arpeggio, video-game "ta-da!": triangle waves read as
+    // toy-like rather than doorbell, and the last note gets to ring out.
+    for (const [freq, at, hold] of [
+      [784, 0, 0.18],
+      [1046.5, 0.08, 0.18],
+      [1318.5, 0.16, 0.18],
+      [1568, 0.24, 0.6],
+    ] as const) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "triangle";
+      osc.frequency.value = freq;
+      gain.gain.setValueAtTime(0, now + at);
+      gain.gain.linearRampToValueAtTime(0.14, now + at + 0.01);
+      gain.gain.exponentialRampToValueAtTime(0.0001, now + at + hold);
+      osc.connect(gain).connect(ctx.destination);
+      osc.start(now + at);
+      osc.stop(now + at + hold + 0.1);
+    }
+  } catch {
+    // No audio device is never worth an error in the chat.
+  }
+}

--- a/desktop/tests/chime.test.ts
+++ b/desktop/tests/chime.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { shouldPlayCompletionChime } from "../src/chime.ts";
+
+test("only successful long turns earn a completion chime", () => {
+  assert.equal(shouldPlayCompletionChime(false, 9000), false);
+  assert.equal(shouldPlayCompletionChime(true, 8000), false);
+  assert.equal(shouldPlayCompletionChime(true, 8001), true);
+});


### PR DESCRIPTION
Adds an optional completion chime so a user who wandered off hears the agent finish. A synthesized Web Audio arpeggio (`desktop/src/chime.ts`, no shipped audio asset) plays after a successful turn longer than 8 seconds; short back-and-forth turns and failures stay quiet. A new Sound toggle in Settings turns it off and previews it on, persisting the choice in localStorage. A unit test covers the successful-and-long gate.