### PR TITLE
Pin benchmark model ids and refresh the wizard's model menu

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -30,19 +30,19 @@ The easy way is the wizard, from anywhere (or paste the line to your AI and let 
 curl -fsSL https://nurb.dev/bench.sh | sh
 ```
 
-It detects which agent CLIs you have, offers the models from a menu so you never guess a spelling, asks how many rounds to run and says why more rounds mean a steadier number, runs them on your subscription, sanitizes the artifacts, and then offers to open the pull request itself with the GitHub CLI: branch, commit, push, fork only if you lack push access, PR URL printed. Every run is its own uniquely named directory, branch, and PR, so run it as many times as you like, even concurrently: more runs mean tighter numbers, and matching rows pool on the leaderboard no matter which PR they arrived in. Agents and scripts can skip every question with flags: `uv run python -m nurb_evals.contribute --harness claude --model sonnet --effort medium --pr yes`.
+It detects which agent CLIs you have, offers the models from a menu so you never guess a spelling, asks how many rounds to run and says why more rounds mean a steadier number, runs them on your subscription, sanitizes the artifacts, and then offers to open the pull request itself with the GitHub CLI: branch, commit, push, fork only if you lack push access, PR URL printed. Every run is its own uniquely named directory, branch, and PR, so run it as many times as you like, even concurrently: more runs mean tighter numbers, and matching rows pool on the leaderboard no matter which PR they arrived in. Agents and scripts can skip every question with flags: `uv run python -m nurb_evals.contribute --harness claude --model claude-sonnet-5 --effort medium --pr yes`.
 
 The manual way needs `uv` and the `claude` or `codex` CLI installed and logged in to your own subscription. Then:
 
 ```
 cd evals
 uv sync --locked
-uv run python -m nurb_evals.run --harness claude --model opus --effort high --seed 13 --trials 3 --task tasks/cable_clip
-uv run python -m nurb_evals.run --harness claude --model opus --effort high --seed 13 --trials 3 --task tasks/bit_block
-uv run python -m nurb_evals.run --harness claude --model opus --effort high --seed 13 --trials 3 --task tasks/bundle_holder
-uv run python -m nurb_evals.run --harness claude --model opus --effort high --seed 13 --trials 3 --task tasks/pole_rest
-uv run python -m nurb_evals.run --harness claude --model opus --effort high --seed 13 --trials 3 --task tasks/valve_knob
-uv run python -m nurb_evals.run --harness claude --model opus --effort high --seed 13 --trials 3 --task tasks/leg_cup
+uv run python -m nurb_evals.run --harness claude --model claude-opus-5 --effort high --seed 13 --trials 3 --task tasks/cable_clip
+uv run python -m nurb_evals.run --harness claude --model claude-opus-5 --effort high --seed 13 --trials 3 --task tasks/bit_block
+uv run python -m nurb_evals.run --harness claude --model claude-opus-5 --effort high --seed 13 --trials 3 --task tasks/bundle_holder
+uv run python -m nurb_evals.run --harness claude --model claude-opus-5 --effort high --seed 13 --trials 3 --task tasks/pole_rest
+uv run python -m nurb_evals.run --harness claude --model claude-opus-5 --effort high --seed 13 --trials 3 --task tasks/valve_knob
+uv run python -m nurb_evals.run --harness claude --model claude-opus-5 --effort high --seed 13 --trials 3 --task tasks/leg_cup
 uv run python -m nurb_evals.report results/claude-opus-high
 ```
 

--- a/evals/models.toml
+++ b/evals/models.toml
@@ -2,39 +2,69 @@
 # spelling. One entry per model a harness currently ships; the id is what the
 # harness CLI actually accepts, the label is what a person sees. Add a model here
 # when a harness ships it, and prune ids the CLI stops accepting.
+#
+# Ids are pinned, never floating aliases: the claude CLI accepts "opus" but that
+# alias resolves to a different model after every release, and rows pool on the id,
+# so an alias would silently mix models in one leaderboard row. The codex and grok
+# menus come from their CLIs' own catalogs (`codex debug models`, `grok models`),
+# which the wizard cross-checks at startup to catch this file going stale.
 
 [[claude]]
-id = "fable"
-label = "Claude Fable (flagship)"
+id = "claude-fable-5"
+label = "Claude Fable 5 (flagship)"
 efforts = ["low", "medium", "high", "xhigh", "max"]
 default_effort = "high"
 
 [[claude]]
-id = "opus"
-label = "Claude Opus"
+id = "claude-opus-5"
+label = "Claude Opus 5"
 efforts = ["low", "medium", "high", "xhigh", "max"]
 default_effort = "high"
 
 [[claude]]
-id = "sonnet"
-label = "Claude Sonnet"
+id = "claude-sonnet-5"
+label = "Claude Sonnet 5"
 efforts = ["low", "medium", "high", "xhigh", "max"]
 default_effort = "high"
 
 [[claude]]
-id = "haiku"
-label = "Claude Haiku (budget)"
+id = "claude-haiku-4-5-20251001"
+label = "Claude Haiku 4.5 (budget)"
 efforts = ["low", "medium", "high"]
 default_effort = "low"
 
 [[codex]]
+id = "gpt-5.6-sol"
+label = "GPT-5.6-Sol (frontier)"
+efforts = ["low", "medium", "high", "xhigh", "max", "ultra"]
+default_effort = "low"
+
+[[codex]]
+id = "gpt-5.6-terra"
+label = "GPT-5.6-Terra (balanced)"
+efforts = ["low", "medium", "high", "xhigh", "max", "ultra"]
+default_effort = "medium"
+
+[[codex]]
+id = "gpt-5.6-luna"
+label = "GPT-5.6-Luna (budget)"
+efforts = ["low", "medium", "high", "xhigh", "max"]
+default_effort = "medium"
+
+[[codex]]
 id = "gpt-5.5"
-label = "GPT-5.5 (Codex)"
-efforts = ["low", "medium", "high"]
+label = "GPT-5.5"
+efforts = ["low", "medium", "high", "xhigh"]
 default_effort = "medium"
 
 [[grok]]
 id = "grok-4.6"
 label = "Grok 4.6"
+efforts = ["low", "medium", "high", "xhigh"]
+default_effort = "high"
+
+[[grok]]
+id = "grok-4.5"
+label = "Grok 4.5"
 efforts = ["low", "medium", "high", "xhigh"]
 default_effort = "high"

--- a/evals/prices.toml
+++ b/evals/prices.toml
@@ -14,33 +14,48 @@
 #
 # priced 2026-08-24. Sources: Anthropic, OpenAI, and xAI published API rates.
 
-[claude.fable]
+[claude."claude-fable-5"]
 input = 10.00
 output = 50.00
 cache_read = 1.00
 cache_write_5m = 12.50
 cache_write_1h = 20.00
 
-[claude.opus]
+[claude."claude-opus-5"]
 input = 5.00
 output = 25.00
 cache_read = 0.50
 cache_write_5m = 6.25
 cache_write_1h = 10.00
 
-[claude.sonnet]
+[claude."claude-sonnet-5"]
 input = 3.00
 output = 15.00
 cache_read = 0.30
 cache_write_5m = 3.75
 cache_write_1h = 6.00
 
-[claude.haiku]
+[claude."claude-haiku-4-5-20251001"]
 input = 1.00
 output = 5.00
 cache_read = 0.10
 cache_write_5m = 1.25
 cache_write_1h = 2.00
+
+[codex."gpt-5.6-sol"]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+
+[codex."gpt-5.6-terra"]
+input = 2.00
+output = 12.00
+cache_read = 0.20
+
+[codex."gpt-5.6-luna"]
+input = 0.20
+output = 1.20
+cache_read = 0.02
 
 [codex."gpt-5.5"]
 input = 5.00
@@ -51,3 +66,8 @@ cache_read = 0.50
 input = 2.00
 output = 6.00
 cache_read = 0.50
+
+[grok."grok-4.5"]
+input = 2.00
+output = 6.00
+cache_read = 0.30

--- a/evals/src/nurb_evals/contribute.py
+++ b/evals/src/nurb_evals/contribute.py
@@ -7,7 +7,7 @@ menu from the curated models.toml, runs the trials, sanitizes machine-specific p
 out of everything, stages the result under submissions/, and prints the two steps
 that remain. Every question has a flag, so an agent can run it non-interactively:
 
-    uv run python -m nurb_evals.contribute --harness claude --model fable --effort high
+    uv run python -m nurb_evals.contribute --harness claude --model claude-fable-5 --effort high
 """
 
 import argparse
@@ -40,6 +40,35 @@ def detected():
         if shutil.which(name):
             out.append((name, harnesses.version(name)))
     return out
+
+
+def flagship(name):
+    """The harness CLI's own top-listed model, for the staleness nudge: catalogs
+    list newest first, so a curated menu missing the top entry is out of date.
+    Older tiers we deliberately leave off the menu never trigger it. Best-effort:
+    claude has no list command, and any failure just skips the nudge."""
+    probes = {"codex": ["codex", "debug", "models"], "grok": ["grok", "models"]}
+    cmd = probes.get(name)
+    if not cmd:
+        return None
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=15).stdout
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if name == "codex":
+        try:
+            data = json.loads(out[out.index("{"):])
+        except ValueError:
+            return None
+        for m in data.get("models", []):
+            if m.get("visibility") == "list" and m.get("slug"):
+                return m["slug"]
+        return None
+    for line in out.splitlines():
+        line = line.strip()
+        if line.startswith(("*", "-")):
+            return line.lstrip("*- ").split()[0]
+    return None
 
 
 def ask(prompt, options, default=None):
@@ -156,6 +185,11 @@ def main():
         sys.exit(f"{name} is not on PATH on this machine.")
 
     menu = catalog().get(name, [])
+    newest = flagship(name)
+    if newest and newest not in {m["id"] for m in menu}:
+        print(f"\n  note: {name} now lists {newest}, which models.toml does not "
+              f"offer yet; pick \"another model\" to run it, and consider a PR "
+              f"updating the menu.")
     if args.model:
         model, efforts, default_effort = args.model, [], args.effort or "high"
         entry = next((m for m in menu if m["id"] == args.model), None)

--- a/evals/src/nurb_evals/harness.py
+++ b/evals/src/nurb_evals/harness.py
@@ -67,6 +67,12 @@ class ClaudeCode:
         for key in ("total_cost_usd", "num_turns", "duration_ms"):
             if key in result:
                 keep[key] = result[key]
+        # The models that actually served the session. --model accepts floating
+        # aliases ("opus"), and rows pool on the model string, so the resolved ids
+        # are what keeps two runs of an alias from pooling across a model release.
+        served = result.get("modelUsage")
+        if isinstance(served, dict) and served:
+            keep["models"] = sorted(served)
         tokens = result.get("usage") or {}
         if not isinstance(tokens, dict):
             return keep

--- a/evals/src/nurb_evals/report.py
+++ b/evals/src/nurb_evals/report.py
@@ -62,16 +62,22 @@ def summarize(rows):
     prices = pricing.load()
     groups = {}
     for row in rows:
+        # The resolved ids are part of the identity: --model accepts floating
+        # aliases, and two runs of "opus" months apart can be different models.
+        # Rows recorded before the runner captured them carry an empty tuple and
+        # pool by label alone, as they always did.
         key = (
             row["task"], row["harness"], row.get("harness_version"),
             row["nurb_version"], row["benchmark_version"], row["benchmark_revision"],
             row["model"], row["effort"],
+            tuple((row.get("usage") or {}).get("models") or ()),
         )
         groups.setdefault(key, []).append(row)
 
     out = []
     for key, trials in groups.items():
-        task, harness, version, nurb_version, benchmark_version, revision, model, effort = key
+        (task, harness, version, nurb_version, benchmark_version, revision,
+         model, effort, resolved) = key
         scores = [t["score"] for t in trials]
         ok = [t for t in trials if built(t)]
         passes = sum(s >= PASS for s in scores)
@@ -85,6 +91,7 @@ def summarize(rows):
             "benchmark_version": benchmark_version,
             "benchmark_revision": revision,
             "model": model,
+            "resolved": list(resolved),
             "effort": effort,
             "trials": n,
             "score": _mean(scores),

--- a/evals/src/nurb_evals/site.py
+++ b/evals/src/nurb_evals/site.py
@@ -336,10 +336,13 @@ for (const b of document.querySelectorAll('[data-copy]')) {
 
 
 def _combos(summary):
-    """Fold per-task rows into one entry per harness+model+effort, best score first."""
+    """Fold per-task rows into one entry per harness+model+effort, best score first.
+    The resolved ids ride along in the key so two same-label groups (a floating
+    alias that served different models) never silently overwrite each other."""
     combos = {}
     for row in summary:
-        key = (row["harness"], row["model"], row["effort"])
+        key = (row["harness"], row["model"], row["effort"],
+               tuple(row.get("resolved") or ()))
         combos.setdefault(key, {})[row["task"]] = row
     order = []
     for key, tasks in combos.items():
@@ -405,7 +408,8 @@ def _answers(combos):
     for harness, (label, color) in SUBSCRIPTIONS.items():
         if harness not in best:
             continue
-        _, (h, model, effort), (firsts, total, minutes, capped, dollars) = best[harness]
+        _, key, (firsts, total, minutes, capped, dollars) = best[harness]
+        model, effort = key[1], key[2]
         cards.append(
             f'<div class="answer">\n'
             f'  <div class="have"><i style="background:{color}"></i>Have {html.escape(label)}?</div>\n'
@@ -428,7 +432,7 @@ def _chart(combos):
     pw, ph = width - left - right, height - top - bottom
 
     points = []
-    for (harness, model, effort), tasks in combos:
+    for (harness, model, effort, _), tasks in combos:
         firsts, total, minutes, capped, dollars = _stats(tasks)
         points.append(
             {
@@ -559,8 +563,8 @@ def _cells(tasks):
 
 
 def _row(rank, key, tasks):
-    harness, model, effort = key
-    verdict = VERDICTS.get(key, "")
+    harness, model, effort = key[:3]
+    verdict = VERDICTS.get(key[:3], "")
     firsts, total, minutes, capped, dollars = _stats(tasks)
     rate = firsts / total if total else 0.0
     plan, color = SUBSCRIPTIONS.get(harness, (harness, "var(--dim)"))

--- a/evals/tests/test_contribute.py
+++ b/evals/tests/test_contribute.py
@@ -22,7 +22,10 @@ from test_runner import GOOD, SEED, Stub
 
 def test_catalog_offers_real_ids():
     book = contribute.catalog()
-    assert {m["id"] for m in book["claude"]} >= {"fable", "opus", "sonnet", "haiku"}
+    claude_ids = {m["id"] for m in book["claude"]}
+    assert {"claude-fable-5", "claude-opus-5", "claude-sonnet-5"} <= claude_ids
+    # Floating aliases would pool different models into one leaderboard row.
+    assert not claude_ids & {"fable", "opus", "sonnet", "haiku"}
     for entries in book.values():
         for entry in entries:
             assert entry["default_effort"] in entry["efforts"]


### PR DESCRIPTION
The contribute wizard offered floating claude aliases like `opus`, which resolve to a different model after every release while leaderboard rows pool on the model string, so runs months apart could silently mix models in one row. Claude menu entries now use pinned ids (verified live against the CLI), the claude adapter records which models actually served each session from the CLI's `modelUsage`, and both the report and the benchmarks page include those resolved ids in the pooling key so mixed rows split instead of merging. The menu itself was stale: codex gains the GPT-5.6 family (Sol, Terra, Luna) alongside GPT-5.5, grok gains 4.5, and `prices.toml` carries current list rates for the new ids. The wizard also cross-checks the harness CLI's own catalog (`codex debug models`, `grok models`) at startup and nudges when the top-listed model is missing from the menu. Existing submissions keep their alias labels and simply stop pooling with new pinned-id runs, which is correct since they were a different model generation.