### PR TITLE
Wizard asks how many rounds, and says why rounds matter

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -30,7 +30,7 @@ The easy way is the wizard, from anywhere (or paste the line to your AI and let 
 curl -fsSL https://nurb.dev/bench.sh | sh
 ```
 
-It detects which agent CLIs you have, offers the models from a menu so you never guess a spelling, runs the trials on your subscription, sanitizes the artifacts, and then offers to open the pull request itself with the GitHub CLI: branch, commit, push, fork only if you lack push access, PR URL printed. Every run is its own uniquely named directory, branch, and PR, so run it as many times as you like, even concurrently: more runs mean tighter numbers, and matching rows pool on the leaderboard no matter which PR they arrived in. Agents and scripts can skip every question with flags: `uv run python -m nurb_evals.contribute --harness claude --model sonnet --effort medium --pr yes`.
+It detects which agent CLIs you have, offers the models from a menu so you never guess a spelling, asks how many rounds to run and says why more rounds mean a steadier number, runs them on your subscription, sanitizes the artifacts, and then offers to open the pull request itself with the GitHub CLI: branch, commit, push, fork only if you lack push access, PR URL printed. Every run is its own uniquely named directory, branch, and PR, so run it as many times as you like, even concurrently: more runs mean tighter numbers, and matching rows pool on the leaderboard no matter which PR they arrived in. Agents and scripts can skip every question with flags: `uv run python -m nurb_evals.contribute --harness claude --model sonnet --effort medium --pr yes`.
 
 The manual way needs `uv` and the `claude` or `codex` CLI installed and logged in to your own subscription. Then:
 

--- a/evals/src/nurb_evals/contribute.py
+++ b/evals/src/nurb_evals/contribute.py
@@ -120,7 +120,12 @@ def main():
     ap.add_argument("--harness", choices=sorted(harnesses.HARNESSES))
     ap.add_argument("--model")
     ap.add_argument("--effort")
-    ap.add_argument("--trials", type=int, default=1)
+    ap.add_argument(
+        "--trials",
+        type=int,
+        default=None,
+        help="rounds per job; the wizard asks when omitted (default there: 1)",
+    )
     ap.add_argument("--tasks", default=",".join(TASKS), help="comma-separated, default all")
     ap.add_argument("--seed", type=int, default=SEED)
     ap.add_argument("--timeout", type=float, default=3600.0)
@@ -175,6 +180,39 @@ def main():
     )
 
     tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
+
+    # Rounds are the sample size: scores vary run to run, and the leaderboard pools
+    # every submitted trial, so more rounds tighten this model's number. The wizard
+    # says why so the choice is informed, not a magic knob. Scripted runs (no
+    # terminal) keep the old behavior: one round unless --trials says otherwise.
+    if args.trials is None and not sys.stdin.isatty():
+        trials = 1
+    elif args.trials is None:
+        print(
+            "\nEach round is one fresh attempt at every job. Scores vary between"
+            "\nattempts, so more rounds mean a steadier average on the leaderboard;"
+            "\none round is still a valid contribution, and later runs pool with it."
+            f"\nBallpark {len(tasks) * 8} minutes of agent time per round."
+        )
+        trials = ask(
+            "How many rounds",
+            [
+                (1, "1 round: a quick single sample"),
+                (3, "3 rounds: a steady average"),
+                (5, "5 rounds: tight error bars"),
+                (None, "another number (type it)"),
+            ],
+            default=1,
+        )
+        if trials is None:
+            try:
+                trials = int(input("rounds: ").strip() or "1")
+            except (EOFError, ValueError):
+                sys.exit("\nCould not read a number; pass --trials instead.")
+    else:
+        trials = args.trials
+    if trials < 1:
+        sys.exit("--trials must be at least 1")
     # Every run gets its own directory, branch, and PR: the same person running the
     # same combo ten times, or in three sessions at once, produces ten independent
     # pure-addition PRs that merge in any order with zero conflicts. Matching rows
@@ -184,9 +222,9 @@ def main():
     run_name = f"{label}-{run_id}"
     out = EVALS / "results" / run_name
     out.mkdir(parents=True, exist_ok=True)
-    minutes = len(tasks) * args.trials * 8
+    minutes = len(tasks) * trials * 8
     print(
-        f"\nRunning {model} at {effort} effort: {args.trials} trial(s) on "
+        f"\nRunning {model} at {effort} effort: {trials} round(s) on "
         f"{len(tasks)} job(s), on your own {name} subscription. Ballpark "
         f"{minutes} minutes of agent time; slow models can take much longer.\n"
     )
@@ -195,7 +233,7 @@ def main():
     staged = []
     with open(out / "results.jsonl", "a", encoding="utf-8") as sink:
         for task in tasks:
-            for _ in range(args.trials):
+            for _ in range(trials):
                 n = next_trial(out, task)
                 print(f"[{task} trial {n}] running...", flush=True)
                 row = completed_trial(

--- a/evals/tests/test_contribute.py
+++ b/evals/tests/test_contribute.py
@@ -106,6 +106,61 @@ def test_wizard_runs_and_stages_a_sanitized_submission(tmp_path, monkeypatch, ca
     assert "skip if you have push access" in printed
 
 
+def test_wizard_asks_for_rounds_and_says_why(tmp_path, monkeypatch, capsys):
+    """With a terminal and no --trials, the wizard asks how many rounds and gives
+    the reason (more rounds, steadier average). Typing past the menu into 'another
+    number' runs exactly that many rounds."""
+    root = tmp_path / "evals"
+    (root / "tasks").mkdir(parents=True)
+    real = contribute.EVALS
+    shutil.copy(real / "models.toml", root / "models.toml")
+    os.symlink(real / "tasks" / "cable_clip", root / "tasks" / "cable_clip")
+
+    monkeypatch.setattr(contribute, "EVALS", root)
+    which = contribute.shutil.which
+    monkeypatch.setattr(
+        contribute.shutil,
+        "which",
+        lambda name: "/usr/bin/true" if name == "stub" else which(name),
+    )
+    monkeypatch.setitem(harnesses.HARNESSES, "stub", Stub(GOOD))
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    answers = iter(["4", "2"])  # menu: another number; then the number itself
+    asked = []
+
+    def scripted(prompt=""):
+        asked.append(prompt)
+        return next(answers)
+
+    monkeypatch.setattr("builtins.input", scripted)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "contribute",
+            "--harness", "stub",
+            "--model", "stub-model",
+            "--effort", "low",
+            "--tasks", "cable_clip",
+            "--seed", str(SEED),
+            "--pr", "no",
+        ],
+    )
+    contribute.main()
+
+    printed = capsys.readouterr().out
+    assert any("How many rounds" in prompt for prompt in asked)
+    assert "steadier average" in printed, "the wizard explains why rounds matter"
+    assert "another number" in printed, "an exact count is always available"
+    sub = next((root / "submissions").glob("stub-stub-model-low-*"))
+    rows = [
+        json.loads(line)
+        for line in (sub / "results.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    assert len(rows) == 2, "two rounds were asked for, two rows exist"
+
+
 def test_open_pr_drives_git_and_gh_end_to_end(tmp_path, monkeypatch):
     """The wizard owns the submission: branch from origin's main, commit only this
     run's directory, push, PR. Faked git/gh log every invocation and pr create


### PR DESCRIPTION
The bench.sh wizard always ran one trial; running more required a flag that curl-pipe users never see. Now, when a terminal is attached and --trials is omitted, the wizard asks for a round count and explains the tradeoff: each round is a fresh attempt at every job, scores vary between attempts, and more rounds mean a steadier pooled average, with a per-round time ballpark. The menu offers 1, 3, or 5 rounds plus a free-form exact count, scripted and non-interactive runs keep the old single-round default, and the end-to-end wizard test now drives the prompt and verifies a two-round answer produces two rows.