### PR TITLE
Release 0.20.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.19.2"
+version = "0.20.0"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.19.2"
+version = "0.20.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,15 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.20.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.20.0">v0.20.0</a></span><time datetime="2026-08-15">August 15, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Intel Macs.</b> The Mac app now comes in two downloads, one for Apple silicon and one for Intel. The download page names which is which, so an older Mac gets a build that runs.</span></li>
+      <li><b class="tag">fixed</b><span>A part with variants shows every one of them in the Mac app's part list, each with its own row under the part. The active one is marked, and the mark follows a slider drag or an edit by your AI, not just the last row you clicked.</span></li>
+      <li><b class="tag">fixed</b><span>Setting up an AI in the app no longer half installs. A missing piece used to look like a sign-in problem; now it fails clearly and installs again.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.19.2">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.19.2">v0.19.2</a></span><time datetime="2026-08-14">August 14, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.19.2"
+  version: "0.20.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.19.2"
+  version: "0.20.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.19.2"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Cuts 0.20.0 across the engine and the desktop app: bumps `pyproject.toml`, both skill files, and `tauri.conf.json`, relocks `evals/uv.lock` against the new version, and adds the changelog entry.

## What ships

- **Intel Macs** (#134). The Mac app now builds, notarizes, and publishes an Intel artifact alongside Apple silicon, with its own updater entry and stable DMG URL. The README and landing page name which download is which.
- **Variants in the Mac app's part list** (#142). A part with card variants shows a row per variant nested under it, and the active mark follows the server-resolved variant, so it tracks slider drags and agent edits rather than the last click.
- **Provisioning fails honestly** (#136). Agent provisioning forces npm optional dependencies and executes both native CLIs before stamping healthy, so a half-installed adapter retries instead of surfacing a misleading sign-in error.
- Benchmark trials now run against a locked, non-editable install in their own temp environment, so the answer key stays hidden without touching checkout permissions (#139), and evals gained a Grok Build harness (#137). Neither is user-visible, so neither takes a changelog line.

`uv run pytest tests/test_cli.py -q` passes (53), which is what enforces the four version strings agreeing.