### PR TITLE
Release 0.19.2

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.19.1"
+version = "0.19.2"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.19.1"
+version = "0.19.2"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,14 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.19.2">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.19.2">v0.19.2</a></span><time datetime="2026-08-14">August 14, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Completion chime.</b> A short chime plays when your AI finishes a task that took a while, so you can look away and still hear the part is ready. Quick back and forth stays quiet. Settings has a Sound switch that turns it off, and plays it once when you turn it back on.</span></li>
+      <li><b class="tag">fixed</b><span>Typing a new project or part name no longer capitalizes the first letter for you.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.19.1">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.19.1">v0.19.1</a></span><time datetime="2026-08-14">August 14, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.19.1"
+  version: "0.19.2"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.19.1"
+  version: "0.19.2"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.19.1"
+version = "0.19.2"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
A patch release: one small feature and one fix, both in the desktop app.

**Completion chime.** A short chime plays when the agent finishes a turn that ran longer than eight seconds, so a user who wandered off hears the part is ready. Quick back and forth and failed turns stay quiet. A Sound toggle in Settings turns it off and previews it when turned back on.

**Name inputs stay lowercase.** WKWebView's autocorrect was capitalizing the first letter of a new project or part name as you typed it. Both inputs now turn autocapitalize, autocorrect, and spellcheck off.

Bumps the four version strings, relocks `evals/uv.lock`, and adds the v0.19.2 changelog entry.