### PR TITLE
Release 0.22.1

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.22.0"
+version = "0.22.1"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.22.0"
+version = "0.22.1"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,13 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.22.1">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.22.1">v0.22.1</a></span><time datetime="2026-08-19">August 19, 2026</time></div>
+    <ul>
+      <li><b class="tag">fixed</b><span>Saving a variant from the sliders failed on variants your AI had set up, so your numbers never got written back. It saves them now.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.22.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.22.0">v0.22.0</a></span><time datetime="2026-08-19">August 19, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.22.0"
+  version: "0.22.1"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.22.0"
+  version: "0.22.1"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.22.0"
+version = "0.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Patch release. One user-visible fix since 0.22.0.

**Saving a variant from the sliders now works on AI-written parts.** Updating a variant from the viewer failed with `Cannot overwrite a value` whenever the card held that variant's overrides as an inline `params = { ... }` table, which is how agent-written cards commonly declare them. The editor only knew the section form, so it wrote a second definition and its own validation refused the write. The inline line is now rewritten in place, leaving the note and sibling variants untouched (#155).

Bumps the four version strings (`pyproject.toml`, `src/nurb/skill.md`, `skills/nurb/SKILL.md`, `desktop/src-tauri/tauri.conf.json`), relocks `evals/uv.lock`, and adds the v0.22.1 changelog entry to the site.

`uv run pytest tests/test_cli.py -q` passes (53 tests), which is what enforces the version agreement.