### PR TITLE
Strip grok transcript byte arrays during submission sanitization

### DIFF
--- a/evals/src/nurb_evals/contribute.py
+++ b/evals/src/nurb_evals/contribute.py
@@ -74,7 +74,13 @@ def replacements(project_root):
     return sorted(pairs, key=lambda p: -len(p[0]))
 
 
+# grok's transcript repeats every tool result as a raw byte array next to the
+# sanitized text, and paths hide from string replacement inside the integers.
+_BYTE_ARRAY = re.compile(r'"output":\[[0-9,]+\]')
+
+
 def sanitize(text, pairs):
+    text = _BYTE_ARRAY.sub('"output":[]', text)
     for needle, token in pairs:
         text = text.replace(needle, token)
     return text

--- a/evals/tests/test_contribute.py
+++ b/evals/tests/test_contribute.py
@@ -35,6 +35,14 @@ def test_sanitize_scrubs_longest_first(tmp_path):
     assert str(pathlib.Path.home()) not in clean and "<workspace>" in clean
 
 
+def test_sanitize_drops_byte_arrays_that_hide_paths(tmp_path):
+    home = str(pathlib.Path.home())
+    encoded = ",".join(str(b) for b in home.encode())
+    dirty = '{"output":[%s],"output_for_prompt":"%s"}' % (encoded, home)
+    clean = contribute.sanitize(dirty, contribute.replacements(tmp_path / "project"))
+    assert clean == '{"output":[],"output_for_prompt":"<home>"}'
+
+
 def test_next_trial_continues_numbering(tmp_path):
     (tmp_path / "cable_clip" / "trial_1").mkdir(parents=True)
     (tmp_path / "cable_clip" / "trial_2").mkdir()

--- a/evals/tests/test_report.py
+++ b/evals/tests/test_report.py
@@ -1,6 +1,7 @@
 """The report is arithmetic over rows; every column has to be checkable by hand."""
 
 import json
+import re
 import pathlib
 
 import pytest
@@ -119,6 +120,8 @@ def test_committed_submission_artifacts_are_complete_and_sanitized():
             assert source.is_file() and source.read_text(encoding="utf-8").strip()
             for artifact in (transcript, source):
                 text = artifact.read_text(encoding="utf-8")
+                for arr in re.findall(r'"output":\[([0-9,]+)\]', text):
+                    text += bytes(int(b) for b in arr.split(",")).decode("utf-8", "replace")
                 assert "/Users/" not in text and "/home/" not in text
                 assert "joshpigford" not in text.lower() and "shpigford" not in text.lower()
     # rows == 0 is a legal state: the board was reset before first deploy and fills


### PR DESCRIPTION
grok's transcript stores every tool result twice: as sanitized `output_for_prompt` text and as a raw `"output":[...]` byte array. `sanitize()` does string replacement, so a home path encoded as integers passed straight through. #140 shipped with `/Users/<user>` in four of those arrays.

`sanitize()` now collapses the arrays to `[]` (the text is already in `output_for_prompt`), and the committed-submissions test decodes any surviving arrays before checking for home paths, so this cannot land again unnoticed.

The transcripts on #140 were fixed the same way in place.