### PR TITLE
Update a variant from the viewer's sliders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,14 @@ Nearly always that surface belongs in `src/nurb/viewer.html`, not in `desktop/sr
 
 Two things a surface owes the user that a command does not. It must not dead-end: when a feature needs something the project has not chosen yet, offer the choice in place rather than printing what the user should have configured. And a result that outlived its geometry is worse than no result, so anything cached from a build clears when that part rebuilds.
 
+### No change is done until the desktop is accounted for
+
+The recurring failure mode in this repo: a change lands in the Python engine or the viewer, works in a browser, and ships with the desktop app never considered. That is backwards. The desktop app is the primary UI, so every change ends with an explicit desktop pass: what does `desktop/src` need for this, and if the honest answer is nothing, say that in the summary rather than leaving it unexamined.
+
+The shell duplicates viewer state on purpose, and that duplication is where changes go silently missing. Its rail draws its own part and variant rows from `list_parts` polling, not from the viewer's sidebar; selection flows through `nurb:part` postMessages; viewer state the shell must react to travels over `nurb:*` messages (`nurb:saved`, `nurb:shared`, `nurb:variant`). So check each seam: new server fields the rail should reflect need `list_parts` plumbing, new viewer state the rail mirrors needs a message, and anything that lives in the sidebar or footer is invisible in the app, because `?embed` hides both. Labels too: embed mode speaks to hobbyists, so a button that names a `.py` or `.md` file in the browser needs an embed variant that does not.
+
+The check is cheap: grep `desktop/src` for the concept you touched, and run `./node_modules/.bin/tsc --noEmit` plus `npm test` in `desktop/` whenever it changed.
+
 ### Command names stay boring
 
 The CLI's user is a language model, while the app's user is a person; both surfaces are real and neither substitutes for the other. An agent that has never seen this tool can guess `build`, `check`, `export`. It cannot guess a themed alias. Every clever name is an indirection that degrades in a fresh context. The brand can be distinctive; the interface cannot.

--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -374,6 +374,14 @@ textarea {
   border-left-color: var(--accent);
 }
 
+/* Drifted off a variant: still where the work is, so the row stays lit, and the
+   accent name says these are its values plus some drag. */
+.part-var.modified {
+  color: var(--accent);
+  background: var(--active);
+  border-left-color: var(--accent);
+}
+
 .part-add {
   display: flex;
   align-items: center;

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -140,6 +140,9 @@ function App() {
   // the selected part itself did not change.
   const variantRequest = useRef<PartConfigurationRequest | null>(null);
   const [variantRequestVersion, setVariantRequestVersion] = useState(0);
+  // The viewer's report of which variant the sliders started from, and whether they
+  // have drifted off it. It is what keeps a drifted variant's rail row pinned.
+  const [variantOrigin, setVariantOrigin] = useState<{ part: string; variant: string; drifted: boolean } | null>(null);
   const [naming, setNaming] = useState(false);
   const [creating, setCreating] = useState(false);
   const [partNaming, setPartNaming] = useState(false);
@@ -352,6 +355,14 @@ function App() {
       if (event.data === "nurb:drag") getCurrentWindow().startDragging().catch(() => {});
       if (event.data?.type === "nurb:saved" && typeof event.data.path === "string")
         revealItemInDir(event.data.path).catch(() => {});
+      // The viewer's variant pin: the sliders started from a variant and may have
+      // left it, and the rail draws its own variant rows, so it needs to know.
+      if (event.data?.type === "nurb:variant")
+        setVariantOrigin(
+          typeof event.data.part === "string" && typeof event.data.variant === "string"
+            ? { part: event.data.part, variant: event.data.variant, drifted: !!event.data.drifted }
+            : null,
+        );
       // The viewer's "unify in chat" nudge: parts repeating the same construction
       // are a project-wide matter, so it lands in the project conversation.
       if (
@@ -505,6 +516,7 @@ function App() {
   // an agent without session listing), just mean fresh chats.
   useEffect(() => {
     setResumeState(null);
+    setVariantOrigin(null);   // the pin belongs to the viewer this project just left
     // Leaving a project keeps busy columns and hidden results. Ordinary idle
     // columns go now; an unseen one goes after its exact chat has been shown.
     setColumns((list) => retainChatColumns(list, active, busyRef.current));
@@ -1033,10 +1045,18 @@ function App() {
                         const how = Object.entries(v.params)
                           .map(([k, val]) => `${k} = ${val}`)
                           .join("\n");
+                        // Drifted off this variant: no longer resolved by the server,
+                        // but still where the work is, so the row stays pinned.
+                        const modified =
+                          part.name === selectedPart &&
+                          part.variant !== v.name &&
+                          variantOrigin?.drifted === true &&
+                          variantOrigin.part === part.name &&
+                          variantOrigin.variant === v.name;
                         return (
                           <li
                             key={`${part.name}:${v.name}`}
-                            className={`part-var ${part.name === selectedPart && part.variant === v.name ? "selected" : ""}`}
+                            className={`part-var ${part.name === selectedPart && part.variant === v.name ? "selected" : ""} ${modified ? "modified" : ""}`}
                             title={v.note ? `${v.note}\n\n${how}` : how}
                             onClick={() => selectPart(part.name, v.name)}
                           >

--- a/src/nurb/edit.py
+++ b/src/nurb/edit.py
@@ -4,12 +4,15 @@ The keyword defaults are the parameters, so an exploration that ends up in the f
 to end up in the signature. This is the only module that writes to a part file, and it
 rewrites exactly the default it was asked to and nothing else: the source is edited as
 text at the offsets the parser reports, so comments, formatting and every other line
-survive untouched.
+survive untouched. The same care extends to the card: a variant lives in its
+`[variants.<name>.params]` block, and updating one replaces that block alone.
 """
 
 import ast
+import json
 import os
 import pathlib
+import tomllib
 
 
 class EditError(Exception):
@@ -121,3 +124,125 @@ def apply(path, values):
     tmp.write_text(out, encoding="utf-8")
     os.replace(tmp, path)
     return sorted(name for name, _, _ in edits), skipped
+
+
+def _header(line):
+    """The key path a TOML section header line declares, or None."""
+    s = line.strip()
+    if not s.startswith("["):
+        return None
+
+    # Let TOML itself split dotted and quoted keys. Appending a marker makes the
+    # otherwise-empty table discoverable without reimplementing TOML's key grammar.
+    marker = "__nurb_header_marker__"
+    try:
+        parsed = tomllib.loads(f"{s}\n{marker} = true")
+    except tomllib.TOMLDecodeError:
+        return None
+
+    def marked_path(value, path=()):
+        if isinstance(value, dict):
+            if value.get(marker) is True:
+                return path
+            for key, child in value.items():
+                found = marked_path(child, path + (key,))
+                if found is not None:
+                    return found
+        elif isinstance(value, list):
+            for child in value:
+                found = marked_path(child, path)
+                if found is not None:
+                    return found
+        return None
+
+    return marked_path(parsed)
+
+
+def _toml_key(value):
+    """One TOML key, bare when possible and quoted otherwise."""
+    bare = value and all(c.isascii() and (c.isalnum() or c in "_-") for c in value)
+    return value if bare else json.dumps(value, ensure_ascii=False)
+
+
+def apply_variant(path, variant, values):
+    """Write `values` into one variant's params block in the part's card.
+
+    A variant is its overrides, so the whole `[variants.<name>.params]` section is
+    replaced with what is on screen: a value dragged back to the part's default is no
+    longer an override and drops out. Everything else in the card survives untouched.
+    Returns the sorted parameter names written.
+    """
+    from .checks import CARD_SETTINGS
+
+    path = pathlib.Path(path)
+    card = path.with_suffix(".md")
+    if not card.is_file():
+        raise EditError(f"{path.stem} has no card to hold the variant")
+
+    src = path.read_text(encoding="utf-8")
+    defaults = _defaults(_part_function(ast.parse(src, filename=str(path)), path))
+
+    def formatted(name, new):
+        if isinstance(new, bool):
+            return "true" if new else "false"
+        if isinstance(new, str):
+            # JSON and TOML share the escapes used here, but JSON's default surrogate
+            # pairs are not valid TOML Unicode escapes. Write scalar values directly.
+            return json.dumps(new, ensure_ascii=False)
+        node = defaults.get(name)
+        if node is None:
+            raise EditError(f"{path.name} has no parameter named {name}")
+        # The default says whether this dimension is an int or a float, exactly as
+        # `apply` keeps for the signature itself. A default written as an expression
+        # says nothing, so the value's own type decides.
+        old = _number(node)
+        return _format(old if old is not None else new, new)
+
+    text = card.read_text(encoding="utf-8")
+    opening = f"```{CARD_SETTINGS}"
+    if opening not in text:
+        raise EditError(f"{card.name} has no settings block declaring variants")
+    head, _, rest = text.partition(opening)
+    block, closing, tail = rest.partition("```")
+    if not closing:
+        raise EditError(f"{card.name}: the settings block never closes")
+
+    lines = block.split("\n")
+    target = ("variants", variant, "params")
+    target_text = f"variants.{_toml_key(variant)}.params"
+    body = [f"{k} = {formatted(k, v)}" for k, v in sorted(values.items())]
+    start = next((i for i, l in enumerate(lines) if _header(l) == target), None)
+    if start is None:
+        # The variant exists in some other form, [variants.<name>] alone or a dotted
+        # sibling like [variants.<name>.accepted]; a fresh params section goes in
+        # front of the first of them. A name the card never mentions is not a variant.
+        anchor = next(
+            (i for i, l in enumerate(lines)
+             if (h := _header(l)) and len(h) >= 2 and h[:2] == ("variants", variant)),
+            None,
+        )
+        if anchor is None:
+            raise EditError(f"{card.name} has no variant named {variant}")
+        lines[anchor:anchor] = [f"[{target_text}]", *body, ""]
+    else:
+        end = next((j for j in range(start + 1, len(lines)) if _header(lines[j])), len(lines))
+        # Blank lines before the next header are the gap between sections, not ours.
+        while end - 1 > start and not lines[end - 1].strip():
+            end -= 1
+        lines[start + 1 : end] = body
+    new_block = "\n".join(lines)
+
+    # This rewrites someone's card, so it checks its own work before saving: the block
+    # still parses, and the variant reads back as exactly the values it was given.
+    try:
+        parsed = tomllib.loads(new_block)
+    except tomllib.TOMLDecodeError as exc:
+        raise EditError(f"updating {variant} in {card.name} did not come out right ({exc})") from exc
+    if parsed.get("variants", {}).get(variant, {}).get("params") != values:
+        raise EditError(f"updating {variant} in {card.name} did not come out right")
+
+    # Atomic for the same reason `apply` is: the watcher rebuilds on this write.
+    tmp = card.with_name(f"_{card.name}.tmp")
+    tmp.write_text(head + opening + new_block + "```" + tail, encoding="utf-8")
+    os.replace(tmp, card)
+    return sorted(values)

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -1153,6 +1153,26 @@ class Server:
                 }
             )
 
+        elif msg.get("type") == "apply_variant":
+            from . import edit
+
+            variant = msg.get("variant")
+            if not isinstance(variant, str):
+                return
+            held = {k: v for k, v in (self.overrides.get(name) or {}).items() if v is not None}
+            try:
+                written = edit.apply_variant(path, variant, held)
+            except Exception as exc:
+                await self.send({"type": "applied", "name": name, "variant": variant, "error": str(exc)})
+                return
+            # The overrides stay: they are what differs from the file's defaults, which
+            # is exactly what the variant now says. The watcher sees the card write and
+            # rebuilds, and that build is the one that re-matches the variant.
+            print(f"  {name}: updated variant {variant} ({', '.join(written) or 'no overrides'})", flush=True)
+            await self.send(
+                {"type": "applied", "name": name, "variant": variant, "written": written, "skipped": []}
+            )
+
     async def upgrade(self):
         """Run the install's own upgrade, then exec ourselves so the new code serves.
 

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -64,6 +64,10 @@
   /* The sliders glyph says what a variant is: the same part at other values. */
   .item.var .vic { width: 10px; height: 10px; flex: none; color: var(--dim); }
   .item.var.active .vic { color: var(--accent); }
+  /* Drifted off a variant: still where the work is, so the row stays lit, and the
+     accent on the name says these are its values plus some drag. */
+  .item.var.mod { background: #2c313b; }
+  .item.var.mod .name, .item.var.mod .vic { color: var(--accent); }
   .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); flex: none; }
   .dot.bad { background: var(--bad); }
   /* Amber for a refusal: the part declined these values on purpose, nothing broke. */
@@ -422,6 +426,8 @@
   }
   #write { display: none; width: 100%; margin-top: 10px; text-align: left; line-height: 1.4; }
   body.dirty #write { display: block; }
+  #writevar { display: none; width: 100%; margin-top: 10px; text-align: left; line-height: 1.4; }
+  #writevar.on { display: block; }
   #note { font-size: 11px; color: var(--dim); margin-top: 8px; white-space: pre-wrap; }
   #note.bad { color: var(--bad); }
   /* ?bare hides the chrome so a render is geometry on the plate and nothing else.
@@ -648,10 +654,12 @@ if (embed) {
     // newer, so an explicit click must supersede it even when the entry appears
     // to already show the requested configuration.
     const changing = inflight === name || (pending !== null && pendingFor === name);
-    const needsApply = changing || (v ? !variantActive(entry, v) : !!activeVariant(entry));
+    const needsApply = changing || (v ? !variantActive(entry, v)
+      : !!activeVariant(entry) || !!(origin && origin.part === name));
     if (!switching && !needsApply) return;
     current = name;
     if (needsApply) applyVariant(name, v || { params: {} });
+    else origin = v ? { part: name, variant: v.name } : null;
     render();
     if (switching) show(name, { keepCamera: false });
     setURL(v && v.name);
@@ -2047,12 +2055,30 @@ let panelSig = null;
 // throw away the note saying what was written. Held here so it survives that, which
 // matters most when the answer was "left side_clearance alone, and here is why".
 let lastNote = null;
+// The variant the sliders started from, as {part, variant}. The server only names a
+// variant while the values match it exactly, so once a slider moves this is the only
+// record of where the drag began, and it is what the update button writes back to.
+let origin = null;
+let postedDrift = null;   // the last nurb:variant message, so the shell hears changes once
 
 function adjustable(p) { return p.kind === 'int' || p.kind === 'float'; }
 
 function dirty() {
   const out = {};
   for (const [k, v] of values) if (v !== defaults.get(k)) out[k] = v;
+  return out;
+}
+
+// Bool and string parameters have no controls, but they can still be part of the
+// variant being adjusted. Keep those origin overrides in every slider payload: the
+// server treats a params message as the whole configuration, so omission resets them.
+function held() {
+  const out = dirty();
+  const v = origin && origin.part === current
+    && ((parts.get(current) || {}).variants || []).find(x => x.name === origin.variant);
+  if (v) for (const [name, value] of Object.entries(v.params)) {
+    if (!values.has(name)) out[name] = value;
+  }
   return out;
 }
 
@@ -2069,6 +2095,30 @@ function markDirty() {
     write.textContent = document.body.classList.contains('embed')
       ? 'save changes'
       : `write ${changed.length} default${changed.length === 1 ? '' : 's'} to ${current}.py`;
+  }
+  // The update offer appears once the values have left the origin variant, and not
+  // while a rebuild is away: applying a variant moves the sliders only when its build
+  // lands, and the offer must not flash during that gap.
+  const v = origin && origin.part === current
+    && ((parts.get(current) || {}).variants || []).find(x => x.name === origin.variant);
+  const drifted = !!v && pending === null && inflight === null
+    && [...values].some(([k, val]) => val !== (k in v.params ? v.params[k] : defaults.get(k)));
+  const update = document.getElementById('writevar');
+  if (update) {
+    update.classList.toggle('on', drifted);
+    if (drifted) update.textContent = document.body.classList.contains('embed')
+      ? `update ${origin.variant}`
+      : `update ${origin.variant} in ${current}.md`;
+  }
+  // The app's rail draws its own variant rows, so it needs the same pin the sidebar
+  // gets: which variant the sliders started from, and whether they have left it.
+  if (embed) {
+    const state = JSON.stringify({
+      type: 'nurb:variant', part: current,
+      variant: origin && origin.part === current ? origin.variant : null,
+      drifted,
+    });
+    if (state !== postedDrift) { postedDrift = state; window.parent.postMessage(JSON.parse(state), '*'); }
   }
 }
 
@@ -2230,6 +2280,14 @@ function params(e) {
     (fold && p.family ? fold : box).appendChild(row);
   }
   if (fold) box.appendChild(fold);
+  // Drifted off a variant, the values have two homes, so there are two write-backs:
+  // this one updates the variant in the card, the one below rewrites the defaults.
+  const writeVar = document.createElement('button');
+  writeVar.id = 'writevar';
+  writeVar.title = "replaces the variant's values in the card";
+  writeVar.onclick = () => origin && sock
+    && sock.send(JSON.stringify({ type: 'apply_variant', name: current, variant: origin.variant }));
+  box.appendChild(writeVar);
   const write = document.createElement('button');
   write.id = 'write';
   write.title = 'replaces the keyword defaults in the part file';
@@ -2246,6 +2304,7 @@ function params(e) {
   // the values back off the entry, which still holds the overrides being discarded, and
   // put every slider straight back where it was.
   document.getElementById('resetall').onclick = () => {
+    origin = null;   // reset means the defaults, not a variant to keep updating
     for (const [name, set] of setters) set(defaults.get(name), false);
     push(true);
   };
@@ -2313,7 +2372,7 @@ function push(commit) {
   lastNote = null;                      // moving a slider answers the last write
   const note = document.getElementById('note');
   if (note) note.textContent = '';
-  pending = dirty();
+  pending = held();
   pendingFor = current;
   pendingCommitted = commit;
   clearTimeout(timer);
@@ -2366,6 +2425,7 @@ function activeVariant(e) {
 // push per parameter; sync() moves the sliders when the rebuild lands.
 function applyVariant(name, v) {
   if (!sock || sock.readyState !== WebSocket.OPEN) return;
+  origin = v.name ? { part: name, variant: v.name } : null;
   // Join the sliders' one-flight queue. If an older build is away, `settled`
   // sends these values after its response instead of mistaking that response
   // for this newer request and letting the older configuration win.
@@ -2410,15 +2470,21 @@ function render() {
       // A click supersedes a deep link whose part is still waiting to build.
       want = null; wantVariant = null; wantConfiguration = false;
       current = e.name;
-      // The part row is the defaults configuration. With a variant active it is also
-      // the only way back: a variant that flips a bool has no slider to drag home.
-      if (activeVariant(e)) applyVariant(e.name, { params: {} });
+      // The part row is the defaults configuration. With a variant active, or drifted
+      // off one, it is also the only way back: a variant that flips a bool has no
+      // slider to drag home.
+      if (activeVariant(e) || (origin && origin.part === e.name)) applyVariant(e.name, { params: {} });
       render(); show(e.name, { keepCamera: false }); setURL();
     };
     list.appendChild(row);
     for (const v of e.variants || []) {
       const vr = document.createElement('div');
-      vr.className = 'item var' + (e.name === current && variantActive(e, v) ? ' active' : '');
+      // Drifted off a variant: no longer active, but still where the work is, so the
+      // row stays pinned and its accent says these are its values plus some drag.
+      const mod = e.name === current && !variantActive(e, v)
+        && origin && origin.part === e.name && origin.variant === v.name;
+      vr.className = 'item var' + (e.name === current && variantActive(e, v) ? ' active' : '')
+        + (mod ? ' mod' : '');
       vr.innerHTML = `<svg class="vic"><title>variant</title><use href="#i-variant"/></svg>`
         + `<span class="name">${v.name}</span>`;
       // The note is the why, the params are the how; a hover gets both, why first.
@@ -2611,6 +2677,11 @@ function connect() {
     }
     if (msg.type === 'rebuilt') {
       parts.set(msg.name, msg);
+      // The build is the authority on which variant the values are: landing on one
+      // adopts it as the origin, and a variant deleted from the card stops pinning.
+      if (msg.name === current && !msg.error && msg.variant) origin = { part: msg.name, variant: msg.variant };
+      else if (origin && origin.part === msg.name
+               && !(msg.variants || []).some(v => v.name === origin.variant)) origin = null;
       let linked = null;
       if (msg.name === want) {
         current = want;
@@ -2691,8 +2762,10 @@ function connect() {
         bad: !!msg.error,
         text: msg.error
           ? msg.error
-          : [`wrote ${msg.written.join(', ') || 'nothing'}`,
-             ...(msg.skipped || []).map(s => `left ${s.name} alone: ${s.why}`)].join('\n'),
+          : msg.variant
+            ? `updated ${msg.variant} (${msg.written.join(', ') || 'no overrides left'})`
+            : [`wrote ${msg.written.join(', ') || 'nothing'}`,
+               ...(msg.skipped || []).map(s => `left ${s.name} alone: ${s.why}`)].join('\n'),
       };
       const note = document.getElementById('note');
       if (note) { note.classList.toggle('bad', lastNote.bad); note.textContent = lastNote.text; }

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -129,6 +129,111 @@ def test_the_temp_file_does_not_survive(part_file):
     assert [p.name for p in part_file.parent.iterdir()] == ["thing.py"]
 
 
+CARD = '''# thing
+
+Ported by hand.
+
+```toml
+[part]
+min_wall = 0.7
+
+# Why the wide one exists.
+[variants.wide.params]
+count = 6
+chamfer = 2.0
+
+[variants.wide.accepted]
+sliver = 4
+
+[variants.bare.accepted]
+sliver = 2
+```
+
+## Notes
+
+More prose after the block.
+'''
+
+
+@pytest.fixture
+def carded(part_file):
+    (part_file.parent / "thing.md").write_text(CARD)
+    return part_file
+
+
+def read_variants(card):
+    import tomllib
+
+    block = card.read_text(encoding="utf-8").split("```toml", 1)[1].split("```", 1)[0]
+    return tomllib.loads(block)["variants"]
+
+
+def test_updates_only_the_variant_it_was_given(carded):
+    written = edit.apply_variant(carded, "wide", {"count": 8, "height": 50})
+    assert written == ["count", "height"]
+    card = carded.parent / "thing.md"
+    variants = read_variants(card)
+    # chamfer went back to the default at some point, so it is no longer an override.
+    assert variants["wide"]["params"] == {"count": 8, "height": 50}
+    assert variants["wide"]["accepted"] == {"sliver": 4}
+    text = card.read_text()
+    assert "# Why the wide one exists." in text
+    assert "min_wall = 0.7" in text
+    assert "More prose after the block." in text
+
+
+def test_variant_values_keep_the_signature_types(carded):
+    edit.apply_variant(carded, "wide", {"count": 8.0, "chamfer": 2, "flag": True, "label": "x"})
+    text = (carded.parent / "thing.md").read_text()
+    assert "count = 8\n" in text
+    assert "chamfer = 2.0\n" in text
+    assert "flag = true\n" in text
+    assert 'label = "x"\n' in text
+
+
+def test_variant_strings_keep_non_bmp_unicode(carded):
+    edit.apply_variant(carded, "wide", {"label": "fixture 😀"})
+    variants = read_variants(carded.parent / "thing.md")
+    assert variants["wide"]["params"] == {"label": "fixture 😀"}
+
+
+def test_a_quoted_variant_name_is_updated(carded):
+    card = carded.parent / "thing.md"
+    card.write_text(CARD.replace("variants.wide", 'variants."wide one"'))
+    edit.apply_variant(carded, "wide one", {"count": 8})
+    assert read_variants(card)["wide one"]["params"] == {"count": 8}
+
+
+def test_a_quoted_variant_name_gets_a_params_section(carded):
+    card = carded.parent / "thing.md"
+    card.write_text(CARD.replace("variants.bare", 'variants."bare one"'))
+    edit.apply_variant(carded, "bare one", {"height": 30})
+    assert read_variants(card)["bare one"] == {
+        "params": {"height": 30}, "accepted": {"sliver": 2}
+    }
+
+
+def test_a_variant_without_a_params_section_gets_one(carded):
+    edit.apply_variant(carded, "bare", {"height": 30})
+    variants = read_variants(carded.parent / "thing.md")
+    assert variants["bare"] == {"params": {"height": 30}, "accepted": {"sliver": 2}}
+
+
+def test_a_variant_the_card_never_mentions_is_an_error(carded):
+    with pytest.raises(edit.EditError, match="no variant named tall"):
+        edit.apply_variant(carded, "tall", {"count": 8})
+
+
+def test_a_part_without_a_card_says_so(part_file):
+    with pytest.raises(edit.EditError, match="no card"):
+        edit.apply_variant(part_file, "wide", {"count": 8})
+
+
+def test_the_variant_temp_file_does_not_survive(carded):
+    edit.apply_variant(carded, "wide", {"count": 8})
+    assert sorted(p.name for p in carded.parent.iterdir()) == ["thing.md", "thing.py"]
+
+
 def test_non_ascii_earlier_on_the_line_does_not_shift_the_offsets(tmp_path):
     """col_offset counts utf-8 bytes, not characters.
 


### PR DESCRIPTION
Changing a parameter while on a variant used to drop the variant highlight with no way to write the new values back; the only path was hand-editing the card's TOML. The viewer now tracks which variant the sliders started from, keeps its row pinned with an accent while drifted, and offers an update button that writes the on-screen values into exactly that variant's `[variants.<name>.params]` block in the card, preserving comments, other sections, and the signature's int/float types. A new `apply_variant` websocket command does the card surgery in `edit.py` with the same validate-then-atomic-write care as the defaults write, and the watcher's rebuild re-matches the variant so the row relights on its own. The desktop rail gets the same pin over a new `nurb:variant` postMessage, embed mode gets a hobbyist label without filenames, and the rail's part-row reset now also works while drifted. CLAUDE.md gains a rule making the desktop pass mandatory for every change, with the seams to check.