### PR TITLE
Release 0.22.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.21.0"
+version = "0.22.0"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.21.0"
+version = "0.22.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,16 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.22.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.22.0">v0.22.0</a></span><time datetime="2026-08-19">August 19, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Print settings come with the file.</b> The 3MF you download now opens in Bambu Studio or Orca already set up for that part: gyroid infill, three walls, no supports, and a brim only when the part is tall enough or warp-prone enough to earn one. The print time and filament estimate describes the same file you got. This needs a slicer installed and a printer picked, and the download tells you when either one is missing.</span></li>
+      <li><b class="tag new">new</b><span><b>Save a variant from the sliders.</b> Move a slider while a variant is selected and the app now offers to write those numbers back into that variant. Until you do, the variant stays marked so you can see your values have drifted from the saved ones.</span></li>
+      <li><b class="tag new">new</b><span><b>Gemini.</b> Gemini joins the AIs you can work with in the app. Sign in with a Google AI Studio key from inside the app, and it is kept in your Mac's keychain.</span></li>
+      <li><b class="tag new">new</b><span>The Anycubic Kobra 2 is now one of the printers you can choose, with its bed size and its own slicer settings.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.21.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.21.0">v0.21.0</a></span><time datetime="2026-08-18">August 18, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.21.0"
+  version: "0.22.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.21.0"
+  version: "0.22.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.21.0"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Cuts 0.22.0 across the engine, the skill files, and the desktop app, and writes the changelog entry for what shipped since 0.21.0.

## What ships

- **Print settings come with the file.** Exported 3MFs open in Bambu Studio or Orca already configured for the part: gyroid infill, three walls, no supports, and an outer brim only when the warp or stability checks earn one. Print time and filament estimates describe the same file (#150).
- **Save a variant from the sliders.** Moving a slider while a variant is selected keeps the row pinned and offers to write the on-screen values back into that variant's card block (#153).
- **Gemini.** Gemini joins the desktop chat agents, with an in-app Google AI Studio key flow backed by the macOS Keychain (#152).
- **Anycubic Kobra 2 profile**, with its bed size and vendor slicer preset (#152).

Site and README changes (#148, #149) are not user-facing and get no changelog line.

## Version strings

pyproject, `src/nurb/skill.md`, `skills/nurb/SKILL.md`, and `desktop/src-tauri/tauri.conf.json` all read 0.22.0; `evals/uv.lock` is relocked to match.

`uv run pytest tests/test_cli.py`: 53 passed. Changelog page checked in a browser: the new entry renders like its neighbors, versions still descend, no em-dashes, no duplicate anchors.