### PR TITLE
Allow composing messages while the agent is working

### DIFF
--- a/desktop/src/Chat.tsx
+++ b/desktop/src/Chat.tsx
@@ -13,6 +13,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { IconChevronDown, IconMessagePlus, IconPaperclip } from "./Icons";
 import Markdown from "./Markdown";
 import { playChime, shouldPlayCompletionChime } from "./chime";
+import { restoreDraftFiles, restoreDraftText } from "./chatDraft";
 
 // The whole-project conversation rides the per-part plumbing under a name no part
 // file can have. Twins live in App.tsx's mount and acp.rs's context line.
@@ -513,13 +514,15 @@ function Chat({
       } catch (e) {
         const message = String(e);
         if (message.includes("auth_required")) {
-          // Nothing was sent. Put the exact draft back instead of leaving a
-          // false sent bubble and making the user reconstruct attachments.
+          // Nothing was sent. Restore it ahead of any next draft composed
+          // during the turn, and keep both turns' attachments.
           setItems((list) =>
             list.filter((item) => item.kind !== "user" || item.localId !== localId),
           );
-          if (inputRef.current) inputRef.current.value = text;
-          setAttachments(files);
+          if (inputRef.current) {
+            inputRef.current.value = restoreDraftText(text, inputRef.current.value);
+          }
+          setAttachments((draftFiles) => restoreDraftFiles(files, draftFiles));
           setAuthNeeded(true);
         } else {
           setItems((list) => [...list, { kind: "note", text: message }]);
@@ -848,7 +851,7 @@ function Chat({
                 : `Describe or change ${isProject ? "the project" : part}…`
           }
           rows={2}
-          disabled={busy || starting}
+          disabled={starting}
           onKeyDown={keydown}
         />
         <div className="chat-composer-controls">
@@ -857,7 +860,7 @@ function Chat({
             className="chat-attach"
             title="attach photos or files"
             aria-label="attach photos or files"
-            disabled={busy || starting}
+            disabled={starting}
             onClick={attach}
           >
             <IconPaperclip />

--- a/desktop/src/chatDraft.ts
+++ b/desktop/src/chatDraft.ts
@@ -1,0 +1,9 @@
+export function restoreDraftText(failed: string, draft: string): string {
+  if (!failed) return draft;
+  if (!draft) return failed;
+  return `${failed}\n\n${draft}`;
+}
+
+export function restoreDraftFiles(failed: string[], draft: string[]): string[] {
+  return [...new Set([...failed, ...draft])];
+}

--- a/desktop/tests/chatDraft.test.ts
+++ b/desktop/tests/chatDraft.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { restoreDraftFiles, restoreDraftText } from "../src/chatDraft.ts";
+
+test("an auth failure preserves work composed during the failed turn", () => {
+  assert.equal(
+    restoreDraftText("Original message", "Next draft"),
+    "Original message\n\nNext draft",
+  );
+  assert.equal(restoreDraftText("", "Next draft"), "Next draft");
+  assert.equal(restoreDraftText("Original message", ""), "Original message");
+  assert.deepEqual(
+    restoreDraftFiles(["original.stl"], ["next.png", "original.stl"]),
+    ["original.stl", "next.png"],
+  );
+});


### PR DESCRIPTION
Allows users to type and attach files while an agent is working; submission remains blocked by the active Stop control. Auth recovery now merges the failed prompt and attachments with any in-progress draft instead of overwriting it. Adds regression coverage for draft recovery.

Tests: `npm test`; `npm run build`.

Closes #161