### PR TITLE
Add three benchmark tasks: chamfer-dense spec, curvature, and mating fit

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -8,8 +8,8 @@ The current leaderboard is in [REPORT.md](REPORT.md).
 
 Tasks come in classes, because the benchmark measures two different abilities:
 
-- **Spec tasks** (`tasks/cable_clip`): every dimension stated, zero interpretation. They measure execution fidelity, the floor.
-- **Function tasks** (`tasks/bundle_holder`): the problem, the measured interfaces, and the printer are stated, the geometry is not. Scoring is functional gates that are mechanical facts of the B-rep (the bundle has a retained place to sit, the screw has a bore, a seat, and driver access) plus a material-economy gradient, so a cleverer design legitimately wins without a human deciding it was clever. This is where models that can interpret outmaneuver models that can only follow.
+- **Spec tasks** (`tasks/cable_clip`, `tasks/bit_block`): every dimension stated, zero interpretation. They measure execution fidelity, the floor. bit_block raises that floor to where the kernel pushes back: a grid of chamfered pocket mouths with 2.0 webs sits close to OCCT's adjacent-chamfer limit, so a wrong chamfer order, a selector resolved before the pockets were cut, or a grid slid half a millimetre does not lose points, it does not build. Its grid is driven by an int parameter and the flex probes rebuild it at other counts, which catches a grid written out by hand.
+- **Function tasks** (`tasks/bundle_holder`, `tasks/pole_rest`, `tasks/valve_knob`): the problem, the measured interfaces, and the printer are stated, the geometry is not. Scoring is functional gates that are mechanical facts of the B-rep (the bundle has a retained place to sit, the screw has a bore, a seat, and driver access) plus a material-economy gradient, so a cleverer design legitimately wins without a human deciding it was clever. This is where models that can interpret outmaneuver models that can only follow. pole_rest is the class's curvature test: the support gate demands one continuous 120 degree arc of backed contact around a measured pole, which a V-block or a square channel mechanically cannot own, so only geometry sized to the measured curve passes. valve_knob is the class's mating-fit test: the grader drives a virtual D-stem into the candidate's bore and grades the tolerance band from both sides (grown by the stated clearance it must pass, grown by the stated slop it must jam) and then turns it 20 degrees, which a lazy round bore survives freely and therefore fails.
 - **Judgment tasks** (`tasks/leg_cup`): the geometry is stated, but one real-world dimension is deliberately not on file and nobody can measure it right now. What is scored, beyond the geometry, is measurement discipline the way nurb's doctrine defines it: the part derives from `measured()` values (the scorer rebuilds it against a rewritten `measurements.toml` and the geometry must track), and the missing dimension is recorded as a provisional guess with provenance instead of baked into the code. A silent plausible number works tonight and is exactly what loses points. Because the graded artifact is the part plus the measurements entry next to it, this task is always graded inside a materialized project.
 
 Every scored check is stated in the task instruction; nothing unstated is ever graded.
@@ -38,7 +38,10 @@ The manual way needs `uv` and the `claude` or `codex` CLI installed and logged i
 cd evals
 uv sync --locked
 uv run python -m nurb_evals.run --harness claude --model opus --effort high --seed 13 --trials 3 --task tasks/cable_clip
+uv run python -m nurb_evals.run --harness claude --model opus --effort high --seed 13 --trials 3 --task tasks/bit_block
 uv run python -m nurb_evals.run --harness claude --model opus --effort high --seed 13 --trials 3 --task tasks/bundle_holder
+uv run python -m nurb_evals.run --harness claude --model opus --effort high --seed 13 --trials 3 --task tasks/pole_rest
+uv run python -m nurb_evals.run --harness claude --model opus --effort high --seed 13 --trials 3 --task tasks/valve_knob
 uv run python -m nurb_evals.run --harness claude --model opus --effort high --seed 13 --trials 3 --task tasks/leg_cup
 uv run python -m nurb_evals.report results/claude-opus-high
 ```

--- a/evals/src/nurb_evals/contribute.py
+++ b/evals/src/nurb_evals/contribute.py
@@ -25,7 +25,7 @@ from . import harness as harnesses
 from .run import trial
 
 EVALS = pathlib.Path(__file__).parents[2]
-TASKS = ("cable_clip", "bundle_holder", "leg_cup")
+TASKS = ("cable_clip", "bit_block", "bundle_holder", "pole_rest", "valve_knob", "leg_cup")
 SEED = 13
 
 

--- a/evals/src/nurb_evals/site.py
+++ b/evals/src/nurb_evals/site.py
@@ -26,9 +26,21 @@ JOBS = {
         "Follow the spec",
         "A cable clip with every dimension stated. Can it build exactly what you asked?",
     ),
+    "bit_block": (
+        "Survive the kernel",
+        "A bit block dense with chamfers, right at the CAD kernel's limits. One wrong move and the part never builds.",
+    ),
     "bundle_holder": (
         "Design from a problem",
         "“Hold this cable bundle on the wall with one screw.” No shape given: it has to design one that works and prints.",
+    ),
+    "pole_rest": (
+        "Design a curve",
+        "A rest that must cradle a measured pole along a real arc. Flat answers touch at lines and lose; only curvature passes.",
+    ),
+    "valve_knob": (
+        "Make it fit",
+        "A knob for a measured D-shaft. The grader drives the real stem: too tight jams, too loose rattles, a round bore spins.",
     ),
     "leg_cup": (
         "Handle a missing measurement",

--- a/evals/tasks/bit_block/fixture/printer.toml
+++ b/evals/tasks/bit_block/fixture/printer.toml
@@ -1,0 +1,1 @@
+profile = "bambu_p1s"

--- a/evals/tasks/bit_block/task.py
+++ b/evals/tasks/bit_block/task.py
@@ -1,0 +1,324 @@
+"""The bit_block task: a bench block for driver bits, dense with chamfers.
+
+A spec task like cable_clip, but aimed at the two abilities the first corpus never
+touched. First, chamfer execution: every pocket mouth and the top perimeter get an
+exact 0.8 lead-in, with 2.0 webs between pockets, so the part sits close to OCCT's
+adjacent-chamfer limit and an agent that chamfers in the wrong order, or against
+selectors resolved before the pockets were cut, does not build at all. Second, count
+parametrization: the pocket grid is driven by an int parameter, and the flex probes
+regenerate the grid at other counts, which catches a grid written out by hand.
+
+Every scored dimension is stated in the instruction, and nothing unstated is graded.
+"""
+
+import math
+import pathlib
+import random
+import shutil
+from dataclasses import dataclass
+
+from build123d import Cylinder, GeomType, Pos, Vector
+
+from nurb import checks
+
+EPS = 1e-3
+TOL = 0.05  # stated dimensions are exact; this absorbs kernel noise, not design slack
+
+ROWS = 2
+WEB = 2.0  # material between pocket walls, and from outer pockets to the block's side
+DEPTH = 12.0
+FLOOR = 3.0
+CHAM = 0.8
+CLEAR = 0.3
+
+INSTRUCTION = """\
+Design a bench block that holds driver bits upright, and save it as
+parts/bit_block.py.
+
+The bits' shanks are measured at {shank} mm across; the measurement is on file as
+shank_diameter in measurements.toml. Bits drop straight down into round pockets and
+stand there; the block sits flat on the bench.
+
+Requirements, all in mm:
+- A grid of {count} round pockets, {cols} columns by 2 rows, opening straight up.
+  Pocket diameter exactly shank_diameter + 0.3 = {pocket_d}, pocket depth exactly
+  12.0, flat floors, nothing intruding into any pocket and nothing roofing them over.
+- Grid pitch exactly {pitch} in both directions (2.0 of material between neighbouring
+  pocket walls), and 2.0 of material from the outermost pocket walls to the block's
+  sides, so the block is exactly {bbox_x} x {bbox_y}.
+- The floor under the pockets is solid, exactly 3.0 thick: overall height exactly
+  15.0.
+- Every pocket mouth gets an exact 0.8 x 45 degree chamfer lead-in. The top outer
+  perimeter gets the same 0.8 chamfer. No other edges are broken: the bottom
+  perimeter stays sharp so the stated bounding box is exact.
+- The part prints as it sits: flat bottom on the bed, one solid.
+- No material beyond what the features above require; the grader checks total volume
+  within 10% of nominal.
+- Expose shank_diameter as a float parameter and columns as an int parameter
+  (default {cols}), and derive the geometry from both: the block must rebuild
+  correctly for nearby shank sizes and other column counts.
+- nurb check must report zero findings. The grader runs the checks itself and
+  ignores the card's [accepted] blocks, so fix findings in the geometry instead of
+  accepting them.
+"""
+
+MEASUREMENTS = """\
+[shank_diameter]
+value = {shank}
+unit = "mm"
+how = "calipers across a bit shank, 2026-08-20"
+"""
+
+
+@dataclass(frozen=True)
+class Instance:
+    seed: int
+    dims: dict
+    instruction: str
+    measurements: str
+
+
+def _dims(shank, cols):
+    pocket_d = round(shank + CLEAR, 2)
+    pitch = round(pocket_d + WEB, 2)
+    return {
+        "shank": shank,
+        "pocket_d": pocket_d,
+        "cols": cols,
+        "count": cols * ROWS,
+        "pitch": pitch,
+        "bbox_x": round(cols * pitch + WEB, 2),
+        "bbox_y": round(ROWS * pitch + WEB, 2),
+        "bbox_z": round(FLOOR + DEPTH, 2),
+    }
+
+
+def instance(seed):
+    rng = random.Random(seed)
+    shank = 4.0 + 0.25 * rng.randrange(17)
+    cols = 4 + rng.randrange(3)
+    dims = _dims(shank, cols)
+    return Instance(
+        seed=seed,
+        dims=dims,
+        instruction=INSTRUCTION.format(**dims),
+        measurements=MEASUREMENTS.format(shank=dims["shank"]),
+    )
+
+
+def context():
+    """The Context this task is graded under. Frozen here, never read from the
+    candidate's card or printer.toml: a card's [accepted] block must not mute rules."""
+    return checks.Context()
+
+
+def _volume(dims):
+    r = dims["pocket_d"] / 2
+    n = dims["count"]
+    block = dims["bbox_x"] * dims["bbox_y"] * dims["bbox_z"]
+    pockets = n * math.pi * r**2 * DEPTH
+    # The mouth chamfer ring, beyond the cylinder already subtracted.
+    rings = n * math.pi * CHAM**2 * (r + CHAM / 3)
+    # The perimeter chamfer prism, corners counted once.
+    perimeter = CHAM**2 / 2 * 2 * (dims["bbox_x"] + dims["bbox_y"]) - 4 * CHAM**3 / 3
+    return block - pockets - rings - perimeter
+
+
+def _grid_centers(dims, bb):
+    """Where the stated grid puts each pocket axis, from the bounding box alone."""
+    r = dims["pocket_d"] / 2
+    return [
+        (
+            bb.min.X + WEB + r + col * dims["pitch"],
+            bb.min.Y + WEB + r + row * dims["pitch"],
+        )
+        for col in range(dims["cols"])
+        for row in range(ROWS)
+    ]
+
+
+def misfits(shape, dims):
+    """Everything wrong with the block, as (problems, checks). Translation-tolerant,
+    rotation-pinned: the grid is derived from the bounding box, which the stated
+    borders pin to the pockets, so every per-pocket check is against stated geometry
+    rather than whatever centers the candidate chose."""
+    problems = []
+    checks_run = 0
+    bb = shape.bounding_box()
+    r = dims["pocket_d"] / 2
+
+    for axis, want in (("X", dims["bbox_x"]), ("Y", dims["bbox_y"]), ("Z", dims["bbox_z"])):
+        checks_run += 1
+        got = getattr(bb.size, axis)
+        if abs(got - want) > TOL:
+            problems.append(f"bounding box {axis} is {got:.2f}mm, expected {want}")
+
+    centers = _grid_centers(dims, bb)
+
+    # The bottom: one flat rectangular face spanning the full footprint. This is what
+    # keeps the bottom perimeter sharp; a bottom chamfer or feet shrink it.
+    checks_run += 1
+    bottom = [
+        face
+        for face in shape.faces()
+        if abs(face.bounding_box().min.Z - bb.min.Z) < EPS
+        and abs(face.bounding_box().max.Z - bb.min.Z) < EPS
+    ]
+    footprint = bb.size.X * bb.size.Y
+    full = (
+        len(bottom) == 1
+        and abs(bottom[0].bounding_box().size.X - bb.size.X) < TOL
+        and abs(bottom[0].bounding_box().size.Y - bb.size.Y) < TOL
+        and abs(bottom[0].area - footprint) < 0.1
+    )
+    if not full:
+        problems.append("the bottom is not one flat face spanning the full footprint")
+
+    # Pocket floors: a circle rim of the pocket radius at floor height on every grid
+    # center. The rim, not a face probe, is what pins the diameter exactly.
+    checks_run += 1
+    floor_z = bb.max.Z - DEPTH
+    floor_rims = [
+        edge
+        for edge in shape.edges()
+        if edge.geom_type == GeomType.CIRCLE
+        and abs(edge.radius - r) < TOL
+        and abs(edge.arc_center.Z - floor_z) < TOL
+    ]
+    placed = _matched(centers, floor_rims)
+    if placed < len(centers):
+        problems.append(
+            f"only {placed} of {len(centers)} pockets have a {dims['pocket_d']}mm "
+            f"floor rim at {DEPTH}mm depth on the stated grid"
+        )
+
+    # The mouth chamfer, pinned from both ends: the pocket radius where the chamfer
+    # lands (0.8 below the top) and the widened rim at the top. Together they state
+    # 0.8 x 45 exactly.
+    checks_run += 1
+    lands = [
+        e
+        for e in shape.edges()
+        if e.geom_type == GeomType.CIRCLE
+        and abs(e.radius - r) < TOL
+        and abs(e.arc_center.Z - (bb.max.Z - CHAM)) < TOL
+    ]
+    mouths = [
+        e
+        for e in shape.edges()
+        if e.geom_type == GeomType.CIRCLE
+        and abs(e.radius - (r + CHAM)) < TOL
+        and abs(e.arc_center.Z - bb.max.Z) < TOL
+    ]
+    chamfered = min(_matched(centers, lands), _matched(centers, mouths))
+    if chamfered < len(centers):
+        problems.append(
+            f"only {chamfered} of {len(centers)} pocket mouths have the exact "
+            f"{CHAM} x 45 degree lead-in chamfer"
+        )
+
+    # The perimeter chamfer: the top face shrinks by 0.8 on every side, and 45 degree
+    # planar faces connect it to the sides.
+    checks_run += 1
+    top = [
+        face
+        for face in shape.faces()
+        if abs(face.bounding_box().min.Z - bb.max.Z) < EPS
+        and abs(face.bounding_box().max.Z - bb.max.Z) < EPS
+    ]
+    shrunk = any(
+        abs(f.bounding_box().size.X - (bb.size.X - 2 * CHAM)) < TOL
+        and abs(f.bounding_box().size.Y - (bb.size.Y - 2 * CHAM)) < TOL
+        for f in top
+    )
+    bevels = [
+        face
+        for face in shape.faces()
+        if face.geom_type == GeomType.PLANE
+        and abs(face.normal_at(face.center()).Z - math.sin(math.pi / 4)) < 0.01
+        and abs(face.bounding_box().max.Z - bb.max.Z) < EPS
+        and abs(face.bounding_box().min.Z - (bb.max.Z - CHAM)) < TOL
+    ]
+    if not shrunk or len(bevels) < 4:
+        problems.append(
+            f"the top perimeter is missing its {CHAM} x 45 degree chamfer on all four sides"
+        )
+
+    # A virtual bit drives straight down into every pocket: pocket radius, full
+    # depth, plus headroom above the block. Clear space here is what rejects a roofed
+    # pocket, an intrusion, or a shallow pocket, as one boolean per pocket instead of
+    # a point grid.
+    checks_run += 1
+    blocked = 0
+    for cx, cy in centers:
+        probe = Pos(cx, cy, (floor_z + bb.max.Z + 4.0) / 2) * Cylinder(
+            r - TOL, bb.max.Z + 4.0 - floor_z
+        )
+        try:
+            hit = shape & probe
+            if (hit.volume if hit is not None else 0.0) > 0.01:
+                blocked += 1
+        except Exception:
+            blocked += 1
+    if blocked:
+        problems.append(f"{blocked} of {len(centers)} pockets are not clear for a straight drop-in")
+
+    # Solid under the floors and between the pockets: the stated material, probed
+    # where neither chamfer can reach.
+    checks_run += 1
+    web_x = bb.min.X + WEB + r + dims["pitch"] / 2  # between the first two columns
+    web_y = (bb.min.Y + bb.max.Y) / 2
+    solid = all(
+        shape.is_inside(Vector(cx, cy, bb.min.Z + FLOOR / 2)) for cx, cy in centers
+    ) and shape.is_inside(Vector(web_x, web_y, bb.max.Z - DEPTH / 2))
+    if not solid:
+        problems.append("the floor under the pockets or the web between them is not solid")
+
+    checks_run += 1
+    want = _volume(dims)
+    if abs(shape.volume - want) > 0.10 * want:
+        problems.append(f"volume {shape.volume:.0f}mm3 is off nominal {want:.0f}mm3 by >10%")
+
+    return problems, checks_run
+
+
+def _matched(centers, edges):
+    """How many stated grid centers have one of `edges` on their axis."""
+    count = 0
+    for cx, cy in centers:
+        if any(
+            abs(e.arc_center.X - cx) < TOL and abs(e.arc_center.Y - cy) < TOL for e in edges
+        ):
+            count += 1
+    return count
+
+
+def flex_probes(inst):
+    """Parameter overrides and matching ground truth for the isolated build worker.
+    The column probes are what catch a grid written out by hand instead of derived
+    from the int parameter."""
+    shank = inst.dims["shank"]
+    cols = inst.dims["cols"]
+    return [
+        ({"params": {"shank_diameter": round(shank + 0.5, 2)}}, _dims(round(shank + 0.5, 2), cols)),
+        ({"params": {"columns": cols + 1}}, _dims(shank, cols + 1)),
+        (
+            {"params": {"shank_diameter": round(shank + 1.0, 2), "columns": cols - 1}},
+            _dims(round(shank + 1.0, 2), cols - 1),
+        ),
+    ]
+
+
+def materialize(seed, dest):
+    """Write the project a model starts from: fixture, the seeded measurement, and the
+    same AGENTS.md a real project gets from `nurb new`, so the model designs with the
+    shipped skill in front of it exactly the way a user's session would."""
+    import importlib.resources
+
+    dest = pathlib.Path(dest)
+    fixture = pathlib.Path(__file__).parent / "fixture"
+    shutil.copytree(fixture, dest, dirs_exist_ok=True)
+    (dest / "measurements.toml").write_text(instance(seed).measurements, encoding="utf-8")
+    skill = importlib.resources.files("nurb").joinpath("agents.md").read_text(encoding="utf-8")
+    (dest / "AGENTS.md").write_text(skill, encoding="utf-8")
+    return dest

--- a/evals/tasks/pole_rest/fixture/printer.toml
+++ b/evals/tasks/pole_rest/fixture/printer.toml
@@ -1,0 +1,1 @@
+profile = "bambu_p1s"

--- a/evals/tasks/pole_rest/task.py
+++ b/evals/tasks/pole_rest/task.py
@@ -1,0 +1,332 @@
+"""The pole_rest task: a drying-rack rest for a measured pole, where only curvature
+passes.
+
+The second function task, and the corpus's first that a prismatic design cannot win.
+The problem states an interface (the pole's axis height, so several rests hold one
+pole level) and a support requirement a machinist would state: contact within 0.4 of
+the pole's surface, with real material behind it, along a continuous 120 degree arc
+of the circumference. A V-block touches at two lines and a square channel at three;
+neither owns an arc. Only a cradle cut near the pole's own radius does, so the gate
+mechanically demands the one thing the first corpus never did: curved geometry sized
+to a measured curve.
+
+Support is measured on meshed cross-sections along the pole, the same machinery as
+bundle_holder: stations are feature-aware so nothing printable hides between them,
+contact is a distance query against the section polygon (exact on the section, no
+point grid to thread), and the backing probe stands 1.2 behind the contact so a film
+that merely traces the arc counts as nothing.
+"""
+
+import math
+import pathlib
+import random
+import shutil
+from dataclasses import dataclass
+
+import numpy as np
+import shapely
+from build123d import Box, Cylinder, GeomType, Pos, Rot
+
+from nurb import builder, checks
+
+EPS = 1e-3
+TOL = 0.05
+
+MIN_LENGTH = 20.0
+MIN_BED = 200.0  # mm2 of flat bottom on the bed
+GAP_MIN = 0.1  # stated minimum clearance around the pole
+CONTACT = 0.4  # stated: support counts within this of the pole's surface
+BACKING = 1.2  # stated continuous material behind the contact
+ARC_DEG = 120.0
+COVER = 2 / 3  # fraction of the length the arc must hold along
+L_REF = 20.0  # reference length for the volume ladder
+
+# Measurement tolerances. Fit is checked 0.02 under the stated gap so kernel noise
+# never charges a legitimate 0.1 clearance. Backing is measured as one continuous
+# radial intersection that starts within the contact band, so a second skin across
+# an air gap cannot stand in for wall thickness.
+FIT_R = GAP_MIN - 0.02
+STEP_DEG = 5
+
+INSTRUCTION = """\
+Design a rest that holds a freshly finished pole while it dries, and save it as
+parts/pole_rest.py.
+
+The pole is measured at {pole} mm across; the measurement is on file as
+pole_diameter in measurements.toml. Several identical rests stand in a row on the
+bench and the pole lies across them, so the interface is fixed: the pole runs along
+Y with its axis exactly {axis_h} above the bed, centered over your part's footprint
+in X. The finish is soft, so the pole must be cradled, not balanced on edges. What
+the rest looks like is up to you: the grader checks function mechanically, and every
+check it runs is listed below.
+
+Function checks, all units mm:
+- The part prints as it sits and is used as it prints: flat on the bed with at least
+  200 mm2 of bottom face, at least 20.0 long along Y, one solid, support-free.
+- Fit: with the pole's axis at the stated position, your material stays at least 0.1
+  clear of the pole along the whole part.
+- Support: at each cross-section, material within 0.4 of the pole's surface, itself
+  backed by at least 1.2 of material behind the contact, along one continuous arc of
+  at least 120 degrees of the pole's circumference. That arc must hold at
+  cross-sections covering at least two thirds of the part's length. Edges and points
+  of contact cannot do this; a cradle close to the pole's own radius can.
+- Drop-in: the pole must lower straight down (-Z) from above into the seat without
+  hitting your part on the way.
+- Material economy: total volume at or below {v1} mm3 earns full marks; credit steps
+  down above {v2} and again above {v3}.
+- nurb check must report zero findings. The grader runs the checks itself and
+  ignores the card's [accepted] blocks, so fix findings in the geometry instead of
+  accepting them.
+- Expose pole_diameter as a float parameter and derive the geometry from it: the
+  rest must rebuild correctly for nearby pole sizes, with the axis height staying
+  exactly {axis_h}.
+"""
+
+MEASUREMENTS = """\
+[pole_diameter]
+value = {pole}
+unit = "mm"
+how = "calipers across the sanded pole, 2026-08-21"
+"""
+
+
+@dataclass(frozen=True)
+class Instance:
+    seed: int
+    dims: dict
+    instruction: str
+    measurements: str
+
+
+def _volume_ladder(pole, axis_h):
+    """A generous reference: a full-width block up to the axis height with the
+    pole's half-cylinder taken out, at the reference length."""
+    r = pole / 2 + GAP_MIN
+    width = 2 * r + 4.8
+    ref = L_REF * (width * axis_h - 0.5 * math.pi * r**2)
+    return round(1.4 * ref), round(2.0 * ref), round(3.0 * ref)
+
+
+def _dims(pole, axis_h, ladder=True):
+    v1, v2, v3 = _volume_ladder(pole, axis_h) if ladder else (None, None, None)
+    return {"pole": pole, "axis_h": axis_h, "v1": v1, "v2": v2, "v3": v3}
+
+
+def instance(seed):
+    rng = random.Random(seed)
+    pole = 18.0 + 0.5 * rng.randrange(13)
+    axis_h = 16.0 + 0.5 * rng.randrange(9)
+    dims = _dims(pole, axis_h)
+    return Instance(
+        seed=seed,
+        dims=dims,
+        instruction=INSTRUCTION.format(**dims),
+        measurements=MEASUREMENTS.format(pole=pole),
+    )
+
+
+def context():
+    """Frozen here, never read from the candidate's card or printer.toml."""
+    return checks.Context()
+
+
+def _cross_sections(shape, bb):
+    """(weights, material polygons) along Y, the polygons in (x, z) coordinates.
+    Stations are feature-aware, not a fixed grid: every distinct mesh-vertex Y plane
+    marks a feature boundary and a station lands in every gap between them, so no
+    printable feature can hide between two stations. Each station carries the length
+    of part it stands for."""
+    mesh = builder.to_mesh(shape, tolerance=0.05)
+    rot = np.array(
+        [[1, 0, 0, 0], [0, 0, -1, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=np.float64
+    )
+    mesh.apply_transform(rot)
+    y0, y1 = bb.min.Y, bb.max.Y
+    planes = np.unique(np.round(mesh.vertices[:, 2], 1))
+    mids = (planes[:-1] + planes[1:]) / 2 + 0.011  # off any face plane
+    uniform = np.arange(y0 + 0.1, y1 - 0.05, 1.0)
+    stations = np.unique(np.concatenate([mids, uniform]))
+    stations = stations[(stations > y0 + 0.02) & (stations < y1 - 0.02)]
+    if len(stations) > 400:
+        stations = stations[:: math.ceil(len(stations) / 400)]
+
+    edges = np.concatenate([[y0], (stations[:-1] + stations[1:]) / 2, [y1]])
+    weights = np.diff(edges)
+
+    paths = mesh.section_multiplane([0, 0, 0], [0, 0, 1], stations)
+    sections = []
+    for path in paths:
+        if path is None:
+            sections.append(None)
+            continue
+        polys = list(path.polygons_full)
+        if not polys:
+            sections.append(None)
+            continue
+        # Snapped to a micron grid: sections of a curved cradle are near-identical
+        # polygons whose iterated set operations otherwise compound vertices without
+        # bound (the lesson bundle_holder's tube cradle taught).
+        sections.append(shapely.set_precision(shapely.union_all(polys), 0.001))
+    # The rotation maps (x, y, z) to (x, -z, y): section coordinates come out as
+    # (x, -z), so flip v to keep the arc math in honest bed coordinates.
+    flipped = [
+        shapely.transform(m, lambda pts: pts * (1.0, -1.0)) if m is not None else None
+        for m in sections
+    ]
+    return weights, flipped
+
+
+def _support(shape, bb, pole, axis_h):
+    """None if the pole is cradled as stated, else what is missing."""
+    r = pole / 2
+    cx = (bb.min.X + bb.max.X) / 2
+    cz = bb.min.Z + axis_h
+    weights, sections = _cross_sections(shape, bb)
+    center = shapely.points([[cx, cz]])[0]
+
+    angles = np.deg2rad(np.arange(0, 360, STEP_DEG))
+    directions = np.stack([np.cos(angles), np.sin(angles)], axis=1)
+    center_xy = np.array([cx, cz])
+    starts = center_xy + (r + FIT_R) * directions
+    ends = center_xy + (r + CONTACT + BACKING + TOL) * directions
+    rays = shapely.linestrings(np.stack([starts, ends], axis=1))
+    need = int(ARC_DEG / STEP_DEG) + 1  # consecutive samples spanning the stated arc
+
+    span = float(weights.sum())
+    held = 0.0
+    for weight, material in zip(weights, sections):
+        if material is None:
+            continue
+        # Fit is exact on the section polygon: the nearest material to the axis must
+        # stay a pole radius plus the stated gap away, at every station.
+        if shapely.distance(material, center) < r + FIT_R:
+            return (
+                f"the pole does not fit: material intrudes within {GAP_MIN} of a "
+                f"{pole} mm pole at the stated axis position"
+            )
+        radial_material = shapely.intersection(material, rays)
+        arc = np.array(
+            [_has_backed_contact(hit, center_xy, r) for hit in radial_material], dtype=bool
+        )
+        # Longest run of supported samples, circularly: doubling the array makes a
+        # wraparound arc an ordinary run.
+        run = best = 0
+        for hit in np.concatenate([arc, arc]):
+            run = run + 1 if hit else 0
+            best = max(best, run)
+        if best >= min(need, len(angles)):
+            held += weight
+    if held + EPS < COVER * span:
+        return (
+            f"the pole is not cradled: a continuous {ARC_DEG:.0f} degree arc of backed "
+            f"contact holds along only {held / span:.0%} of the length, need "
+            f"{COVER:.0%}"
+        )
+    return None
+
+
+def _has_backed_contact(hit, center, pole_r):
+    """Whether one uninterrupted radial material span starts near the pole and is
+    at least the stated backing thickness."""
+    for segment in shapely.get_parts(hit):
+        coords = shapely.get_coordinates(segment)
+        if len(coords) < 2:
+            continue
+        radii = np.linalg.norm(coords - center, axis=1)
+        if radii.min() <= pole_r + CONTACT + TOL and np.ptp(radii) >= BACKING - TOL:
+            return True
+    return False
+
+
+def _drop_in(shape, bb, pole, axis_h):
+    """Whether the pole can lower straight down into the seat: its swept descent,
+    slightly lean so a stated-clearance cradle never collides, must clear the part.
+    A failed boolean counts as a hit."""
+    r = pole / 2 - TOL
+    cx = (bb.min.X + bb.max.X) / 2
+    cz = bb.min.Z + axis_h
+    length = bb.size.Y + 2.0
+    cy = (bb.min.Y + bb.max.Y) / 2
+    top = bb.max.Z + 2.0
+    sweep = Pos(cx, cy, cz) * Rot(90, 0, 0) * Cylinder(r, length)
+    # When the axis sits above the part's top, as an open cradle's does, the descent
+    # above the seat is already outside the part and needs no swept box.
+    if top > cz + EPS:
+        sweep += Pos(cx, cy, (cz + top) / 2) * Box(2 * r, length, top - cz)
+    try:
+        hit = shape & sweep
+        return (hit.volume if hit is not None else 0.0) < 0.05
+    except Exception:
+        return False
+
+
+def misfits(shape, dims):
+    """Everything wrong with the rest, as (problems, total_weight). Entries are
+    (message, weight): fit and the arc are the function and carry the score; length,
+    bed contact, drop-in, and the volume ladder refine it."""
+    problems = []
+    total = 0
+    bb = shape.bounding_box()
+
+    total += 1
+    if bb.size.Y < MIN_LENGTH - TOL:
+        problems.append((f"only {bb.size.Y:.1f} mm long along Y, need {MIN_LENGTH}", 1))
+
+    total += 1
+    bed = sum(
+        face.area
+        for face in shape.faces()
+        if face.geom_type == GeomType.PLANE
+        and abs(face.bounding_box().min.Z - bb.min.Z) < EPS
+        and face.bounding_box().size.Z < EPS
+    )
+    if bed < MIN_BED:
+        problems.append((f"only {bed:.0f} mm2 of flat bottom on the bed, need {MIN_BED:.0f}", 1))
+
+    total += 6
+    miss = _support(shape, bb, dims["pole"], dims["axis_h"])
+    if miss:
+        problems.append((miss, 6))
+
+    total += 2
+    if not _drop_in(shape, bb, dims["pole"], dims["axis_h"]):
+        problems.append(("the pole cannot lower straight down into the seat", 2))
+
+    # The stepped material gradient. Skipped (thresholds None) when re-asserted by
+    # the flex probes: bulk is size-independent and gets charged once.
+    if dims["v1"] is not None:
+        for threshold in (dims["v1"], dims["v2"], dims["v3"]):
+            total += 1
+            if shape.volume > threshold:
+                problems.append(
+                    (f"volume {shape.volume:.0f} mm3 is over the {threshold} mm3 step", 1)
+                )
+
+    return problems, total
+
+
+def flex_probes(inst):
+    out = []
+    for grow in (1.5, -1.5):
+        pole = round(inst.dims["pole"] + grow, 2)
+        out.append(
+            (
+                {"params": {"pole_diameter": pole}},
+                _dims(pole, inst.dims["axis_h"], ladder=False),
+            )
+        )
+    return out
+
+
+def materialize(seed, dest):
+    """Write the project a model starts from: fixture, the seeded measurement, and
+    the same AGENTS.md a real project gets from `nurb new`."""
+    import importlib.resources
+
+    dest = pathlib.Path(dest)
+    fixture = pathlib.Path(__file__).parent / "fixture"
+    shutil.copytree(fixture, dest, dirs_exist_ok=True)
+    (dest / "measurements.toml").write_text(instance(seed).measurements, encoding="utf-8")
+    skill = importlib.resources.files("nurb").joinpath("agents.md").read_text(encoding="utf-8")
+    (dest / "AGENTS.md").write_text(skill, encoding="utf-8")
+    return dest

--- a/evals/tasks/valve_knob/fixture/printer.toml
+++ b/evals/tasks/valve_knob/fixture/printer.toml
@@ -1,0 +1,1 @@
+profile = "bambu_p1s"

--- a/evals/tasks/valve_knob/task.py
+++ b/evals/tasks/valve_knob/task.py
@@ -1,0 +1,292 @@
+"""The valve_knob task: a replacement knob for a measured D-shaft, graded by fit.
+
+The corpus's first mating-fit task. The counterpart is not printed, it is driven: the
+grader builds a virtual D-stem from the measured diameter and across-flat and pushes
+it into the candidate's bore, the way bundle_holder drives a virtual M4. Fit is
+graded from both sides of the tolerance band: the stem grown by the stated clearance
+must pass clean through, and grown by the stated slop it must jam, so a bore that is
+too tight and a bore that rattles both lose. Rotation closes the loop: the same stem
+turned 20 degrees must collide, which only a bore that actually models the flat can
+do; a lazy round bore fits the stem and fails the torque.
+
+Everything is boolean intersections with the actual B-rep, no point grids: material
+anywhere in a swept volume is material, no matter how it dodges a sampler.
+"""
+
+import math
+import pathlib
+import random
+import shutil
+from dataclasses import dataclass
+
+import numpy as np
+import shapely
+from build123d import Box, Cylinder, GeomType, Pos, Rot
+
+from nurb import builder, checks
+
+EPS = 1e-3
+TOL = 0.05
+
+MIN_H = 12.0
+MIN_BED = 300.0  # mm2 of flat bottom on the bed
+ENGAGE = 10.0  # how deep the stem must reach into the bore
+CLEAR = 0.3  # stated diametral clearance the bore must give the stem
+SLOP = 1.0  # stated diametral growth that must jam
+TWIST = 20.0  # degrees the stem is turned for the torque check
+GRIP_MIN = 28.0  # narrowest the knob may be across at grip height
+LOBE = 1.12  # widest reach over narrowest at grip height
+JAM = 0.5  # mm3 of overlap that counts as a real collision, not kernel noise
+
+INSTRUCTION = """\
+Design a replacement knob for a broken valve handle, and save it as
+parts/valve_knob.py.
+
+The valve's stem is a D-shaft measured at {shaft} mm across with {flat} mm across
+the flat; both are on file in measurements.toml as shaft_diameter and
+shaft_across_flat. The stem stands 12.0 proud of the valve body. Model the knob
+bore-up as it prints: the bore opens straight up, on the part's vertical centerline,
+with the stem's flat facing +X; in use the knob flips over onto the stem. What the
+knob looks like is up to you: the grader checks fit and function mechanically, and
+every check it runs is listed below.
+
+Function checks, all units mm:
+- The part prints as it sits: flat on the bed with at least 300 mm2 of bottom face,
+  at least 12.0 tall, one solid, support-free.
+- Fit: the grader drives a virtual stem, grown by 0.3 on both the diameter and the
+  across-flat, straight down the centerline to 10.0 below your top face. It must
+  pass without touching your material, so leave real clearance.
+- No rattle: the same stem grown by 1.0 instead must jam: if it also passes, the
+  bore is too loose to steer the valve.
+- Torque: the 0.3-grown stem, turned 20 degrees about its axis, must collide with
+  your material. A round bore passes the stem at every angle and fails this; only a
+  bore that models the flat transmits torque.
+- Grip: at half the knob's height, the outside must measure at least 28.0 across at
+  its narrowest, and its widest reach from the centerline must be at least 12%
+  past its narrowest: lobes, flats, or a lever arm, so wet hands can turn it.
+- Material economy: total volume at or below {v1} mm3 earns full marks; credit
+  steps down above {v2} and again above {v3}.
+- nurb check must report zero findings. The grader runs the checks itself and
+  ignores the card's [accepted] blocks, so fix findings in the geometry instead of
+  accepting them.
+- Expose shaft_diameter and shaft_across_flat as float parameters and derive the
+  bore from both: the knob must rebuild correctly for nearby stems.
+"""
+
+MEASUREMENTS = """\
+[shaft_diameter]
+value = {shaft}
+unit = "mm"
+how = "calipers across the stem, 2026-08-21"
+
+[shaft_across_flat]
+value = {flat}
+unit = "mm"
+how = "calipers from the flat to the round side, 2026-08-21"
+"""
+
+
+@dataclass(frozen=True)
+class Instance:
+    seed: int
+    dims: dict
+    instruction: str
+    measurements: str
+
+
+def _volume_ladder():
+    """A generous reference: a solid 32 x 14 cylinder of knob."""
+    ref = math.pi * 16.0**2 * 14.0
+    return round(1.2 * ref), round(1.8 * ref), round(2.6 * ref)
+
+
+def _dims(shaft, flat, ladder=True):
+    v1, v2, v3 = _volume_ladder() if ladder else (None, None, None)
+    return {"shaft": shaft, "flat": flat, "v1": v1, "v2": v2, "v3": v3}
+
+
+def instance(seed):
+    rng = random.Random(seed)
+    shaft = 6.0 + 0.5 * rng.randrange(9)
+    flat = round(shaft - 1.0 - 0.25 * rng.randrange(5), 2)
+    dims = _dims(shaft, flat)
+    return Instance(
+        seed=seed,
+        dims=dims,
+        instruction=INSTRUCTION.format(**dims),
+        measurements=MEASUREMENTS.format(shaft=shaft, flat=flat),
+    )
+
+
+def context():
+    """Frozen here, never read from the candidate's card or printer.toml."""
+    return checks.Context()
+
+
+def _stem(shaft, flat, grow, height):
+    """The virtual D-stem at the origin, axis +Z, flat facing +X, grown by `grow`
+    on both measurements. One gapless solid, like bundle_holder's virtual screw."""
+    radius = shaft / 2 + grow / 2
+    offset = (flat - shaft / 2) + grow / 2  # the flat's distance from the axis
+    body = Cylinder(radius, height)
+    # The box's near face lands exactly on the flat plane.
+    cut = Pos(offset + (radius + 1.0) / 2, 0, 0) * Box(
+        radius + 1.0, 2 * radius + 2.0, height + 1.0
+    )
+    return body - cut
+
+
+def _overlap(shape, tool):
+    """Material the tool hits, in mm3. A failed boolean counts as a full jam for
+    probes that must clear, and as no jam for probes that must collide, so a crash
+    never helps the candidate; callers pick the reading."""
+    hit = shape & tool
+    return hit.volume if hit is not None else 0.0
+
+
+def _drive(shape, bb, dims, grow, twist=0.0):
+    """Overlap between the part and the grown, optionally twisted stem, driven down
+    the centerline to ENGAGE below the top face, entering from above the part."""
+    cx = (bb.min.X + bb.max.X) / 2
+    cy = (bb.min.Y + bb.max.Y) / 2
+    height = ENGAGE + 2.0
+    tool = (
+        Pos(cx, cy, bb.max.Z - ENGAGE + height / 2)
+        * Rot(0, 0, twist)
+        * _stem(dims["shaft"], dims["flat"], grow, height)
+    )
+    try:
+        return _overlap(shape, tool)
+    except Exception:
+        return None
+
+
+def _grip(shape, bb):
+    """(narrowest across, widest over narrowest) of the outer profile at half
+    height, from a meshed section: the outer ring's nearest and farthest points from
+    the centerline."""
+    mesh = builder.to_mesh(shape, tolerance=0.05)
+    cx = (bb.min.X + bb.max.X) / 2
+    cy = (bb.min.Y + bb.max.Y) / 2
+    z = (bb.min.Z + bb.max.Z) / 2 + 0.013  # off any face plane
+    paths = mesh.section_multiplane([0, 0, z], [0, 0, 1], [0.0])
+    if not paths or paths[0] is None:
+        return 0.0, 0.0
+    polys = list(paths[0].polygons_full)
+    if not polys:
+        return 0.0, 0.0
+    outer = max(polys, key=lambda p: p.area).exterior
+    center = shapely.points([[cx, cy]])[0]
+    nearest = shapely.distance(outer, center)
+    coords = np.asarray(outer.coords)
+    farthest = float(np.max(np.hypot(coords[:, 0] - cx, coords[:, 1] - cy)))
+    return 2 * nearest, farthest / max(nearest, EPS)
+
+
+def misfits(shape, dims):
+    """Everything wrong with the knob, as (problems, total_weight). Entries are
+    (message, weight): the fit band and the torque are the function and carry the
+    score; height, bed contact, grip, and the volume ladder refine it."""
+    problems = []
+    total = 0
+    bb = shape.bounding_box()
+
+    total += 1
+    if bb.size.Z < MIN_H - TOL:
+        problems.append((f"only {bb.size.Z:.1f} mm tall, need {MIN_H}", 1))
+
+    total += 1
+    bed = sum(
+        face.area
+        for face in shape.faces()
+        if face.geom_type == GeomType.PLANE
+        and abs(face.bounding_box().min.Z - bb.min.Z) < EPS
+        and face.bounding_box().size.Z < EPS
+    )
+    if bed < MIN_BED:
+        problems.append((f"only {bed:.0f} mm2 of flat bottom on the bed, need {MIN_BED:.0f}", 1))
+
+    total += 3
+    fit = _drive(shape, bb, dims, CLEAR)
+    if fit is None or fit > TOL:
+        problems.append(
+            (
+                f"the stem does not fit: the {CLEAR}-grown stem hits material on its "
+                f"way to {ENGAGE} below the top face",
+                3,
+            )
+        )
+
+    total += 2
+    slop = _drive(shape, bb, dims, SLOP)
+    if slop is not None and slop < JAM:
+        problems.append(
+            (f"the bore rattles: even the {SLOP}-grown stem passes clean through", 2)
+        )
+
+    total += 3
+    jams = [_drive(shape, bb, dims, CLEAR, twist=sign * TWIST) for sign in (1, -1)]
+    if any(jam is not None and jam < JAM for jam in jams):
+        problems.append(
+            (
+                f"no torque: the stem turned {TWIST:.0f} degrees still passes, so the "
+                f"bore never engages the flat",
+                3,
+            )
+        )
+
+    across, lobe = _grip(shape, bb)
+    total += 1
+    if across < GRIP_MIN - TOL:
+        problems.append(
+            (f"only {across:.1f} mm across at grip height, need {GRIP_MIN}", 1)
+        )
+    total += 2
+    if lobe < LOBE - 0.005:
+        problems.append(
+            (
+                f"nothing to grip: the profile at half height is {lobe:.2f}x its "
+                f"narrowest, need {LOBE:.2f}x",
+                2,
+            )
+        )
+
+    # The stepped material gradient. Skipped (thresholds None) when re-asserted by
+    # the flex probes: bulk is size-independent and gets charged once.
+    if dims["v1"] is not None:
+        for threshold in (dims["v1"], dims["v2"], dims["v3"]):
+            total += 1
+            if shape.volume > threshold:
+                problems.append(
+                    (f"volume {shape.volume:.0f} mm3 is over the {threshold} mm3 step", 1)
+                )
+
+    return problems, total
+
+
+def flex_probes(inst):
+    shaft, flat = inst.dims["shaft"], inst.dims["flat"]
+    out = []
+    for d_grow, f_grow in ((0.5, 0.5), (1.0, 0.75)):
+        d, f = round(shaft + d_grow, 2), round(flat + f_grow, 2)
+        out.append(
+            (
+                {"params": {"shaft_diameter": d, "shaft_across_flat": f}},
+                _dims(d, f, ladder=False),
+            )
+        )
+    return out
+
+
+def materialize(seed, dest):
+    """Write the project a model starts from: fixture, the seeded measurements, and
+    the same AGENTS.md a real project gets from `nurb new`."""
+    import importlib.resources
+
+    dest = pathlib.Path(dest)
+    fixture = pathlib.Path(__file__).parent / "fixture"
+    shutil.copytree(fixture, dest, dirs_exist_ok=True)
+    (dest / "measurements.toml").write_text(instance(seed).measurements, encoding="utf-8")
+    skill = importlib.resources.files("nurb").joinpath("agents.md").read_text(encoding="utf-8")
+    (dest / "AGENTS.md").write_text(skill, encoding="utf-8")
+    return dest

--- a/evals/tests/solutions/bit_block/bottom_chamfer.py
+++ b/evals/tests/solutions/bit_block/bottom_chamfer.py
@@ -1,0 +1,24 @@
+"""Breaks the bottom perimeter too, against the stated sharp bottom."""
+
+from nurb import *
+
+
+@part
+def bit_block(shank_diameter=6.5, columns=5):
+    web, depth, floor, cham = 2.0, 12.0, 3.0, 0.8
+    pocket_d = shank_diameter + 0.3
+    r = pocket_d / 2
+    pitch = pocket_d + web
+    x = columns * pitch + web
+    y = 2 * pitch + web
+    z = floor + depth
+    body = Pos(x / 2, y / 2, z / 2) * Box(x, y, z)
+    for col in range(columns):
+        for row in range(2):
+            cx = web + r + col * pitch
+            cy = web + r + row * pitch
+            body -= Pos(cx, cy, z - depth / 2) * Cylinder(r, depth)
+    top = body.faces().sort_by(Axis.Z)[-1]
+    body = chamfer(top.edges(), cham)
+    bottom = body.faces().sort_by(Axis.Z)[0]
+    return chamfer(bottom.edges(), cham)

--- a/evals/tests/solutions/bit_block/good.py
+++ b/evals/tests/solutions/bit_block/good.py
@@ -1,0 +1,25 @@
+"""The reference solution: everything the task asks for, nothing else. The mouth
+rims and the top perimeter all border the top face, so one chamfer call over that
+face's edges is the whole finishing pass."""
+
+from nurb import *
+
+
+@part
+def bit_block(shank_diameter=6.5, columns=5):
+    """shank_diameter: bit shank across, from measurements.toml"""
+    web, depth, floor, cham = 2.0, 12.0, 3.0, 0.8
+    pocket_d = shank_diameter + 0.3
+    r = pocket_d / 2
+    pitch = pocket_d + web
+    x = columns * pitch + web
+    y = 2 * pitch + web
+    z = floor + depth
+    body = Pos(x / 2, y / 2, z / 2) * Box(x, y, z)
+    for col in range(columns):
+        for row in range(2):
+            cx = web + r + col * pitch
+            cy = web + r + row * pitch
+            body -= Pos(cx, cy, z - depth / 2) * Cylinder(r, depth)
+    top = body.faces().sort_by(Axis.Z)[-1]
+    return chamfer(top.edges(), cham)

--- a/evals/tests/solutions/bit_block/hand_grid.py
+++ b/evals/tests/solutions/bit_block/hand_grid.py
@@ -1,0 +1,24 @@
+"""Derives everything from the shank but wrote the grid out by hand: five columns
+forever, whatever the columns parameter says. The column flex probes exist for
+exactly this part."""
+
+from nurb import *
+
+
+@part
+def bit_block(shank_diameter=6.5, columns=5):
+    web, depth, floor, cham = 2.0, 12.0, 3.0, 0.8
+    pocket_d = shank_diameter + 0.3
+    r = pocket_d / 2
+    pitch = pocket_d + web
+    x = 5 * pitch + web
+    y = 2 * pitch + web
+    z = floor + depth
+    body = Pos(x / 2, y / 2, z / 2) * Box(x, y, z)
+    for col in range(5):
+        for row in range(2):
+            cx = web + r + col * pitch
+            cy = web + r + row * pitch
+            body -= Pos(cx, cy, z - depth / 2) * Cylinder(r, depth)
+    top = body.faces().sort_by(Axis.Z)[-1]
+    return chamfer(top.edges(), cham)

--- a/evals/tests/solutions/bit_block/hardcoded.py
+++ b/evals/tests/solutions/bit_block/hardcoded.py
@@ -1,0 +1,22 @@
+"""Right at the stated size, deaf to both parameters."""
+
+from nurb import *
+
+
+@part
+def bit_block(shank_diameter=6.5, columns=5):
+    web, depth, floor, cham = 2.0, 12.0, 3.0, 0.8
+    pocket_d = 6.8
+    r = pocket_d / 2
+    pitch = 8.8
+    x = 46.0
+    y = 19.6
+    z = floor + depth
+    body = Pos(x / 2, y / 2, z / 2) * Box(x, y, z)
+    for col in range(5):
+        for row in range(2):
+            cx = web + r + col * pitch
+            cy = web + r + row * pitch
+            body -= Pos(cx, cy, z - depth / 2) * Cylinder(r, depth)
+    top = body.faces().sort_by(Axis.Z)[-1]
+    return chamfer(top.edges(), cham)

--- a/evals/tests/solutions/bit_block/no_chamfer.py
+++ b/evals/tests/solutions/bit_block/no_chamfer.py
@@ -1,0 +1,21 @@
+"""Skips the finishing pass entirely: no lead-ins, no perimeter chamfer."""
+
+from nurb import *
+
+
+@part
+def bit_block(shank_diameter=6.5, columns=5):
+    web, depth, floor = 2.0, 12.0, 3.0
+    pocket_d = shank_diameter + 0.3
+    r = pocket_d / 2
+    pitch = pocket_d + web
+    x = columns * pitch + web
+    y = 2 * pitch + web
+    z = floor + depth
+    body = Pos(x / 2, y / 2, z / 2) * Box(x, y, z)
+    for col in range(columns):
+        for row in range(2):
+            cx = web + r + col * pitch
+            cy = web + r + row * pitch
+            body -= Pos(cx, cy, z - depth / 2) * Cylinder(r, depth)
+    return body

--- a/evals/tests/solutions/bit_block/notched.py
+++ b/evals/tests/solutions/bit_block/notched.py
@@ -1,0 +1,24 @@
+"""A full-height notch in one side leaves the bounding box unchanged but makes
+the bottom concave instead of the required full rectangular footprint."""
+
+from nurb import *
+
+
+@part
+def bit_block(shank_diameter=6.5, columns=5):
+    web, depth, floor, cham = 2.0, 12.0, 3.0, 0.8
+    pocket_d = shank_diameter + 0.3
+    r = pocket_d / 2
+    pitch = pocket_d + web
+    x = columns * pitch + web
+    y = 2 * pitch + web
+    z = floor + depth
+    body = Pos(x / 2, y / 2, z / 2) * Box(x, y, z)
+    for col in range(columns):
+        for row in range(2):
+            cx = web + r + col * pitch
+            cy = web + r + row * pitch
+            body -= Pos(cx, cy, z - depth / 2) * Cylinder(r, depth)
+    top = body.faces().sort_by(Axis.Z)[-1]
+    body = chamfer(top.edges(), cham)
+    return body - Pos(0.5, y / 2, z / 2) * Box(1.0, 2.0, z)

--- a/evals/tests/solutions/bit_block/roofed.py
+++ b/evals/tests/solutions/bit_block/roofed.py
@@ -1,0 +1,23 @@
+"""A 1mm lid over every pocket: the bounding box, grid, and volume all read right,
+and no bit can ever go in. The drop-in probe is what has to catch this."""
+
+from nurb import *
+
+
+@part
+def bit_block(shank_diameter=6.5, columns=5):
+    web, depth, floor, cham = 2.0, 12.0, 3.0, 0.8
+    pocket_d = shank_diameter + 0.3
+    r = pocket_d / 2
+    pitch = pocket_d + web
+    x = columns * pitch + web
+    y = 2 * pitch + web
+    z = floor + depth
+    body = Pos(x / 2, y / 2, z / 2) * Box(x, y, z)
+    for col in range(columns):
+        for row in range(2):
+            cx = web + r + col * pitch
+            cy = web + r + row * pitch
+            body -= Pos(cx, cy, z - 1.0 - (depth - 1.0) / 2) * Cylinder(r, depth - 1.0)
+    top = body.faces().sort_by(Axis.Z)[-1]
+    return chamfer(top.edges(), cham)

--- a/evals/tests/solutions/bit_block/shallow.py
+++ b/evals/tests/solutions/bit_block/shallow.py
@@ -1,0 +1,22 @@
+"""Pockets 3mm short of the stated depth; everything else exact."""
+
+from nurb import *
+
+
+@part
+def bit_block(shank_diameter=6.5, columns=5):
+    web, depth, floor, cham = 2.0, 9.0, 3.0, 0.8
+    pocket_d = shank_diameter + 0.3
+    r = pocket_d / 2
+    pitch = pocket_d + web
+    x = columns * pitch + web
+    y = 2 * pitch + web
+    z = floor + 12.0
+    body = Pos(x / 2, y / 2, z / 2) * Box(x, y, z)
+    for col in range(columns):
+        for row in range(2):
+            cx = web + r + col * pitch
+            cy = web + r + row * pitch
+            body -= Pos(cx, cy, z - depth / 2) * Cylinder(r, depth)
+    top = body.faces().sort_by(Axis.Z)[-1]
+    return chamfer(top.edges(), cham)

--- a/evals/tests/solutions/bit_block/shifted_grid.py
+++ b/evals/tests/solutions/bit_block/shifted_grid.py
@@ -1,0 +1,25 @@
+"""The stated bounding box with the whole grid slid 0.25 in X: 2.25 of border on one
+side, 1.75 on the other. Only the grid derivation from the borders catches it. A
+0.5 slide does not even build: the 1.5 border cannot host both chamfers, which is
+the adjacency limit this task is built around."""
+
+from nurb import *
+
+
+@part
+def bit_block(shank_diameter=6.5, columns=5):
+    web, depth, floor, cham = 2.0, 12.0, 3.0, 0.8
+    pocket_d = shank_diameter + 0.3
+    r = pocket_d / 2
+    pitch = pocket_d + web
+    x = columns * pitch + web
+    y = 2 * pitch + web
+    z = floor + depth
+    body = Pos(x / 2, y / 2, z / 2) * Box(x, y, z)
+    for col in range(columns):
+        for row in range(2):
+            cx = web + 0.25 + r + col * pitch
+            cy = web + r + row * pitch
+            body -= Pos(cx, cy, z - depth / 2) * Cylinder(r, depth)
+    top = body.faces().sort_by(Axis.Z)[-1]
+    return chamfer(top.edges(), cham)

--- a/evals/tests/solutions/pole_rest/bulky.py
+++ b/evals/tests/solutions/pole_rest/bulky.py
@@ -1,0 +1,14 @@
+"""A perfect cradle in three times the block: every functional gate passes and the
+material ladder charges the bulk."""
+
+from nurb import *
+
+
+@part
+def pole_rest(pole_diameter=22.0):
+    length, axis_h = 20.0, 18.0
+    r = pole_diameter / 2 + 0.2
+    width = 3 * (2 * r + 4.8)
+    top = axis_h - 0.34 * r
+    body = Pos(0, 0, top / 2) * Box(width, length, top)
+    return body - Pos(0, 0, axis_h) * Rot(90, 0, 0) * Cylinder(r, length + 2)

--- a/evals/tests/solutions/pole_rest/film.py
+++ b/evals/tests/solutions/pole_rest/film.py
@@ -1,0 +1,16 @@
+"""A 0.6mm shell tracing the perfect arc on a pedestal: contact everywhere, nothing
+behind it. The backing probe is what has to see through this."""
+
+from nurb import *
+
+
+@part
+def pole_rest(pole_diameter=22.0):
+    length, axis_h = 20.0, 18.0
+    r = pole_diameter / 2 + 0.3
+    shell = Pos(0, 0, axis_h) * Rot(90, 0, 0) * Cylinder(r + 0.6, length)
+    shell -= Pos(0, 0, axis_h) * Rot(90, 0, 0) * Cylinder(r, length + 2)
+    shell -= Pos(0, 0, axis_h - 0.34 * r + 50) * Box(2 * r + 4, length + 2, 100)
+    base_top = axis_h - pole_diameter / 2 - 0.4
+    base = Pos(0, 0, base_top / 2) * Box(12, length, base_top)
+    return shell + base

--- a/evals/tests/solutions/pole_rest/good.py
+++ b/evals/tests/solutions/pole_rest/good.py
@@ -1,0 +1,17 @@
+"""The reference solution: a block with the pole's own curve cut out of it. The
+cradle radius rides the measured diameter, the rim stops where a 140 degree arc of
+contact remains, and nothing else exists."""
+
+from nurb import *
+
+
+@part
+def pole_rest(pole_diameter=22.0):
+    """pole_diameter: pole across, from measurements.toml"""
+    gap, wall, length, axis_h = 0.2, 2.4, 20.0, 18.0
+    r = pole_diameter / 2 + gap
+    width = 2 * r + 2 * wall
+    top = axis_h - 0.34 * r
+    body = Pos(0, 0, top / 2) * Box(width, length, top)
+    pocket = Pos(0, 0, axis_h) * Rot(90, 0, 0) * Cylinder(r, length + 2)
+    return body - pocket

--- a/evals/tests/solutions/pole_rest/hardcoded.py
+++ b/evals/tests/solutions/pole_rest/hardcoded.py
@@ -1,0 +1,13 @@
+"""The right cradle at the stated size, deaf to the parameter."""
+
+from nurb import *
+
+
+@part
+def pole_rest(pole_diameter=22.0):
+    length, axis_h = 20.0, 18.0
+    r = 11.2
+    width = 2 * r + 4.8
+    top = axis_h - 0.34 * r
+    body = Pos(0, 0, top / 2) * Box(width, length, top)
+    return body - Pos(0, 0, axis_h) * Rot(90, 0, 0) * Cylinder(r, length + 2)

--- a/evals/tests/solutions/pole_rest/hollow_backing.py
+++ b/evals/tests/solutions/pole_rest/hollow_backing.py
@@ -1,0 +1,19 @@
+"""Two thin radial skins connected only at the base: contact and backing probes
+both hit material, but an air gap separates them around the support arc."""
+
+from nurb import *
+
+
+@part
+def pole_rest(pole_diameter=22.0):
+    length, axis_h = 20.0, 18.0
+    r = pole_diameter / 2 + 0.2
+    inner = Pos(0, 0, axis_h) * Rot(90, 0, 0) * Cylinder(r + 0.3, length)
+    inner -= Pos(0, 0, axis_h) * Rot(90, 0, 0) * Cylinder(r, length + 2)
+    outer = Pos(0, 0, axis_h) * Rot(90, 0, 0) * Cylinder(r + 1.5, length)
+    outer -= Pos(0, 0, axis_h) * Rot(90, 0, 0) * Cylinder(r + 1.2, length + 2)
+    cutoff = axis_h - 0.34 * r
+    clip = Pos(0, 0, cutoff / 2) * Box(2 * (r + 2), length + 2, cutoff)
+    base_top = axis_h - r - 0.25
+    base = Pos(0, 0, base_top / 2) * Box(16.0, length, base_top)
+    return (inner & clip) + (outer & clip) + base

--- a/evals/tests/solutions/pole_rest/polished.py
+++ b/evals/tests/solutions/pole_rest/polished.py
@@ -1,0 +1,17 @@
+"""The reference cradle with the doctrine's finishing pass on its outside edges.
+Every stated gate must survive a polish: the arc lives in the pocket, which the
+chamfers never touch."""
+
+from nurb import *
+
+
+@part
+def pole_rest(pole_diameter=22.0):
+    gap, wall, length, axis_h = 0.2, 2.4, 20.0, 18.0
+    r = pole_diameter / 2 + gap
+    width = 2 * r + 2 * wall
+    top = axis_h - 0.34 * r
+    body = Pos(0, 0, top / 2) * Box(width, length, top)
+    body -= Pos(0, 0, axis_h) * Rot(90, 0, 0) * Cylinder(r, length + 2)
+    outer = body.edges().filter_by(Axis.Z)
+    return chamfer(outer, 1.0)

--- a/evals/tests/solutions/pole_rest/short.py
+++ b/evals/tests/solutions/pole_rest/short.py
@@ -1,0 +1,13 @@
+"""A perfect cradle, 12mm long against the stated 20."""
+
+from nurb import *
+
+
+@part
+def pole_rest(pole_diameter=22.0):
+    length, axis_h = 12.0, 18.0
+    r = pole_diameter / 2 + 0.2
+    width = 2 * r + 4.8
+    top = axis_h - 0.34 * r
+    body = Pos(0, 0, top / 2) * Box(width, length, top)
+    return body - Pos(0, 0, axis_h) * Rot(90, 0, 0) * Cylinder(r, length + 2)

--- a/evals/tests/solutions/pole_rest/tunnel.py
+++ b/evals/tests/solutions/pole_rest/tunnel.py
@@ -1,0 +1,13 @@
+"""A closed ring around the pole: fit and arc are immaculate and the pole can never
+be laid in. The drop-in sweep is what has to catch it."""
+
+from nurb import *
+
+
+@part
+def pole_rest(pole_diameter=22.0):
+    length, axis_h = 20.0, 18.0
+    r = pole_diameter / 2 + 0.2
+    body = Pos(0, 0, (axis_h + r + 2.4) / 2) * Box(2 * r + 4.8, length, axis_h + r + 2.4)
+    body -= Pos(0, 0, axis_h) * Rot(90, 0, 0) * Cylinder(r, length + 2)
+    return body

--- a/evals/tests/solutions/pole_rest/u_channel.py
+++ b/evals/tests/solutions/pole_rest/u_channel.py
@@ -1,0 +1,15 @@
+"""The other prismatic answer: a square channel, floor and walls at the stated
+clearance. Touch at three lines, no arc."""
+
+from nurb import *
+
+
+@part
+def pole_rest(pole_diameter=22.0):
+    wall, length, axis_h = 2.4, 20.0, 18.0
+    r = pole_diameter / 2 + 0.2
+    width = 2 * r + 2 * wall
+    top = 13.0
+    body = Pos(0, 0, top / 2) * Box(width, length, top)
+    body -= Pos(0, 0, (axis_h - r + top + 2) / 2) * Box(2 * r, length + 2, top + 2 - (axis_h - r))
+    return body

--- a/evals/tests/solutions/pole_rest/v_block.py
+++ b/evals/tests/solutions/pole_rest/v_block.py
@@ -1,0 +1,17 @@
+"""The classic prismatic answer: a 90 degree V-block, walls tangent to the pole
+with the stated clearance. The pole sits at exactly the right height and touches
+along two lines; the arc gate is what has to reject it."""
+
+from nurb import *
+
+
+@part
+def pole_rest(pole_diameter=22.0):
+    length, axis_h = 20.0, 18.0
+    r = pole_diameter / 2 + 0.2
+    vertex = axis_h - r * 2**0.5
+    body = Pos(0, 0, 6.5) * Box(34, length, 13)
+    # The vee is a diamond: a square prism stood on its corner, walls at 45 degrees
+    # through the vertex, tangent to the pole's clearance circle.
+    body -= Pos(0, 0, vertex + 50 / 2**0.5) * Rot(0, 45, 0) * Box(50, length + 2, 50)
+    return body

--- a/evals/tests/solutions/valve_knob/bulky.py
+++ b/evals/tests/solutions/valve_knob/bulky.py
@@ -1,0 +1,18 @@
+"""A perfect knob at nearly a hand's width: every functional gate passes and the
+material ladder charges the bulk."""
+
+import math
+
+from nurb import *
+
+
+@part
+def valve_knob(shaft_diameter=8.0, shaft_across_flat=6.5):
+    height, across_flats, clearance = 16.0, 46.0, 0.5
+    bore_r = shaft_diameter / 2 + clearance / 2
+    flat_x = (shaft_across_flat - shaft_diameter / 2) + clearance / 2
+    body = extrude(RegularPolygon(across_flats / math.sqrt(3), 6), height)
+    bore = Cylinder(bore_r, height + 2) - Pos(flat_x + 2, 0, 0) * Box(
+        4, 2 * bore_r + 2, height + 3
+    )
+    return body - Pos(0, 0, height / 2) * bore

--- a/evals/tests/solutions/valve_knob/good.py
+++ b/evals/tests/solutions/valve_knob/good.py
@@ -1,0 +1,21 @@
+"""The reference solution: a hex knob with a snug D-bore. The hexagon is the grip
+(across-flats 30, corners 15.5% past the flats) and the bore gives the stem 0.5 of
+diametral clearance, inside the stated 0.3 to 1.0 band."""
+
+import math
+
+from nurb import *
+
+
+@part
+def valve_knob(shaft_diameter=8.0, shaft_across_flat=6.5):
+    """shaft_diameter, shaft_across_flat: the valve stem's D-section, from
+    measurements.toml"""
+    height, across_flats, clearance = 14.0, 30.0, 0.5
+    bore_r = shaft_diameter / 2 + clearance / 2
+    flat_x = (shaft_across_flat - shaft_diameter / 2) + clearance / 2
+    body = extrude(RegularPolygon(across_flats / math.sqrt(3), 6), height)
+    bore = Cylinder(bore_r, height + 2) - Pos(flat_x + 2, 0, 0) * Box(
+        4, 2 * bore_r + 2, height + 3
+    )
+    return body - Pos(0, 0, height / 2) * bore

--- a/evals/tests/solutions/valve_knob/hardcoded.py
+++ b/evals/tests/solutions/valve_knob/hardcoded.py
@@ -1,0 +1,17 @@
+"""The right knob at the stated stem, deaf to both parameters."""
+
+import math
+
+from nurb import *
+
+
+@part
+def valve_knob(shaft_diameter=8.0, shaft_across_flat=6.5):
+    height, across_flats = 14.0, 30.0
+    bore_r = 4.25
+    flat_x = 2.75
+    body = extrude(RegularPolygon(across_flats / math.sqrt(3), 6), height)
+    bore = Cylinder(bore_r, height + 2) - Pos(flat_x + 2, 0, 0) * Box(
+        4, 2 * bore_r + 2, height + 3
+    )
+    return body - Pos(0, 0, height / 2) * bore

--- a/evals/tests/solutions/valve_knob/no_grip.py
+++ b/evals/tests/solutions/valve_knob/no_grip.py
@@ -1,0 +1,15 @@
+"""A perfect bore in a plain round puck: nothing for wet hands to push against."""
+
+from nurb import *
+
+
+@part
+def valve_knob(shaft_diameter=8.0, shaft_across_flat=6.5):
+    height, clearance = 14.0, 0.5
+    bore_r = shaft_diameter / 2 + clearance / 2
+    flat_x = (shaft_across_flat - shaft_diameter / 2) + clearance / 2
+    body = Pos(0, 0, height / 2) * Cylinder(16.0, height)
+    bore = Cylinder(bore_r, height + 2) - Pos(flat_x + 2, 0, 0) * Box(
+        4, 2 * bore_r + 2, height + 3
+    )
+    return body - Pos(0, 0, height / 2) * bore

--- a/evals/tests/solutions/valve_knob/polished.py
+++ b/evals/tests/solutions/valve_knob/polished.py
@@ -1,0 +1,22 @@
+"""The reference knob with the doctrine's finishing pass on the top perimeter.
+Every stated gate must survive a polish: the grip is measured at half height, below
+any chamfer's reach."""
+
+import math
+
+from nurb import *
+
+
+@part
+def valve_knob(shaft_diameter=8.0, shaft_across_flat=6.5):
+    height, across_flats, clearance = 14.0, 30.0, 0.5
+    bore_r = shaft_diameter / 2 + clearance / 2
+    flat_x = (shaft_across_flat - shaft_diameter / 2) + clearance / 2
+    body = extrude(RegularPolygon(across_flats / math.sqrt(3), 6), height)
+    bore = Cylinder(bore_r, height + 2) - Pos(flat_x + 2, 0, 0) * Box(
+        4, 2 * bore_r + 2, height + 3
+    )
+    body -= Pos(0, 0, height / 2) * bore
+    top = body.faces().sort_by(Axis.Z)[-1]
+    rim = [e for e in top.edges() if e.length > 5.0]  # the outer perimeter, not the bore
+    return chamfer(rim, 1.0)

--- a/evals/tests/solutions/valve_knob/round_bore.py
+++ b/evals/tests/solutions/valve_knob/round_bore.py
@@ -1,0 +1,14 @@
+"""The lazy bore: a plain cylinder at the right clearance. The stem slides in and
+spins forever; only the torque check knows."""
+
+import math
+
+from nurb import *
+
+
+@part
+def valve_knob(shaft_diameter=8.0, shaft_across_flat=6.5):
+    height, across_flats = 14.0, 30.0
+    bore_r = shaft_diameter / 2 + 0.25
+    body = extrude(RegularPolygon(across_flats / math.sqrt(3), 6), height)
+    return body - Pos(0, 0, height / 2) * Cylinder(bore_r, height + 2)

--- a/evals/tests/solutions/valve_knob/sloppy.py
+++ b/evals/tests/solutions/valve_knob/sloppy.py
@@ -1,0 +1,18 @@
+"""A bore at 1.4 of diametral clearance: past the stated 1.0, a knob that rattles.
+The slop stem passes clean through, which is exactly the charge."""
+
+import math
+
+from nurb import *
+
+
+@part
+def valve_knob(shaft_diameter=8.0, shaft_across_flat=6.5):
+    height, across_flats, clearance = 14.0, 30.0, 1.4
+    bore_r = shaft_diameter / 2 + clearance / 2
+    flat_x = (shaft_across_flat - shaft_diameter / 2) + clearance / 2
+    body = extrude(RegularPolygon(across_flats / math.sqrt(3), 6), height)
+    bore = Cylinder(bore_r, height + 2) - Pos(flat_x + 2, 0, 0) * Box(
+        4, 2 * bore_r + 2, height + 3
+    )
+    return body - Pos(0, 0, height / 2) * bore

--- a/evals/tests/solutions/valve_knob/tight.py
+++ b/evals/tests/solutions/valve_knob/tight.py
@@ -1,0 +1,18 @@
+"""A bore at 0.1 of diametral clearance: below the stated 0.3 band, so the printed
+knob would never go on. The grown fit stem is what has to jam here."""
+
+import math
+
+from nurb import *
+
+
+@part
+def valve_knob(shaft_diameter=8.0, shaft_across_flat=6.5):
+    height, across_flats, clearance = 14.0, 30.0, 0.1
+    bore_r = shaft_diameter / 2 + clearance / 2
+    flat_x = (shaft_across_flat - shaft_diameter / 2) + clearance / 2
+    body = extrude(RegularPolygon(across_flats / math.sqrt(3), 6), height)
+    bore = Cylinder(bore_r, height + 2) - Pos(flat_x + 2, 0, 0) * Box(
+        4, 2 * bore_r + 2, height + 3
+    )
+    return body - Pos(0, 0, height / 2) * bore

--- a/evals/tests/solutions/valve_knob/wrong_flat.py
+++ b/evals/tests/solutions/valve_knob/wrong_flat.py
@@ -1,0 +1,18 @@
+"""The right bore with the flat facing -X against the stated +X: the knob only goes
+on one way, and this is the other way."""
+
+import math
+
+from nurb import *
+
+
+@part
+def valve_knob(shaft_diameter=8.0, shaft_across_flat=6.5):
+    height, across_flats, clearance = 14.0, 30.0, 0.5
+    bore_r = shaft_diameter / 2 + clearance / 2
+    flat_x = (shaft_across_flat - shaft_diameter / 2) + clearance / 2
+    body = extrude(RegularPolygon(across_flats / math.sqrt(3), 6), height)
+    bore = Cylinder(bore_r, height + 2) - Pos(-(flat_x + 2), 0, 0) * Box(
+        4, 2 * bore_r + 2, height + 3
+    )
+    return body - Pos(0, 0, height / 2) * bore

--- a/evals/tests/test_bit_block.py
+++ b/evals/tests/test_bit_block.py
@@ -1,0 +1,120 @@
+"""Fairness suite for bit_block, the chamfer-dense spec task.
+
+Every flawed solution is a negative control: each flaw must be caught in the stage
+built to catch it, and the totals must order the way a user would rank the blocks.
+The suite also pins the task's reason to exist: a grid slid far enough into a border
+that both chamfers no longer fit does not build at all, which is the OCCT adjacency
+limit the task holds the candidate against.
+"""
+
+import pathlib
+
+import pytest
+
+from nurb_evals import scoring
+
+EVALS = pathlib.Path(__file__).parents[1]
+TASK = EVALS / "tasks" / "bit_block"
+SOLUTIONS = pathlib.Path(__file__).parent / "solutions" / "bit_block"
+
+task = scoring.load_task(TASK)
+
+# The reference solutions are written for a 6.5mm shank in five columns, so the tests
+# pin the seed that produces one rather than hardcoding a magic number that could
+# drift.
+SEED = next(
+    s
+    for s in range(1000)
+    if task.instance(s).dims["shank"] == 6.5 and task.instance(s).dims["cols"] == 5
+)
+
+
+@pytest.fixture(scope="module")
+def grades():
+    names = (
+        "good",
+        "no_chamfer",
+        "hardcoded",
+        "hand_grid",
+        "shallow",
+        "roofed",
+        "shifted_grid",
+        "bottom_chamfer",
+        "notched",
+    )
+    return {name: scoring.grade(SOLUTIONS / f"{name}.py", TASK, SEED) for name in names}
+
+
+def test_the_reference_solution_scores_full_marks(grades):
+    result = grades["good"]
+    assert result["score"] == 1.0, result
+    assert result["stages"] == {"lint": 1.0, "dims": 1.0, "flex": 1.0}
+    assert result["misfits"] == [] and result["findings"] == []
+
+
+def test_missing_chamfers_lose_the_finishing_checks(grades):
+    result = grades["no_chamfer"]
+    assert result["stages"]["dims"] < 1.0
+    assert any("lead-in chamfer" in m for m in result["misfits"])
+    assert any("top perimeter" in m for m in result["misfits"])
+
+
+def test_hardcoded_dimensions_are_right_once_and_track_nothing(grades):
+    result = grades["hardcoded"]
+    assert result["stages"]["dims"] == 1.0
+    assert result["stages"]["flex"] == 0.0
+
+
+def test_a_hand_written_grid_fails_exactly_the_column_probes(grades):
+    result = grades["hand_grid"]
+    assert result["stages"]["dims"] == 1.0
+    assert result["stages"]["flex"] == pytest.approx(1 / 3, abs=1e-3)
+    assert all("columns" in p for p in result["flex_problems"])
+
+
+def test_shallow_pockets_miss_floor_rim_probe_and_volume(grades):
+    result = grades["shallow"]
+    assert any("floor rim" in m for m in result["misfits"])
+    assert any("drop-in" in m for m in result["misfits"])
+
+
+def test_a_roofed_pocket_never_takes_a_bit(grades):
+    """The bounding box, grid, and volume all read right on this one; only the
+    drop-in probe stands between a lid and full marks."""
+    result = grades["roofed"]
+    assert any("drop-in" in m for m in result["misfits"])
+
+
+def test_a_slid_grid_hides_in_the_bounding_box_but_not_the_borders(grades):
+    result = grades["shifted_grid"]
+    assert result["stages"]["dims"] < 1.0
+    assert any("stated grid" in m for m in result["misfits"])
+
+
+def test_a_broken_bottom_perimeter_is_charged_by_shape_and_doctrine(grades):
+    result = grades["bottom_chamfer"]
+    assert any("bottom" in m for m in result["misfits"])
+    assert result["stages"]["lint"] < 1.0  # bed_bevel findings agree with the spec
+
+
+def test_a_notched_footprint_is_not_a_full_rectangular_bottom(grades):
+    result = grades["notched"]
+    assert any("flat face spanning the full footprint" in m for m in result["misfits"])
+
+
+def test_the_totals_order_like_a_user_would(grades):
+    assert grades["good"]["score"] > grades["hand_grid"]["score"]
+    assert grades["hand_grid"]["score"] > grades["hardcoded"]["score"]
+    assert grades["hardcoded"]["score"] > grades["shallow"]["score"]
+
+
+def test_a_grid_slid_into_the_border_does_not_even_build(tmp_path):
+    """0.5 of slide leaves a 1.5 border: the pocket lead-in and the perimeter chamfer
+    no longer both fit, and OCCT refuses the pass. This is the adjacency limit the
+    task is built around; if this ever starts building, the task lost its teeth."""
+    source = (SOLUTIONS / "shifted_grid.py").read_text(encoding="utf-8")
+    part = tmp_path / "slid_far.py"
+    part.write_text(source.replace("web + 0.25 + r", "web + 0.5 + r"), encoding="utf-8")
+    result = scoring.grade(part, TASK, SEED)
+    assert result["built"] is False
+    assert result["score"] == 0.0

--- a/evals/tests/test_pole_rest.py
+++ b/evals/tests/test_pole_rest.py
@@ -1,0 +1,116 @@
+"""Fairness suite for pole_rest, the curvature function task.
+
+The controls that matter most are the prismatic ones: a V-block and a square channel
+both put the pole at exactly the stated height with legal clearance, and both must
+lose to the arc gate alone, because rejecting flat answers is this task's reason to
+exist. The film control pins the backing probe: an arc traced by an unprintable
+shell counts as no support.
+"""
+
+import pathlib
+
+import pytest
+
+from nurb_evals import scoring
+
+EVALS = pathlib.Path(__file__).parents[1]
+TASK = EVALS / "tasks" / "pole_rest"
+SOLUTIONS = pathlib.Path(__file__).parent / "solutions" / "pole_rest"
+
+task = scoring.load_task(TASK)
+
+# The reference solutions are written for a 22.0mm pole at 18.0 axis height, so the
+# tests pin the seed that produces one rather than hardcoding a magic number.
+SEED = next(
+    s
+    for s in range(2000)
+    if task.instance(s).dims["pole"] == 22.0 and task.instance(s).dims["axis_h"] == 18.0
+)
+
+
+@pytest.fixture(scope="module")
+def grades():
+    names = (
+        "good",
+        "polished",
+        "v_block",
+        "u_channel",
+        "tunnel",
+        "film",
+        "hollow_backing",
+        "hardcoded",
+        "bulky",
+        "short",
+    )
+    return {name: scoring.grade(SOLUTIONS / f"{name}.py", TASK, SEED) for name in names}
+
+
+def test_the_reference_cradle_scores_full_marks(grades):
+    result = grades["good"]
+    assert result["score"] == 1.0, result
+    assert result["stages"] == {"lint": 1.0, "dims": 1.0, "flex": 1.0}
+    assert result["misfits"] == [] and result["findings"] == []
+
+
+def test_a_doctrine_polished_cradle_also_scores_full_marks(grades):
+    """Every stated gate must survive the polish pass the shipped skill teaches."""
+    result = grades["polished"]
+    assert result["score"] == 1.0, result
+
+
+def test_a_v_block_fits_perfectly_and_is_still_not_a_cradle(grades):
+    """Two lines of tangent contact, no arc: the prismatic answer this task exists
+    to reject. It must lose to the arc gate alone, not to a fit technicality."""
+    result = grades["v_block"]
+    assert any("not cradled" in m for m in result["misfits"])
+    assert not any("does not fit" in m for m in result["misfits"])
+
+
+def test_a_square_channel_is_not_a_cradle_either(grades):
+    result = grades["u_channel"]
+    assert any("not cradled" in m for m in result["misfits"])
+    assert not any("does not fit" in m for m in result["misfits"])
+
+
+def test_a_tunnel_cradles_beautifully_and_loses_the_drop_in(grades):
+    result = grades["tunnel"]
+    assert any("lower straight down" in m for m in result["misfits"])
+    assert not any("not cradled" in m for m in result["misfits"])
+
+
+def test_a_film_arc_has_no_backing(grades):
+    """A 0.6mm shell traces the perfect arc; the backing probe reads it as no
+    support at all, and the printability rules charge the film on top."""
+    result = grades["film"]
+    assert any("not cradled" in m for m in result["misfits"])
+    assert result["stages"]["lint"] < 1.0
+
+
+def test_separate_skins_do_not_add_up_to_continuous_backing(grades):
+    result = grades["hollow_backing"]
+    assert any("not cradled" in m for m in result["misfits"])
+
+
+def test_hardcoded_dimensions_track_nothing(grades):
+    result = grades["hardcoded"]
+    assert result["stages"]["dims"] == 1.0
+    assert result["stages"]["flex"] == 0.0
+
+
+def test_bulk_is_charged_only_by_the_ladder(grades):
+    result = grades["bulky"]
+    assert result["stages"]["flex"] == 1.0
+    assert sum("volume" in m for m in result["misfits"]) == 3
+    assert not any("cradled" in m or "fit" in m for m in result["misfits"])
+
+
+def test_a_short_rest_misses_the_stated_length(grades):
+    assert any("long along Y" in m for m in grades["short"]["misfits"])
+
+
+def test_the_totals_order_like_a_user_would(grades):
+    assert grades["good"]["score"] > grades["bulky"]["score"]
+    assert grades["bulky"]["score"] > grades["tunnel"]["score"]
+    assert grades["tunnel"]["score"] > grades["u_channel"]["score"]
+    assert grades["u_channel"]["score"] >= grades["v_block"]["score"]
+    assert grades["v_block"]["score"] > grades["film"]["score"]

--- a/evals/tests/test_valve_knob.py
+++ b/evals/tests/test_valve_knob.py
@@ -1,0 +1,105 @@
+"""Fairness suite for valve_knob, the mating-fit task.
+
+The tolerance band is graded from both sides, so the suite holds a bore that is too
+tight and a bore that rattles, and each must lose exactly its own gate. The round
+bore is the control that matters most: it fits the stem perfectly and transmits no
+torque, which only the twisted-stem drive can know.
+"""
+
+import pathlib
+
+import pytest
+
+from nurb_evals import scoring
+
+EVALS = pathlib.Path(__file__).parents[1]
+TASK = EVALS / "tasks" / "valve_knob"
+SOLUTIONS = pathlib.Path(__file__).parent / "solutions" / "valve_knob"
+
+task = scoring.load_task(TASK)
+
+# The reference solutions are written for an 8.0mm stem with a 6.5mm across-flat, so
+# the tests pin the seed that produces one rather than hardcoding a magic number.
+SEED = next(
+    s
+    for s in range(2000)
+    if task.instance(s).dims["shaft"] == 8.0 and task.instance(s).dims["flat"] == 6.5
+)
+
+
+@pytest.fixture(scope="module")
+def grades():
+    names = (
+        "good",
+        "polished",
+        "round_bore",
+        "tight",
+        "sloppy",
+        "no_grip",
+        "wrong_flat",
+        "hardcoded",
+        "bulky",
+    )
+    return {name: scoring.grade(SOLUTIONS / f"{name}.py", TASK, SEED) for name in names}
+
+
+def test_the_reference_knob_scores_full_marks(grades):
+    result = grades["good"]
+    assert result["score"] == 1.0, result
+    assert result["stages"] == {"lint": 1.0, "dims": 1.0, "flex": 1.0}
+    assert result["misfits"] == [] and result["findings"] == []
+
+
+def test_a_doctrine_polished_knob_also_scores_full_marks(grades):
+    """Every stated gate must survive the polish pass the shipped skill teaches."""
+    result = grades["polished"]
+    assert result["score"] == 1.0, result
+
+
+def test_a_round_bore_fits_and_transmits_no_torque(grades):
+    """The stem slides in at the right clearance and spins forever: only the
+    twisted-stem drive can tell this bore from a real one."""
+    result = grades["round_bore"]
+    assert any("no torque" in m for m in result["misfits"])
+    assert not any("does not fit" in m or "rattles" in m for m in result["misfits"])
+
+
+def test_a_tight_bore_jams_the_grown_stem(grades):
+    result = grades["tight"]
+    assert any("does not fit" in m for m in result["misfits"])
+    assert not any("rattles" in m for m in result["misfits"])
+
+
+def test_a_loose_bore_rattles(grades):
+    result = grades["sloppy"]
+    assert any("rattles" in m for m in result["misfits"])
+    assert not any("does not fit" in m or "no torque" in m for m in result["misfits"])
+
+
+def test_a_round_puck_has_nothing_to_grip(grades):
+    result = grades["no_grip"]
+    assert any("nothing to grip" in m for m in result["misfits"])
+    assert not any("does not fit" in m for m in result["misfits"])
+
+
+def test_the_flat_faces_the_stated_way(grades):
+    assert any("does not fit" in m for m in grades["wrong_flat"]["misfits"])
+
+
+def test_hardcoded_dimensions_track_nothing(grades):
+    result = grades["hardcoded"]
+    assert result["stages"]["dims"] == 1.0
+    assert result["stages"]["flex"] == 0.0
+
+
+def test_bulk_is_charged_only_by_the_ladder(grades):
+    result = grades["bulky"]
+    assert result["stages"]["flex"] == 1.0
+    assert sum("volume" in m for m in result["misfits"]) == 2
+    assert not any("fit" in m or "torque" in m or "grip" in m for m in result["misfits"])
+
+
+def test_the_totals_order_like_a_user_would(grades):
+    assert grades["good"]["score"] > grades["bulky"]["score"]
+    assert grades["bulky"]["score"] > grades["sloppy"]["score"]
+    assert grades["sloppy"]["score"] > grades["round_bore"]["score"]


### PR DESCRIPTION
The first corpus saturated: frontier models score 1.0 on all three existing tasks, so the leaderboard could no longer separate them. This adds three tasks that grade what makes CAD hard rather than instruction following. bit_block is a spec task whose chamfered pocket grid sits close to OCCT's adjacent-chamfer limit (a wrong chamfer order does not lose points, it does not build) with an int-parameter grid the flex probes rebuild at other counts. pole_rest is a function task only curvature can win: a continuous 120 degree arc of backed contact around a measured pole, so a V-block or square channel fits perfectly and still loses; valve_knob drives a virtual D-stem to grade a mating fit from both sides of the tolerance band plus a 20 degree torque turn that fails a lazy round bore. Each task ships a fairness suite (references and doctrine-polished variants score exactly 1.0, every negative control loses exactly its own gate), and existing task files are untouched so submitted rows keep their benchmark revisions.