### PR TITLE
fix: hide eval answer key without mutating checkout permissions

### DIFF
--- a/evals/src/nurb_evals/run.py
+++ b/evals/src/nurb_evals/run.py
@@ -19,7 +19,6 @@ import os
 import pathlib
 import signal
 import shutil
-import stat
 import subprocess
 import sys
 import tempfile
@@ -41,32 +40,64 @@ done, the part file named below must exist at its stated path.
 
 
 @contextlib.contextmanager
-def _answer_key_hidden():
-    """Make the scorers, reference solutions, and prior rows unreadable while the
-    agent runs.
+def _isolated_nurb_environment(env, raw):
+    """Install the locked nurb build outside the checkout for one agent run.
 
-    Moving the project into a temp directory is not enough: the nurb on PATH is an
-    editable install, so `which nurb` or `import nurb` hands any curious model a path
-    back to the checkout, and real transcripts show models following it into
-    tests/solutions and tasks/*/task.py mid-trial. Instead of hiding the path, which
-    cannot be done, deny the read: chmod the sensitive directories to 0 for the
-    duration of the harness run and restore them before grading. This is a guard
-    against a model wandering, not against an adversary (the same user can chmod them
-    back, and the repo is public), and it assumes one trial at a time per checkout.
+    The benchmark itself is editable, so handing its Python or nurb executable to an
+    agent also hands it a path back to tests/solutions and tasks/*/task.py. A locked,
+    non-editable install in the trial's temp directory removes that breadcrumb without
+    changing shared checkout permissions. Concurrent and interrupted trials therefore
+    cannot expose answers to one another or leave the repository unreadable.
     """
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv is required to prepare the isolated nurb runtime")
+
     evals = pathlib.Path(__file__).parents[2]
-    saved = []
-    for name in ("tasks", "tests", "submissions", "results"):
-        path = evals / name
-        if path.is_dir():
-            saved.append((path, path.stat().st_mode))
-    for path, _ in saved:
-        os.chmod(path, 0)
-    try:
-        yield
-    finally:
-        for path, mode in saved:
-            os.chmod(path, stat.S_IMODE(mode))
+    runtime = pathlib.Path(raw) / "runtime"
+    venv = runtime / "venv"
+    setup_env = dict(os.environ)
+    setup_env["VIRTUAL_ENV"] = str(venv)
+    commands = (
+        [uv, "venv", "--python", sys.executable, str(venv)],
+        [
+            uv,
+            "sync",
+            "--project", str(evals),
+            "--active",
+            "--frozen",
+            "--offline",
+            "--no-editable",
+            "--no-dev",
+            "--no-install-project",
+            "--no-progress",
+        ],
+    )
+    for command in commands:
+        done = subprocess.run(command, env=setup_env, capture_output=True, text=True)
+        if done.returncode != 0:
+            detail = (done.stderr or done.stdout).strip().splitlines()
+            raise RuntimeError(
+                "could not prepare isolated nurb runtime"
+                + (f": {detail[-1]}" if detail else "")
+            )
+
+    # Local wheel metadata records where it was built. It is irrelevant at runtime
+    # and would recreate the checkout breadcrumb this environment exists to remove.
+    site = next((venv / "lib").glob("python*/site-packages"))
+    for direct_url in site.glob("nurb-*.dist-info/direct_url.json"):
+        direct_url.unlink()
+
+    clean = dict(env)
+    benchmark_bin = pathlib.Path(sys.executable).parent.resolve()
+    inherited = [
+        entry
+        for entry in clean.get("PATH", "").split(os.pathsep)
+        if not entry or pathlib.Path(entry).expanduser().resolve() != benchmark_bin
+    ]
+    clean["PATH"] = os.pathsep.join((str(venv / "bin"), *inherited))
+    clean["VIRTUAL_ENV"] = str(venv)
+    yield clean
 
 
 def _invoke(cmd, *, cwd, env, timeout):
@@ -117,21 +148,21 @@ def trial(h, task_dir, seed, n, out, model=None, effort=None, timeout=3600.0):
         env["PATH"] = f"{pathlib.Path(sys.executable).parent}:{env.get('PATH', '')}"
         env["PWD"] = str(project)
 
-        started = time.monotonic()
         error = None
         stdout = ""
-        # Build the command before the answer key goes dark: an adapter is free to
-        # read whatever it wants at build time, the agent it launches is not.
+        # Build the adapter command before swapping in the agent's isolated runtime.
         cmd = h.command(
             prompt,
             model=model,
             effort=effort,
             instructions=(project / "AGENTS.md").read_text(encoding="utf-8"),
         )
-        with h.environment(env) as clean_env, _answer_key_hidden():
-            returncode, stdout, stderr, timed_out = _invoke(
-                cmd, cwd=project, env=clean_env, timeout=timeout,
-            )
+        with _isolated_nurb_environment(env, raw) as isolated_env:
+            started = time.monotonic()
+            with h.environment(isolated_env) as clean_env:
+                returncode, stdout, stderr, timed_out = _invoke(
+                    cmd, cwd=project, env=clean_env, timeout=timeout,
+                )
         harness_s = round(time.monotonic() - started, 1)
 
         # The model must not run below the benchmark checkout, where walking to a

--- a/evals/src/nurb_evals/run.py
+++ b/evals/src/nurb_evals/run.py
@@ -13,11 +13,13 @@ left behind, because a leaderboard row nobody can audit is a rumor.
 """
 
 import argparse
+import contextlib
 import json
 import os
 import pathlib
 import signal
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -36,6 +38,35 @@ current directory). There is no human to ask and no browser to look at: never ru
 done, the part file named below must exist at its stated path.
 
 """
+
+
+@contextlib.contextmanager
+def _answer_key_hidden():
+    """Make the scorers, reference solutions, and prior rows unreadable while the
+    agent runs.
+
+    Moving the project into a temp directory is not enough: the nurb on PATH is an
+    editable install, so `which nurb` or `import nurb` hands any curious model a path
+    back to the checkout, and real transcripts show models following it into
+    tests/solutions and tasks/*/task.py mid-trial. Instead of hiding the path, which
+    cannot be done, deny the read: chmod the sensitive directories to 0 for the
+    duration of the harness run and restore them before grading. This is a guard
+    against a model wandering, not against an adversary (the same user can chmod them
+    back, and the repo is public), and it assumes one trial at a time per checkout.
+    """
+    evals = pathlib.Path(__file__).parents[2]
+    saved = []
+    for name in ("tasks", "tests", "submissions", "results"):
+        path = evals / name
+        if path.is_dir():
+            saved.append((path, path.stat().st_mode))
+    for path, _ in saved:
+        os.chmod(path, 0)
+    try:
+        yield
+    finally:
+        for path, mode in saved:
+            os.chmod(path, stat.S_IMODE(mode))
 
 
 def _invoke(cmd, *, cwd, env, timeout):
@@ -89,17 +120,17 @@ def trial(h, task_dir, seed, n, out, model=None, effort=None, timeout=3600.0):
         started = time.monotonic()
         error = None
         stdout = ""
-        with h.environment(env) as clean_env:
+        # Build the command before the answer key goes dark: an adapter is free to
+        # read whatever it wants at build time, the agent it launches is not.
+        cmd = h.command(
+            prompt,
+            model=model,
+            effort=effort,
+            instructions=(project / "AGENTS.md").read_text(encoding="utf-8"),
+        )
+        with h.environment(env) as clean_env, _answer_key_hidden():
             returncode, stdout, stderr, timed_out = _invoke(
-                h.command(
-                    prompt,
-                    model=model,
-                    effort=effort,
-                    instructions=(project / "AGENTS.md").read_text(encoding="utf-8"),
-                ),
-                cwd=project,
-                env=clean_env,
-                timeout=timeout,
+                cmd, cwd=project, env=clean_env, timeout=timeout,
             )
         harness_s = round(time.monotonic() - started, 1)
 

--- a/evals/tests/test_contribute.py
+++ b/evals/tests/test_contribute.py
@@ -50,7 +50,12 @@ def test_wizard_runs_and_stages_a_sanitized_submission(tmp_path, monkeypatch, ca
     os.symlink(real / "tasks" / "cable_clip", root / "tasks" / "cable_clip")
 
     monkeypatch.setattr(contribute, "EVALS", root)
-    monkeypatch.setattr(contribute.shutil, "which", lambda name: "/usr/bin/true")
+    which = contribute.shutil.which
+    monkeypatch.setattr(
+        contribute.shutil,
+        "which",
+        lambda name: "/usr/bin/true" if name == "stub" else which(name),
+    )
     monkeypatch.setitem(harnesses.HARNESSES, "stub", Stub(GOOD))
     monkeypatch.setattr(
         sys,

--- a/evals/tests/test_runner.py
+++ b/evals/tests/test_runner.py
@@ -6,6 +6,7 @@ materialized, part graded, row written, transcript kept — not any real model.
 """
 
 import contextlib
+import concurrent.futures
 import json
 import pathlib
 import sys
@@ -38,12 +39,12 @@ class Stub:
     def command(self, prompt, model=None, effort=None, instructions=None):
         assert instructions and instructions.startswith("#")
         if self.source is None:
-            return [sys.executable, "-c", "pass"]
-        # Embed the solution's text rather than its path: the command is built before
-        # the run, while the "agent" subprocess executes with the answer key dark.
+            return ["python", "-c", "pass"]
+        # Embed the solution's text rather than its path: the "agent" subprocess runs
+        # with only the isolated nurb installation on its import and executable paths.
         text = pathlib.Path(self.source).read_text(encoding="utf-8")
         write = f"import pathlib; pathlib.Path('parts/{self.part}.py').write_text({text!r})"
-        return [sys.executable, "-c", write]
+        return ["python", "-c", write]
 
     def usage(self, stdout):
         return {"stub": True}
@@ -80,7 +81,7 @@ def test_the_agent_project_is_not_inside_the_benchmark_checkout(tmp_path, monkey
                 "print(any((p/'grader-secret').exists() for p in (here,*here.parents)));"
                 f"pathlib.Path('parts/cable_clip.py').write_text({GOOD.read_text()!r})"
             )
-            return [sys.executable, "-c", script]
+            return ["python", "-c", script]
 
     row = runner.trial(AncestorProbe(GOOD), TASK, SEED, 1, out)
     assert row["score"] == 1.0
@@ -89,31 +90,90 @@ def test_the_agent_project_is_not_inside_the_benchmark_checkout(tmp_path, monkey
     assert (slot / "project" / "parts" / "cable_clip.py").is_file()
 
 
-def test_the_answer_key_is_unreadable_while_the_agent_runs(tmp_path):
-    """Real transcripts show models following the editable install's path back into
-    tests/solutions and tasks/*/task.py mid-trial. During the harness run those
-    directories deny reads; grading afterwards still works."""
+def test_the_answer_key_checkout_is_not_discoverable_while_the_agent_runs(tmp_path):
+    """The agent's nurb executable, Python, import path, and install metadata all
+    belong to its throwaway runtime rather than the benchmark checkout."""
 
     class Peeker(Stub):
         def command(self, prompt, model=None, effort=None, instructions=None):
             script = (
-                "import pathlib\n"
-                f"for secret in ({str(GOOD)!r}, {str(TASK / 'task.py')!r}):\n"
-                "    try:\n"
-                "        pathlib.Path(secret).read_text()\n"
-                "        print('LEAKED', secret)\n"
-                "    except PermissionError:\n"
-                "        print('denied')\n"
+                "import importlib.metadata, importlib.util, os, shutil, sys\n"
+                f"checkout = {str(EVALS.parent)!r}\n"
+                "dist = importlib.metadata.distribution('nurb')\n"
+                "breadcrumbs = [shutil.which('nurb'), sys.executable, *sys.path, "
+                "*os.environ['PATH'].split(os.pathsep), "
+                "importlib.util.find_spec('nurb').origin, "
+                "dist.read_text('direct_url.json')]\n"
+                "print('LEAKED' if any(checkout in (p or '') for p in breadcrumbs) "
+                "else 'hidden')\n"
                 f"pathlib.Path('parts/cable_clip.py').write_text({GOOD.read_text()!r})\n"
             )
-            return [sys.executable, "-c", script]
+            return ["python", "-c", "import pathlib\n" + script]
 
     row = runner.trial(Peeker(GOOD), TASK, SEED, 1, tmp_path)
-    assert row["score"] == 1.0, "directories are restored in time for grading"
+    assert row["score"] == 1.0
     transcript = (tmp_path / "cable_clip" / "trial_1" / "transcript.txt").read_text()
     assert "LEAKED" not in transcript
-    assert transcript.count("denied") == 2
-    assert GOOD.read_text(), "and restored for the next caller"
+    assert transcript.strip() == "hidden"
+
+
+def test_the_isolated_nurb_cli_builds_the_agent_project(tmp_path):
+    class Builds(Stub):
+        def command(self, prompt, model=None, effort=None, instructions=None):
+            script = (
+                "import pathlib,subprocess\n"
+                f"pathlib.Path('parts/cable_clip.py').write_text({GOOD.read_text()!r})\n"
+                "subprocess.run(['nurb', 'build', 'cable_clip'], check=True)\n"
+            )
+            return ["python", "-c", script]
+
+    row = runner.trial(Builds(GOOD), TASK, SEED, 1, tmp_path)
+    assert row["score"] == 1.0
+    assert row["error"] is None
+
+
+def test_trials_never_change_checkout_permissions(tmp_path, monkeypatch):
+    chmod = runner.os.chmod
+
+    def guarded(path, *args, **kwargs):
+        if pathlib.Path(path).resolve().is_relative_to(EVALS.resolve()):
+            raise AssertionError("a trial must not mutate shared checkout permissions")
+        return chmod(path, *args, **kwargs)
+
+    monkeypatch.setattr(runner.os, "chmod", guarded)
+    assert runner.trial(Stub(GOOD), TASK, SEED, 1, tmp_path)["score"] == 1.0
+
+
+def test_two_trials_can_run_concurrently(tmp_path):
+    rendezvous = tmp_path / "rendezvous"
+    rendezvous.mkdir()
+
+    class Overlap(Stub):
+        def __init__(self, marker):
+            super().__init__(GOOD)
+            self.marker = marker
+
+        def command(self, prompt, model=None, effort=None, instructions=None):
+            script = (
+                "import pathlib,time\n"
+                f"shared=pathlib.Path({str(rendezvous)!r})\n"
+                f"(shared/{self.marker!r}).write_text('ready')\n"
+                "deadline=time.monotonic()+20\n"
+                "while len(list(shared.iterdir())) < 2 and time.monotonic() < deadline:\n"
+                "    time.sleep(0.01)\n"
+                "assert len(list(shared.iterdir())) == 2\n"
+                f"pathlib.Path('parts/cable_clip.py').write_text({GOOD.read_text()!r})\n"
+            )
+            return ["python", "-c", script]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        rows = list(
+            pool.map(
+                lambda pair: runner.trial(pair[0], TASK, SEED, pair[1], tmp_path),
+                ((Overlap("one"), 1), (Overlap("two"), 2)),
+            )
+        )
+    assert [row["score"] for row in rows] == [1.0, 1.0]
 
 
 def test_the_part_path_follows_the_task(tmp_path):
@@ -195,7 +255,7 @@ def test_timeout_kills_harness_descendants(tmp_path):
                 "while not pathlib.Path('child_started').exists(): time.sleep(0.01)\n"
                 "time.sleep(60)"
             )
-            return [sys.executable, "-c", parent]
+            return ["python", "-c", parent]
 
     runner.trial(SpawnsChild(), TASK, SEED, 1, tmp_path, timeout=1.0)
     project = tmp_path / "cable_clip" / "trial_1" / "project"

--- a/evals/tests/test_runner.py
+++ b/evals/tests/test_runner.py
@@ -39,10 +39,10 @@ class Stub:
         assert instructions and instructions.startswith("#")
         if self.source is None:
             return [sys.executable, "-c", "pass"]
-        write = (
-            "import pathlib, shutil;"
-            f"shutil.copy({str(self.source)!r}, 'parts/{self.part}.py')"
-        )
+        # Embed the solution's text rather than its path: the command is built before
+        # the run, while the "agent" subprocess executes with the answer key dark.
+        text = pathlib.Path(self.source).read_text(encoding="utf-8")
+        write = f"import pathlib; pathlib.Path('parts/{self.part}.py').write_text({text!r})"
         return [sys.executable, "-c", write]
 
     def usage(self, stdout):
@@ -75,10 +75,10 @@ def test_the_agent_project_is_not_inside_the_benchmark_checkout(tmp_path, monkey
 
         def command(self, prompt, model=None, effort=None, instructions=None):
             script = (
-                "import pathlib,shutil;"
+                "import pathlib;"
                 "here=pathlib.Path.cwd();"
                 "print(any((p/'grader-secret').exists() for p in (here,*here.parents)));"
-                f"shutil.copy({str(GOOD)!r}, 'parts/cable_clip.py')"
+                f"pathlib.Path('parts/cable_clip.py').write_text({GOOD.read_text()!r})"
             )
             return [sys.executable, "-c", script]
 
@@ -87,6 +87,33 @@ def test_the_agent_project_is_not_inside_the_benchmark_checkout(tmp_path, monkey
     slot = out / "cable_clip" / "trial_1"
     assert (slot / "transcript.txt").read_text(encoding="utf-8").strip() == "False"
     assert (slot / "project" / "parts" / "cable_clip.py").is_file()
+
+
+def test_the_answer_key_is_unreadable_while_the_agent_runs(tmp_path):
+    """Real transcripts show models following the editable install's path back into
+    tests/solutions and tasks/*/task.py mid-trial. During the harness run those
+    directories deny reads; grading afterwards still works."""
+
+    class Peeker(Stub):
+        def command(self, prompt, model=None, effort=None, instructions=None):
+            script = (
+                "import pathlib\n"
+                f"for secret in ({str(GOOD)!r}, {str(TASK / 'task.py')!r}):\n"
+                "    try:\n"
+                "        pathlib.Path(secret).read_text()\n"
+                "        print('LEAKED', secret)\n"
+                "    except PermissionError:\n"
+                "        print('denied')\n"
+                f"pathlib.Path('parts/cable_clip.py').write_text({GOOD.read_text()!r})\n"
+            )
+            return [sys.executable, "-c", script]
+
+    row = runner.trial(Peeker(GOOD), TASK, SEED, 1, tmp_path)
+    assert row["score"] == 1.0, "directories are restored in time for grading"
+    transcript = (tmp_path / "cable_clip" / "trial_1" / "transcript.txt").read_text()
+    assert "LEAKED" not in transcript
+    assert transcript.count("denied") == 2
+    assert GOOD.read_text(), "and restored for the next caller"
 
 
 def test_the_part_path_follows_the_task(tmp_path):


### PR DESCRIPTION
## Summary

- run each benchmark agent against a locked, non-editable `nurb` installation in its own temporary environment
- remove checkout paths from the agent's executable/import paths and local wheel metadata
- keep concurrent and interrupted trials from changing shared checkout permissions

## Root cause

The editable benchmark environment exposed a path back to task scorers and reference solutions. The first fix hid those directories with checkout-wide permission changes, but overlapping or interrupted trials could expose the answer key or leave the checkout unreadable.

## Validation

- `uv run --project evals pytest -q evals/tests` — 100 passed
- exercised a real `nurb build cable_clip` through the isolated trial runtime
- verified two overlapping trials complete successfully
- verified benchmark checkout permissions remain unchanged
- `git diff --check`
