### PR TITLE
Release 0.21.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.20.0"
+version = "0.21.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,15 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.21.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.21.0">v0.21.0</a></span><time datetime="2026-08-18">August 18, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>A first run that starts you off.</b> Opening the app with no projects yet now shows what a project is and a form to make one, instead of an empty window with nothing to click. There is a link to add a folder you already have.</span></li>
+      <li><b class="tag">improved</b><span>Parts are easier to read. Edges are drawn on the shape now, so faces stop blending into one grey blob and you can see where a chamfer or a step actually is.</span></li>
+      <li><b class="tag">fixed</b><span>Installing nurb added nurb's own internal commands to your AI along with the real skill. The installer now takes only the nurb skill.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.20.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.20.0">v0.20.0</a></span><time datetime="2026-08-15">August 15, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.20.0"
+  version: "0.21.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.20.0"
+  version: "0.21.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Cuts 0.21.0 across the engine and the desktop app: bumps `pyproject.toml`, both skill files, and `tauri.conf.json`, relocks `evals/uv.lock` against the new version, and adds the changelog entry.

## What ships

- **A first run that starts you off** (#144). Opening the app with no projects showed an empty rail and a pane with nothing to click. It now shows the logo, one sentence on what a project is, the create form itself, and a quiet link to add a folder you already have. The welcome waits for the registry to load so it never flashes, and it goes away the moment a project exists.
- **Edges on part geometry** (#146). The viewer draws a faint dark outline at every crease past 25 degrees, so faces stop melting together under the flat grey material. The surface is polygon-offset to avoid z-fighting, and the outlines fade, clear, and dispose along with the geometry they belong to.
- **The installer takes only the nurb skill** (#145). `npx skills add shpigford/nurb` scanned the whole repo and installed the dev-only skills (release, changelog, leaderboard) onto users' machines. Every published invocation now pins `--skill nurb`: the installer, its manual fallback, the README command, and the `nurb skill --sync` hint.

## Verification

- `uv run pytest tests/test_cli.py -q` passes, which is where the four version strings are checked against each other.
- The changelog entry rendered and screenshotted against the live page; it matches its neighbors and the versions still descend.