### PR TITLE
Disable macOS autocapitalize in project and part name inputs

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -879,6 +879,9 @@ function App() {
               className="name-input"
               name="name"
               placeholder="project name"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
               disabled={creating}
               autoFocus
               onKeyDown={(e) => e.key === "Escape" && setNaming(false)}
@@ -1025,6 +1028,9 @@ function App() {
                           className="name-input"
                           name="name"
                           placeholder="part name"
+                          autoCapitalize="off"
+                          autoCorrect="off"
+                          spellCheck={false}
                           disabled={partCreating}
                           autoFocus
                           onKeyDown={(e) => e.key === "Escape" && setPartNaming(false)}


### PR DESCRIPTION
The system autocorrect in WKWebView uppercased the first letter when typing a new project or part name. Both name inputs in the desktop app now set autoCapitalize, autoCorrect, and spellCheck off, so names stay lowercase as typed.