### PR TITLE
Report API-equivalent cost as a first-class column

### DIFF
--- a/evals/prices.toml
+++ b/evals/prices.toml
@@ -1,0 +1,53 @@
+# API list prices per million tokens, USD, for the cost column on the leaderboard.
+#
+# Trials run on subscriptions, so no invoice exists; the honest proxy, and the one
+# every usage tool converged on, is what the same tokens would have cost through
+# the API at list prices. claude rows carry the CLI's own cache-aware total_cost_usd
+# and never touch this table; it prices the harnesses that report only token counts,
+# and it is read at report time only, so editing it never changes a benchmark
+# revision or orphans a submitted row.
+#
+# Keys are the model ids exactly as the rows record them (models.toml spellings).
+# cache_read and the cache_write rates apply only when a row carries those token
+# counts; a harness that folds cached tokens into input_tokens simply prices them
+# as input, which overstates slightly and is noted in the report footer.
+#
+# priced 2026-08-24. Sources: Anthropic, OpenAI, and xAI published API rates.
+
+[claude.fable]
+input = 10.00
+output = 50.00
+cache_read = 1.00
+cache_write_5m = 12.50
+cache_write_1h = 20.00
+
+[claude.opus]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write_5m = 6.25
+cache_write_1h = 10.00
+
+[claude.sonnet]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write_5m = 3.75
+cache_write_1h = 6.00
+
+[claude.haiku]
+input = 1.00
+output = 5.00
+cache_read = 0.10
+cache_write_5m = 1.25
+cache_write_1h = 2.00
+
+[codex."gpt-5.5"]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+
+[grok."grok-4.6"]
+input = 2.00
+output = 6.00
+cache_read = 0.50

--- a/evals/src/nurb_evals/pricing.py
+++ b/evals/src/nurb_evals/pricing.py
@@ -1,0 +1,43 @@
+"""API-equivalent cost of a trial, at list prices.
+
+Subscription trials have no invoice, so the leaderboard reports what the same
+tokens would have cost through the API at list prices, the convention every usage
+tool (Claude Code's own cost line, ccusage, aider's leaderboard) converged on.
+
+Two paths, in order of trust. A row whose harness computed its own cost keeps it:
+claude's total_cost_usd is cache-aware, priced with the CLI's own multipliers, and
+recorded at run time, so it never drifts with this file. Everything else derives
+from the row's token counts and prices.toml, which is read at report time only:
+cost lives outside the benchmark revision on purpose, because a price change must
+never orphan a submitted row.
+"""
+
+import pathlib
+import tomllib
+
+EVALS = pathlib.Path(__file__).parents[2]
+
+
+def load():
+    path = EVALS / "prices.toml"
+    if not path.is_file():
+        return {}
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def trial_cost(row, prices):
+    """Dollars for one trial, or None when the row carries too little to price."""
+    usage = row.get("usage") or {}
+    reported = usage.get("total_cost_usd")
+    if isinstance(reported, (int, float)):
+        return float(reported)
+    table = (prices.get(row.get("harness")) or {}).get(row.get("model"))
+    if not table or "input_tokens" not in usage or "output_tokens" not in usage:
+        return None
+    per_million = (
+        usage["input_tokens"] * table["input"]
+        + usage["output_tokens"] * table["output"]
+        + usage.get("cache_read_input_tokens", 0) * table.get("cache_read", 0.0)
+        + usage.get("cache_creation_input_tokens", 0) * table.get("cache_write_5m", 0.0)
+    )
+    return per_million / 1e6

--- a/evals/src/nurb_evals/report.py
+++ b/evals/src/nurb_evals/report.py
@@ -13,6 +13,8 @@ import math
 import pathlib
 import sys
 
+from . import pricing
+
 # A pass is a near-perfect part: every stated dimension, no lint findings, honest
 # parameters. Matches the fairness suite's bar for the reference solution.
 PASS = 0.99
@@ -57,6 +59,7 @@ def _tokens(row):
 
 
 def summarize(rows):
+    prices = pricing.load()
     groups = {}
     for row in rows:
         key = (
@@ -92,6 +95,7 @@ def summarize(rows):
             "pass@1": pass_at(1, n, passes),
             "pass@3": pass_at(3, n, passes),
             "tokens": _mean([_tokens(t) for t in trials]),
+            "cost": _mean([pricing.trial_cost(t, prices) for t in trials]),
             "wall_s": _mean([t.get("harness_s") for t in trials]),
             # Killed at the wall clock, so the trial's duration is a floor, not a
             # measurement: anything averaging wall_s owes the reader this count.
@@ -113,8 +117,8 @@ def table(summary):
         seeds = sorted({s for r in rows for s in r["seeds"]})
         lines.append(f"## {task} (seed {', '.join(map(str, seeds))})")
         lines.append("")
-        lines.append("| harness | benchmark | model | effort | trials | score | built | lint | dims | flex | pass@1 | pass@3 | tokens | wall | trial scores |")
-        lines.append("|---|---|---|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|---|")
+        lines.append("| harness | benchmark | model | effort | trials | score | built | lint | dims | flex | pass@1 | pass@3 | tokens | cost | wall | trial scores |")
+        lines.append("|---|---|---|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|---|")
         for r in rows:
             # "2.1.220 (Claude Code)" and "codex-cli 0.139.0" both yield the number.
             tokens = (r["harness_version"] or "").split()
@@ -133,11 +137,12 @@ def table(summary):
                 _cell(r["pass@1"]),
                 _cell(r["pass@3"]),
                 _cell(r["tokens"], "{:,.0f}") if r["tokens"] is not None else "-",
+                _cell(r["cost"], "${:.2f}"),
                 _cell(r["wall_s"], "{:.0f}s"),
                 " / ".join(f"{s:.3f}" for s in r["scores"]),
             )) + " |")
         lines.append("")
-        lines.append(f"`benchmark` is nurb/evals@content-revision and separates rows whenever the tool, task, scorer, harness adapter, or locked dependencies change. `score` averages all trials with gate failures as zeros; `built` is the fraction of trials past the gate, and lint/dims/flex average built trials only. A pass is a score of at least {PASS}. Stage columns overlap by design: a part wrong at the stated size is wrong at every probed size too, so it loses dims and flex together. `tokens` is input plus output as the harness reports them, and harnesses count differently (claude's input excludes cache reads, codex counts full per-turn context), so compare tokens within a harness only.")
+        lines.append(f"`benchmark` is nurb/evals@content-revision and separates rows whenever the tool, task, scorer, harness adapter, or locked dependencies change. `score` averages all trials with gate failures as zeros; `built` is the fraction of trials past the gate, and lint/dims/flex average built trials only. A pass is a score of at least {PASS}. Stage columns overlap by design: a part wrong at the stated size is wrong at every probed size too, so it loses dims and flex together. `tokens` is input plus output as the harness reports them, and harnesses count differently (claude's input excludes cache reads, codex counts full per-turn context), so compare tokens within a harness only. `cost` is the API-equivalent dollar cost of a trial at list prices, the mean across trials: subscription runs paid no invoice, so this is what the same tokens would have cost through the API. claude rows carry the CLI's own cache-aware figure; other harnesses derive from their token counts and the dated prices.toml, which folds any cached tokens in at the full input rate and so reads slightly high.")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 

--- a/evals/src/nurb_evals/site.py
+++ b/evals/src/nurb_evals/site.py
@@ -264,12 +264,24 @@ def _bar(score, scores):
 
 
 def _stats(tasks):
-    """The three numbers a combo is judged by, shared by every layer of the page."""
+    """The numbers a combo is judged by, shared by every layer of the page."""
     total = sum(r["trials"] for r in tasks.values())
     firsts = sum(sum(s >= PASS for s in r["scores"]) for r in tasks.values())
     minutes = sum(r["wall_s"] for r in tasks.values()) / len(tasks) / 60
     capped = sum(r.get("capped", 0) for r in tasks.values())
-    return firsts, total, minutes, capped
+    costs = [r.get("cost") for r in tasks.values()]
+    dollars = sum(costs) / len(costs) if all(c is not None for c in costs) else None
+    return firsts, total, minutes, capped, dollars
+
+
+def _cost_note(dollars):
+    """Dollars per part, or nothing when a harness never reported enough to price.
+    API-equivalent at list prices: the subscription paid no invoice, this is what
+    the same tokens would have cost through the API."""
+    if dollars is None:
+        return ""
+    figure = f"${dollars:.2f}" if dollars >= 0.10 else f"${dollars:.3f}"
+    return f" &middot; ~{figure}/part at API rates"
 
 
 def _time_note(minutes, capped):
@@ -286,20 +298,21 @@ def _answers(combos):
     best = {}
     for key, tasks in combos:
         harness = key[0]
-        firsts, total, minutes, capped = _stats(tasks)
+        firsts, total, minutes, capped, dollars = _stats(tasks)
         rank = (firsts / total if total else 0, -minutes)
         if harness not in best or rank > best[harness][0]:
-            best[harness] = (rank, key, (firsts, total, minutes, capped))
+            best[harness] = (rank, key, (firsts, total, minutes, capped, dollars))
     cards = []
     for harness, (label, color) in SUBSCRIPTIONS.items():
         if harness not in best:
             continue
-        _, (h, model, effort), (firsts, total, minutes, capped) = best[harness]
+        _, (h, model, effort), (firsts, total, minutes, capped, dollars) = best[harness]
         cards.append(
             f'<div class="answer" style="border-top-color:{color}">\n'
             f'  <div class="have">Have {html.escape(label)}?</div>\n'
             f'  <div class="pick">run {html.escape(model)} <small>at {html.escape(effort)} effort</small></div>\n'
-            f'  <div class="why">{firsts}/{total} first-try prints &middot; {_time_note(minutes, capped)}</div>\n'
+            f'  <div class="why">{firsts}/{total} first-try prints &middot; '
+            f"{_time_note(minutes, capped)}{_cost_note(dollars)}</div>\n"
             f"</div>"
         )
     return "\n".join(cards)
@@ -317,7 +330,7 @@ def _chart(combos):
 
     points = []
     for (harness, model, effort), tasks in combos:
-        firsts, total, minutes, capped = _stats(tasks)
+        firsts, total, minutes, capped, dollars = _stats(tasks)
         points.append(
             {
                 "harness": harness,
@@ -326,6 +339,7 @@ def _chart(combos):
                 "rate": firsts / total if total else 0.0,
                 "minutes": minutes,
                 "capped": capped,
+                "dollars": dollars,
                 "firsts": firsts,
                 "total": total,
             }
@@ -394,6 +408,7 @@ def _chart(combos):
         title = (
             f"{p['model']} ({p['effort']} effort): {p['firsts']}/{p['total']} first-try, "
             f"{_time_note(p['minutes'], p['capped'])}"
+            f"{_cost_note(p['dollars']).replace('&middot;', '·')}"
         )
         if p["capped"]:
             parts.append(
@@ -427,7 +442,7 @@ def _chart(combos):
 def _card(key, tasks):
     harness, model, effort = key
     runs_on, verdict = VERDICTS.get(key, (f"{harness} harness", ""))
-    firsts, total, minutes, capped = _stats(tasks)
+    firsts, total, minutes, capped, dollars = _stats(tasks)
     bars = []
     for task in JOBS:
         name = html.escape(JOBS[task][0])
@@ -444,7 +459,7 @@ def _card(key, tasks):
   <summary><div class="top">
     <span class="model">{html.escape(model)} <small>({html.escape(effort)} effort)</small></span>
     <span class="runs">{html.escape(runs_on)}</span>
-    <span class="first">first-try prints <b>{firsts}/{total}</b> &middot; {_time_note(minutes, capped)}</span>
+    <span class="first">first-try prints <b>{firsts}/{total}</b> &middot; {_time_note(minutes, capped)}{_cost_note(dollars)}</span>
   </div></summary>
   <div class="body">{verdict_html}
   <div class="bars">

--- a/evals/tests/test_pricing.py
+++ b/evals/tests/test_pricing.py
@@ -1,0 +1,73 @@
+"""The cost proxy: API-equivalent dollars at list prices, never a guess.
+
+A harness that computed its own cache-aware cost is believed verbatim; a harness
+that only counted tokens is priced from the committed table; a row that carries
+neither stays blank rather than pretending.
+"""
+
+from nurb_evals import pricing
+
+PRICES = {
+    "grok": {"grok-4.6": {"input": 2.0, "output": 6.0, "cache_read": 0.5}},
+    "claude": {
+        "sonnet": {
+            "input": 3.0,
+            "output": 15.0,
+            "cache_read": 0.3,
+            "cache_write_5m": 3.75,
+        }
+    },
+}
+
+
+def test_a_harness_reported_cost_is_believed_verbatim():
+    row = {
+        "harness": "claude",
+        "model": "sonnet",
+        "usage": {"total_cost_usd": 0.4321, "input_tokens": 1, "output_tokens": 1},
+    }
+    assert pricing.trial_cost(row, PRICES) == 0.4321
+
+
+def test_token_counts_price_from_the_table():
+    row = {
+        "harness": "grok",
+        "model": "grok-4.6",
+        "usage": {"input_tokens": 1_000_000, "output_tokens": 500_000},
+    }
+    assert pricing.trial_cost(row, PRICES) == 2.0 + 3.0
+
+
+def test_cache_fields_price_at_their_own_rates_when_present():
+    row = {
+        "harness": "claude",
+        "model": "sonnet",
+        "usage": {
+            "input_tokens": 1_000_000,
+            "output_tokens": 0,
+            "cache_read_input_tokens": 1_000_000,
+            "cache_creation_input_tokens": 1_000_000,
+        },
+    }
+    assert pricing.trial_cost(row, PRICES) == 3.0 + 0.3 + 3.75
+
+
+def test_an_unpriced_model_or_empty_usage_stays_blank():
+    assert pricing.trial_cost({"harness": "codex", "model": "mystery", "usage": {"input_tokens": 1, "output_tokens": 1}}, PRICES) is None
+    assert pricing.trial_cost({"harness": "grok", "model": "grok-4.6", "usage": {}}, PRICES) is None
+    assert pricing.trial_cost({"harness": "grok", "model": "grok-4.6"}, PRICES) is None
+
+
+def test_the_committed_table_prices_every_menu_model():
+    """Every model the wizard offers must be priceable, so a codex or grok row is
+    never blank by accident. claude entries exist too, as the fallback for rows
+    whose CLI ever stops reporting its own figure."""
+    import tomllib
+
+    prices = pricing.load()
+    menu = tomllib.loads((pricing.EVALS / "models.toml").read_text(encoding="utf-8"))
+    for harness, entries in menu.items():
+        for entry in entries:
+            table = prices.get(harness, {}).get(entry["id"])
+            assert table, f"prices.toml is missing [{harness}.{entry['id']}]"
+            assert table["input"] > 0 and table["output"] > 0


### PR DESCRIPTION
Subscription trials pay no invoice, so the leaderboard now reports the convention every usage tool converged on: what the same tokens would have cost through the API at list prices. A new pricing module believes a harness-reported cost verbatim (claude's CLI computes a cache-aware total_cost_usd itself) and prices token-only rows (codex, grok) against a committed, dated prices.toml with cache read/write rates, read at report time only so price edits never change a benchmark revision or orphan submitted rows. REPORT.md gains a cost column with caveats in the footer, the site's answer cards, model cards, and chart tooltips gain dollars-per-part next to minutes-per-part, and a menu-coverage test keeps prices.toml in sync with models.toml. Verified against the merged submissions: every claude row prices from its own figure and the grok row derives correctly from the table.