### PR TITLE
Show card variants in the macOS app's part list

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -338,7 +338,17 @@ fn part_views(project: &std::path::Path, body: &str) -> Result<serde_json::Value
                     .and_then(|entry| entry.get("uses"))
                     .cloned()
                     .unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
-                serde_json::json!({ "name": name, "error": error, "refused": refused, "assembly": assembly, "uses": uses })
+                // The card's variants, plus which one the server resolved as active,
+                // so the rail can nest them the way the browser viewer does.
+                let variants = entry
+                    .and_then(|entry| entry.get("variants"))
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
+                let variant = entry
+                    .and_then(|entry| entry.get("variant"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                serde_json::json!({ "name": name, "error": error, "refused": refused, "assembly": assembly, "uses": uses, "variants": variants, "variant": variant })
             })
             .collect(),
     ))
@@ -609,6 +619,8 @@ mod tests {
             &root,
             r#"[{"name":"broken","error":"trace"},{"name":"gone","error":null},
                 {"name":"held","error":"hole too small","refused":"hole"},
+                {"name":"alpha","error":null,"variant":"tall",
+                 "variants":[{"name":"tall","params":{"height":200.0},"note":"the pantry"}]},
                 {"name":"rig","error":null,"joints":[],"uses":["alpha"]}]"#,
         )
         .unwrap();
@@ -616,10 +628,12 @@ mod tests {
         assert_eq!(
             views,
             serde_json::json!([
-                { "name": "alpha", "error": null, "refused": false, "assembly": false, "uses": [] },
-                { "name": "broken", "error": "trace", "refused": false, "assembly": false, "uses": [] },
-                { "name": "held", "error": "hole too small", "refused": true, "assembly": false, "uses": [] },
-                { "name": "rig", "error": null, "refused": false, "assembly": true, "uses": ["alpha"] }
+                { "name": "alpha", "error": null, "refused": false, "assembly": false, "uses": [],
+                  "variants": [{ "name": "tall", "params": { "height": 200.0 }, "note": "the pantry" }],
+                  "variant": "tall" },
+                { "name": "broken", "error": "trace", "refused": false, "assembly": false, "uses": [], "variants": [], "variant": null },
+                { "name": "held", "error": "hole too small", "refused": true, "assembly": false, "uses": [], "variants": [], "variant": null },
+                { "name": "rig", "error": null, "refused": false, "assembly": true, "uses": ["alpha"], "variants": [], "variant": null }
             ])
         );
         std::fs::remove_dir_all(root).unwrap();

--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -348,6 +348,32 @@ textarea {
   color: var(--dim);
 }
 
+/* A card variant: the same part flexed to other values, so it nests under its
+   part the way the viewer's list draws it, indented past the icon column. */
+.part-var {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 9px;
+  padding: 2px 7px 2px 9px;
+  border-left: 1px solid var(--line);
+  border-radius: 0 5px 5px 0;
+  font-size: 11px;
+  color: var(--dimmer);
+  cursor: pointer;
+}
+
+.part-var:hover {
+  background: var(--hover);
+  color: var(--dim);
+}
+
+.part-var.selected {
+  color: var(--text);
+  background: var(--active);
+  border-left-color: var(--accent);
+}
+
 .part-add {
   display: flex;
   align-items: center;

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -16,9 +16,10 @@ import {
   updateChatActivity,
   type ChatColumn,
 } from "./chatColumns";
-import { IconCheck, IconCube, IconCubes, IconFolder, IconFolderPlus } from "./Icons";
+import { IconCheck, IconCube, IconCubes, IconFolder, IconFolderPlus, IconVariant } from "./Icons";
 import { COLUMNS, fitColumns, initialColumns, resizedColumn } from "./layout";
 import type { Column } from "./layout";
+import { partMessage, type PartConfigurationRequest } from "./partMessages";
 import Setup from "./Setup";
 import Settings from "./Settings";
 import "./App.css";
@@ -34,12 +35,18 @@ type Project = {
 type Server = { url: string; port: number };
 // `assembly` and `uses` are the placed-parts pair: an assembly is not one printable
 // solid, and the rail says so rather than letting it pass as another part.
+type Variant = { name: string; params: Record<string, unknown>; note?: string | null };
 type Part = {
   name: string;
   error: string | null;
   refused: boolean;
   assembly: boolean;
   uses: string[];
+  variants: Variant[];
+  // The variant the server resolved from the last successful build, so the rail's
+  // active mark tracks truth (an agent or a slider drag can move it) rather than
+  // the last click.
+  variant: string | null;
 };
 type PartState = { path: string; parts: Part[] };
 type ChatInfo = {
@@ -126,6 +133,11 @@ function App() {
   const [opening, setOpening] = useState<Record<string, boolean>>({});
   const [active, setActive] = useState<string | null>(null);
   const [partState, setPartState] = useState<PartState | null>(null);
+  // One explicit configuration click waiting for the loaded viewer. Kept out of
+  // render state because delivery consumes it; the version wakes the effect when
+  // the selected part itself did not change.
+  const variantRequest = useRef<PartConfigurationRequest | null>(null);
+  const [variantRequestVersion, setVariantRequestVersion] = useState(0);
   const [naming, setNaming] = useState(false);
   const [creating, setCreating] = useState(false);
   const [partNaming, setPartNaming] = useState(false);
@@ -466,7 +478,7 @@ function App() {
         setPartState({
           path: active,
           parts: entries
-            .map(({ name, error, refused, assembly, uses }) => ({ name, error, refused, assembly, uses }))
+            .map(({ name, error, refused, assembly, uses, variants, variant }) => ({ name, error, refused, assembly, uses, variants, variant }))
             .sort((a, b) => a.name.localeCompare(b.name)),
         });
       } catch {
@@ -693,9 +705,13 @@ function App() {
     if (projectChatFocused) openChat(PROJECT_CHAT);
   }, [openChat, projectChatFocused]);
 
-  const selectPart = (name: string) => {
+  // The part row is the defaults configuration, so selecting it clears any
+  // variant; a variant row passes its name and the viewer loads its overrides.
+  const selectPart = (name: string, variant?: string) => {
     if (!active) return;
     setProjectChatFocused(false);
+    variantRequest.current = { path: active, part: name, variant: variant ?? null };
+    setVariantRequestVersion((version) => version + 1);
     setProjects((list) =>
       list.map((p) => (p.path === active ? { ...p, selectedPart: name } : p)),
     );
@@ -710,7 +726,7 @@ function App() {
     for (let attempt = 0; ; attempt++) {
       const entries = await invoke<Part[]>("list_parts", { path });
       const listed = entries
-        .map(({ name, error, refused, assembly, uses }) => ({ name, error, refused, assembly, uses }))
+        .map(({ name, error, refused, assembly, uses, variants, variant }) => ({ name, error, refused, assembly, uses, variants, variant }))
         .sort((a, b) => a.name.localeCompare(b.name));
       if (settled(listed) || attempt >= 19) {
         setPartState({ path, parts: listed });
@@ -828,6 +844,7 @@ function App() {
   // once per server and part switches travel by postMessage instead.
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   const [frame, setFrame] = useState<{ key: string; src: string } | null>(null);
+  const [loadedFrame, setLoadedFrame] = useState<{ key: string; token: number } | null>(null);
   useEffect(() => {
     if (!activeServer || !partsReady) {
       setFrame(null);
@@ -845,13 +862,26 @@ function App() {
     );
   }, [activeServer, partsReady, selectedPart]);
 
+  // A request belongs to the project where it was clicked. Do not carry it out
+  // and back across a project switch, where it would overwrite newer viewer state.
+  useEffect(() => {
+    if (variantRequest.current?.path !== active) variantRequest.current = null;
+  }, [active]);
+
   const postPart = useCallback(() => {
-    if (!frame || !selectedPart) return;
+    if (!frame || loadedFrame?.key !== frame.key || !active || !selectedPart) return;
+    const request = variantRequest.current;
+    const { message, consumed } = partMessage(active, selectedPart, request);
+    // Any other current selection makes an older request stale. Consume before
+    // posting so React's development effect replay cannot send it twice.
+    if (request && (consumed || request.path !== active || request.part !== selectedPart)) {
+      variantRequest.current = null;
+    }
     frameRef.current?.contentWindow?.postMessage(
-      { type: "nurb:part", name: selectedPart },
+      message,
       frame.key,
     );
-  }, [frame, selectedPart]);
+  }, [frame, loadedFrame, selectedPart, active, variantRequestVersion]);
   useEffect(postPart, [postPart]);
 
   if (ready !== true) {
@@ -991,6 +1021,27 @@ function App() {
                           </span>
                         )}
                       </li>
+                      {/* The card's variants nest under their part the way the
+                          browser viewer draws them: the same part at other values,
+                          wearing the sliders glyph. The active mark follows the
+                          server's resolved variant, so it tracks slider drags and
+                          agent edits too, one poll behind. */}
+                      {part.variants.map((v) => {
+                        const how = Object.entries(v.params)
+                          .map(([k, val]) => `${k} = ${val}`)
+                          .join("\n");
+                        return (
+                          <li
+                            key={`${part.name}:${v.name}`}
+                            className={`part-var ${part.name === selectedPart && part.variant === v.name ? "selected" : ""}`}
+                            title={v.note ? `${v.note}\n\n${how}` : how}
+                            onClick={() => selectPart(part.name, v.name)}
+                          >
+                            <IconVariant />
+                            <span className="part-name">{v.name}</span>
+                          </li>
+                        );
+                      })}
                       {/* The selection expands to its counterparts: the assemblies
                           that place this part, or the parts this assembly places.
                           Only under the selection, because the relationship is what
@@ -1257,7 +1308,12 @@ function App() {
             title="nurb viewer"
             // The selection can move while the document is still loading and a
             // message posted into a loading frame is dropped; repeat it on load.
-            onLoad={postPart}
+            onLoad={() =>
+              setLoadedFrame((loaded) => ({
+                key: frame.key,
+                token: (loaded?.token ?? 0) + 1,
+              }))
+            }
           />
         ) : active && opening[active] ? (
           <div className="viewer-status">starting the CAD engine…</div>

--- a/desktop/src/Icons.tsx
+++ b/desktop/src/Icons.tsx
@@ -109,6 +109,22 @@ export function IconChevronDown({ size = 10 }: { size?: number }) {
   );
 }
 
+// The viewer's sliders glyph for a variant: the same part at other values.
+export function IconVariant({ size = 11 }: { size?: number }) {
+  return (
+    <svg className="row-icon" width={size} height={size} viewBox="0 0 12 12" aria-hidden="true">
+      <g {...strokeProps}>
+        <line x1="11.25" y1="8.75" x2="6.25" y2="8.75" />
+        <circle cx="4.25" cy="8.75" r="2" />
+        <line x1="2.25" y1="8.75" x2=".75" y2="8.75" />
+        <line x1=".75" y1="3.25" x2="5.75" y2="3.25" />
+        <circle cx="7.75" cy="3.25" r="2" />
+        <line x1="9.75" y1="3.25" x2="11.25" y2="3.25" />
+      </g>
+    </svg>
+  );
+}
+
 export function IconCube({ size = 12 }: { size?: number }) {
   return (
     <svg className="row-icon" width={size} height={size} viewBox="0 0 18 18" aria-hidden="true">

--- a/desktop/src/partMessages.ts
+++ b/desktop/src/partMessages.ts
@@ -1,0 +1,27 @@
+export type PartConfigurationRequest = {
+  path: string;
+  part: string;
+  variant: string | null;
+};
+
+type PartMessage = {
+  type: "nurb:part";
+  name: string;
+  variant?: string | null;
+};
+
+// Missing `variant` means "show this part as it is". A present null means the
+// user explicitly clicked its defaults row, so the viewer may reset a variant.
+export function partMessage(
+  path: string,
+  part: string,
+  request: PartConfigurationRequest | null,
+): { message: PartMessage; consumed: boolean } {
+  const consumed = request?.path === path && request.part === part;
+  return {
+    message: consumed
+      ? { type: "nurb:part", name: part, variant: request.variant }
+      : { type: "nurb:part", name: part },
+    consumed,
+  };
+}

--- a/desktop/tests/partMessages.test.ts
+++ b/desktop/tests/partMessages.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { partMessage } from "../src/partMessages.ts";
+
+test("passive part synchronization cannot change its configuration", () => {
+  const { message, consumed } = partMessage("/one", "shelf", null);
+
+  assert.deepEqual(message, { type: "nurb:part", name: "shelf" });
+  assert.equal(Object.hasOwn(message, "variant"), false);
+  assert.equal(consumed, false);
+});
+
+test("an explicit defaults or variant click is delivered once to its part", () => {
+  const defaults = partMessage("/one", "shelf", {
+    path: "/one",
+    part: "shelf",
+    variant: null,
+  });
+  const variant = partMessage("/one", "shelf", {
+    path: "/one",
+    part: "shelf",
+    variant: "tall",
+  });
+
+  assert.deepEqual(defaults, {
+    message: { type: "nurb:part", name: "shelf", variant: null },
+    consumed: true,
+  });
+  assert.deepEqual(variant, {
+    message: { type: "nurb:part", name: "shelf", variant: "tall" },
+    consumed: true,
+  });
+});
+
+test("a configuration click cannot leak into another project", () => {
+  const result = partMessage("/two", "shelf", {
+    path: "/one",
+    part: "shelf",
+    variant: "tall",
+  });
+
+  assert.deepEqual(result, {
+    message: { type: "nurb:part", name: "shelf" },
+    consumed: false,
+  });
+});

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -596,6 +596,7 @@ const q = new URLSearchParams(location.search);
 let want = q.get('part');
 const view = q.get('view'), bare = q.has('bare'), embed = q.has('embed');
 let wantVariant = q.get('variant');   // consumed by the first sync, then the URL just mirrors
+let wantConfiguration = wantVariant !== null;
 const VIEWS = {
   iso: [0.7, -0.75, 0.6], front: [0, -1, 0], back: [0, 1, 0],
   left: [-1, 0, 0], right: [1, 0, 0], top: [0, 0, 1],
@@ -624,13 +625,36 @@ if (embed) {
   window.addEventListener('message', e => {
     if (e.source !== window.parent || !e.data || e.data.type !== 'nurb:part') return;
     const name = String(e.data.name);
-    if (name === current) return;
-    want = null; wantVariant = null;
+    const hasConfiguration = Object.prototype.hasOwnProperty.call(e.data, 'variant');
+    const vname = hasConfiguration && e.data.variant !== null ? String(e.data.variant) : null;
+    want = null; wantVariant = null; wantConfiguration = false;
     const entry = parts.get(name);
-    if (!entry) { want = name; return; }   // still building; sync or rebuilt finishes the switch
+    if (!entry) {   // still building; sync or rebuilt finishes the switch
+      want = name; wantVariant = vname; wantConfiguration = hasConfiguration;
+      return;
+    }
+    const switching = name !== current;
+    // A missing variant is selection synchronization, never a command to change
+    // slider values. Only a rail click includes the field.
+    if (!hasConfiguration) {
+      if (!switching) return;
+      current = name;
+      render(); show(name, { keepCamera: false }); setURL();
+      return;
+    }
+    const v = vname && (entry.variants || []).find(x => x.name === vname) || null;
+    if (vname !== null && !v) return;
+    // The entry is the last completed build. Pending slider or variant work is
+    // newer, so an explicit click must supersede it even when the entry appears
+    // to already show the requested configuration.
+    const changing = inflight === name || (pending !== null && pendingFor === name);
+    const needsApply = changing || (v ? !variantActive(entry, v) : !!activeVariant(entry));
+    if (!switching && !needsApply) return;
     current = name;
-    if (activeVariant(entry)) applyVariant(name, { params: {} });
-    render(); show(name, { keepCamera: false }); setURL();
+    if (needsApply) applyVariant(name, v || { params: {} });
+    render();
+    if (switching) show(name, { keepCamera: false });
+    setURL(v && v.name);
   });
 }
 
@@ -2313,10 +2337,14 @@ function activeVariant(e) {
 // push per parameter; sync() moves the sliders when the rebuild lands.
 function applyVariant(name, v) {
   if (!sock || sock.readyState !== WebSocket.OPEN) return;
-  pending = null; pendingFor = null;   // a drag in flight must not resurrect old values
-  inflight = name;
-  beginStale();
-  sock.send(JSON.stringify({ type: 'params', name, values: { ...v.params } }));
+  // Join the sliders' one-flight queue. If an older build is away, `settled`
+  // sends these values after its response instead of mistaking that response
+  // for this newer request and letting the older configuration win.
+  clearTimeout(timer);
+  pending = { ...v.params };
+  pendingFor = name;
+  pendingCommitted = true;
+  flush();
 }
 
 // The address bar always holds the link to what is on screen, so any part or variant
@@ -2351,7 +2379,7 @@ function render() {
       + `<span class="ms">${e.error ? (e.refused ? '' : 'err') : e.ms + 'ms'}</span>`;
     row.onclick = () => {
       // A click supersedes a deep link whose part is still waiting to build.
-      want = null; wantVariant = null;
+      want = null; wantVariant = null; wantConfiguration = false;
       current = e.name;
       // The part row is the defaults configuration. With a variant active it is also
       // the only way back: a variant that flips a bool has no slider to drag home.
@@ -2368,7 +2396,7 @@ function render() {
       const how = Object.entries(v.params).map(([k, val]) => `${k} = ${val}`).join('\n');
       vr.title = v.note ? `${v.note}\n\n${how}` : how;
       vr.onclick = () => {
-        want = null; wantVariant = null;
+        want = null; wantVariant = null; wantConfiguration = false;
         if (current !== e.name) { current = e.name; show(e.name, { keepCamera: false }); }
         applyVariant(e.name, v);
         render();
@@ -2529,7 +2557,9 @@ function connect() {
       parts.clear();
       msg.parts.forEach(p => parts.set(p.name, p));
       sharedRuns = msg.shared || [];
-      if (want && !msg.sources.includes(want)) { want = null; wantVariant = null; }
+      if (want && !msg.sources.includes(want)) {
+        want = null; wantVariant = null; wantConfiguration = false;
+      }
       // A fallback render may have filled `current` while the socket was down.
       // The still-pending deep link outranks that temporary choice.
       if (want && parts.has(want)) current = want;
@@ -2537,11 +2567,15 @@ function connect() {
       // ?variant= is an ask, so it loads that variant's overrides once. Once, because
       // a reconnect sync must not snap back what the user has since dragged away.
       let linked = null;
-      if (wantVariant && current === want) {
-        linked = (parts.get(current).variants || []).find(v => v.name === wantVariant);
+      if (wantConfiguration && current === want) {
+        linked = wantVariant && (parts.get(current).variants || []).find(v => v.name === wantVariant);
         if (linked) applyVariant(current, linked);
+        else if (wantVariant === null && activeVariant(parts.get(current)))
+          applyVariant(current, { params: {} });
       }
-      if (current === want) { want = null; wantVariant = null; }
+      if (current === want) {
+        want = null; wantVariant = null; wantConfiguration = false;
+      }
       render();
       if (current) show(current, { keepCamera: false });
       setURL(linked && linked.name);
@@ -2551,9 +2585,12 @@ function connect() {
       let linked = null;
       if (msg.name === want) {
         current = want;
-        linked = wantVariant && (msg.variants || []).find(v => v.name === wantVariant);
+        linked = wantConfiguration && wantVariant
+          && (msg.variants || []).find(v => v.name === wantVariant);
         if (linked) applyVariant(current, linked);
-        want = null; wantVariant = null;
+        else if (wantConfiguration && wantVariant === null && activeVariant(msg))
+          applyVariant(current, { params: {} });
+        want = null; wantVariant = null; wantConfiguration = false;
       }
       // The first part in an empty project arrives here, not in a sync, so without
       // this `nurb new` in a running `nurb dev` fills the list and leaves the canvas
@@ -2571,7 +2608,9 @@ function connect() {
     // sliders that rebuild a file that is not there.
     if (msg.type === 'gone') {
       parts.delete(msg.name);
-      if (want === msg.name) { want = null; wantVariant = null; }
+      if (want === msg.name) {
+        want = null; wantVariant = null; wantConfiguration = false;
+      }
       if (current === msg.name) {
         current = parts.size ? parts.keys().next().value : null;
         if (current) show(current, { keepCamera: false });

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -594,6 +594,20 @@ def test_viewer_keeps_a_deep_link_pending_until_that_part_builds():
     assert "vr.onclick = () => {\n        want = null; wantVariant = null;" in viewer
 
 
+def test_embed_part_messages_separate_selection_from_configuration():
+    """Frame-load synchronization must not reset a variant, while the latest
+    explicit rail click must beat slider or variant work still rebuilding."""
+    from nurb import server as server_mod
+
+    viewer = server_mod.VIEWER.read_text(encoding="utf-8")
+    assert "hasOwnProperty.call(e.data, 'variant')" in viewer
+    assert "if (!hasConfiguration)" in viewer
+    assert "inflight === name || (pending !== null && pendingFor === name)" in viewer
+    assert "const needsApply = changing ||" in viewer
+    assert "pending = { ...v.params };\n  pendingFor = name;" in viewer
+    assert "pendingCommitted = true;\n  flush();" in viewer
+
+
 def test_viewer_frames_the_first_geometry_a_page_paints():
     """A deep link's build lands as a `rebuilt`, which keeps the camera. On the
     page's first paint there is no camera to keep, and keeping the one at the


### PR DESCRIPTION
Fixes #141. A part with card variants showed only one row in the macOS app's part list, because the app drew its own rail from `/api/parts` and never read the `variants` array. The browser viewer had them all along.

`part_views` now carries each part's variants and the server-resolved active variant, and the rail nests a row per variant under its part wearing the viewer's sliders glyph, with the active mark following the resolved variant so it tracks slider drags and agent edits rather than the last click. A new `partMessages` module separates a passive frame-load synchronization, which must never reset a variant, from an explicit rail click, which supersedes slider or variant work still rebuilding; the embedded viewer's message handler learns the same distinction. Covered by the new Rust `part_views` case, the `partMessages` node tests, and a `test_server` viewer assertion.