### PR TITLE
Release 0.22.2

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.22.1"
+version = "0.22.2"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.22.1"
+version = "0.22.2"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,14 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.22.2">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.22.2">v0.22.2</a></span><time datetime="2026-08-19">August 19, 2026</time></div>
+    <ul>
+      <li><b class="tag">fixed</b><span>When setup fails the first time you open the app, the screen now names the piece that failed and shows what it said, instead of one generic message for every failure. Setup also waits longer for a newly installed tool to start, which was one cause of those failures.</span></li>
+      <li><b class="tag new">new</b><span><b>Report a broken setup.</b> A report this button sits next to try again on that screen. It opens a bug report already filled in with the error and your Mac's details, so you do not have to describe what went wrong.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.22.1">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.22.1">v0.22.1</a></span><time datetime="2026-08-19">August 19, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.22.1"
+  version: "0.22.2"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.22.1"
+  version: "0.22.2"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.22.1"
+version = "0.22.2"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Patch release. One user-visible change since 0.22.1, from #158.

When first-launch setup fails, the setup screen now names which component broke and quotes what it said, instead of collapsing every failure into one generic message. The probe that checks for a platform-native CLI waits 30s instead of 10s, since the first exec of a freshly written binary can stall while macOS assesses it, which may have been the original failure in #157. The screen also gains a "report this" button that opens a prefilled GitHub bug report with the error, app version, macOS version, and architecture.

Bumps the four version strings (package, `src/nurb/skill.md`, `skills/nurb/SKILL.md`, `desktop/src-tauri/tauri.conf.json`), relocks `evals/uv.lock`, and adds the changelog entry for v0.22.2.

`uv run pytest tests/test_cli.py -q` passes: 53 tests, version agreement included. Changelog entry verified in a browser.