### PR TITLE
Pin the skill installer to the shipped nurb skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl -fsSL https://nurb.dev/bench.sh | sh
 Install the nurb skill once and your agent reaches for nurb on its own whenever you ask for a printable part. The installer above already did this; by hand, [skills.sh](https://www.skills.sh/) detects whatever harnesses you have and installs into each:
 
 ```bash
-npx skills add shpigford/nurb
+npx skills add shpigford/nurb --skill nurb
 ```
 
 Or `nurb skill` prints the same skill file out for you. Later, `nurb update` upgrades nurb and rewrites the installed skill to match, so the two move together.

--- a/site/install.sh
+++ b/site/install.sh
@@ -46,8 +46,10 @@ main() {
 
   say "[3/3] teaching your AI to use nurb..."
   if command -v npx >/dev/null 2>&1; then
-    # skills.sh detects every AI harness on the machine and installs into each
-    npx -y skills add shpigford/nurb -g -y </dev/null || install_skill_directly || fail "could not install the nurb skill; run manually: npx skills add shpigford/nurb"
+    # skills.sh detects every AI harness on the machine and installs into each.
+    # --skill nurb keeps it to the shipped skill; the repo also carries dev-only
+    # skills (release, changelog) that must not land on a user's machine.
+    npx -y skills add shpigford/nurb --skill nurb -g -y </dev/null || install_skill_directly || fail "could not install the nurb skill; run manually: npx skills add shpigford/nurb --skill nurb"
   else
     install_skill_directly || fail "could not install the nurb skill; see https://nurb.dev"
   fi

--- a/src/nurb/cli.py
+++ b/src/nurb/cli.py
@@ -780,7 +780,7 @@ def cmd_skill(args):
             state = "updated"
         print(f"  ~/{target.relative_to(home)}: {state}")
     if not found:
-        print("  no installed skill found. install one: npx skills add shpigford/nurb")
+        print("  no installed skill found. install one: npx skills add shpigford/nurb --skill nurb")
 
 
 def cmd_update(args):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -783,7 +783,7 @@ def test_skill_sync_leaves_a_current_copy_alone(tmp_path, monkeypatch, capsys):
 def test_skill_sync_with_nothing_installed_points_at_the_installer(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HOME", str(tmp_path))
     cli.main(["skill", "--sync"])
-    assert "npx skills add shpigford/nurb" in capsys.readouterr().out
+    assert "npx skills add shpigford/nurb --skill nurb" in capsys.readouterr().out
 
 
 # --- diff --------------------------------------------------------------------


### PR DESCRIPTION
The curl installer's skill step ran `npx skills add shpigford/nurb`, and skills.sh scans the whole cloned repo for SKILL.md files, so it also installed the dev-only skills in `.claude/skills/` (release, changelog, leaderboard) globally on users' machines. Reported by a new user on X.

This pins every published invocation with `--skill nurb`: the installer itself (plus its manual-fallback message), the README's by-hand command, and the `nurb skill --sync` hint, with the test assertion tightened to the full pinned command. Verified against the live repo: the pinned command reports "Installed 1 skill", only nurb.

Note: the fix takes effect for users once `site/install.sh` deploys to nurb.dev.