### PR TITLE
Welcome new users with a create-project empty state

### DIFF
--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -1311,6 +1311,53 @@ textarea {
   font-size: 12px;
 }
 
+.welcome {
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  max-width: 34ch;
+  padding: 0 16px;
+  text-align: center;
+}
+
+.welcome-title {
+  font-size: 14px;
+  color: var(--text);
+}
+
+.welcome-copy {
+  margin: 0;
+  font-size: 12px;
+  color: var(--dim);
+}
+
+.welcome-form {
+  width: 100%;
+  margin: 4px 0 0;
+}
+
+.welcome-create {
+  font-size: 12px;
+  padding: 5px 10px;
+  border: 1px solid rgba(110, 231, 168, 0.45);
+  color: var(--accent);
+}
+
+.welcome-existing {
+  font: inherit;
+  font-size: 11px;
+  color: var(--dimmer);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.welcome-existing:hover {
+  color: var(--dim);
+}
+
 .viewer {
   min-width: 0;
   display: flex;

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -18,6 +18,7 @@ import {
 } from "./chatColumns";
 import { IconCheck, IconCube, IconCubes, IconFolder, IconFolderPlus, IconVariant } from "./Icons";
 import { COLUMNS, fitColumns, initialColumns, resizedColumn } from "./layout";
+import Logo from "./Logo";
 import type { Column } from "./layout";
 import { partMessage, type PartConfigurationRequest } from "./partMessages";
 import Setup from "./Setup";
@@ -129,6 +130,7 @@ const viewportWidth = () => document.documentElement.clientWidth;
 
 function App() {
   const [projects, setProjects] = useState<Project[]>([]);
+  const [projectsLoaded, setProjectsLoaded] = useState(false);
   const [servers, setServers] = useState<Record<string, Server>>({});
   const [opening, setOpening] = useState<Record<string, boolean>>({});
   const [active, setActive] = useState<string | null>(null);
@@ -396,6 +398,7 @@ function App() {
   const refreshProjects = useCallback(async () => {
     const list = await invoke<Project[]>("list_projects");
     setProjects(list);
+    setProjectsLoaded(true);
     return list;
   }, []);
 
@@ -1295,7 +1298,37 @@ function App() {
       {!columns.some(columnVisible) && (
         <section className="chat">
           <div className="chat-header" data-tauri-drag-region />
-          <div className="placeholder">chat</div>
+          {projectsLoaded && projects.length === 0 ? (
+            // The zero-project welcome: the one moment the app has to explain
+            // itself, so the create form lives here, not behind the rail's +.
+            <div className="welcome">
+              <Logo size={36} />
+              <div className="welcome-title">Design your first part</div>
+              <p className="welcome-copy">
+                A project holds the parts you design. Name it, then describe
+                what you want to make.
+              </p>
+              <form className="name-form welcome-form" onSubmit={createProject}>
+                <input
+                  className="name-input"
+                  name="name"
+                  placeholder="project name"
+                  autoCapitalize="off"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  disabled={creating}
+                />
+                <button className="rail-button welcome-create" type="submit" disabled={creating}>
+                  {creating ? "creating…" : "create"}
+                </button>
+              </form>
+              <button className="welcome-existing" onClick={addExisting}>
+                or add an existing folder…
+              </button>
+            </div>
+          ) : (
+            <div className="placeholder">chat</div>
+          )}
         </section>
       )}
       <main className="viewer">
@@ -1318,7 +1351,11 @@ function App() {
         ) : active && opening[active] ? (
           <div className="viewer-status">starting the CAD engine…</div>
         ) : (
-          <div className="viewer-status">open a project to start</div>
+          <div className="viewer-status">
+            {projectsLoaded && projects.length === 0
+              ? "create a project to start"
+              : "open a project to start"}
+          </div>
         )}
       </main>
       <div


### PR DESCRIPTION
A first launch showed an empty rail, a pane that said "chat", and a dim "open a project to start" with nothing to click, so a new user's first instinct was to click the agents' signed-in labels. When no projects exist, the chat pane now shows a welcome: the logo, one sentence explaining what a project is, the create form itself, and a quiet add-existing link, all wired to the existing create and add paths. The viewer text points at creation ("create a project to start") until a project exists. The welcome is gated on the registry having loaded so it never flashes, and it disappears the moment a project exists with no popup or persisted flag. Verified end to end in the debug app against a scratch data dir: the welcome renders, creating from it seeds the first part, and the full shell comes alive.