### PR TITLE
Ask for the round count directly in the contribute wizard

### DIFF
--- a/evals/src/nurb_evals/contribute.py
+++ b/evals/src/nurb_evals/contribute.py
@@ -281,22 +281,22 @@ def main():
             "\nattempts, so more rounds mean a steadier average on the leaderboard;"
             "\none round is still a valid contribution, and later runs pool with it."
             f"\nBallpark {len(tasks) * 8} minutes of agent time per round."
+            "\n  1 round: a quick single sample"
+            "\n  3 rounds: a steady average"
+            "\n  5 rounds: tight error bars"
         )
-        trials = ask(
-            "How many rounds",
-            [
-                (1, "1 round: a quick single sample"),
-                (3, "3 rounds: a steady average"),
-                (5, "5 rounds: tight error bars"),
-                (None, "another number (type it)"),
-            ],
-            default=1,
-        )
-        if trials is None:
+        while True:
             try:
-                trials = int(input("rounds: ").strip() or "1")
-            except (EOFError, ValueError):
+                raw = input("How many rounds [1]: ").strip()
+            except EOFError:
                 sys.exit("\nCould not read a number; pass --trials instead.")
+            if not raw:
+                trials = 1
+                break
+            if raw.isdigit() and int(raw) >= 1:
+                trials = int(raw)
+                break
+            print("  type a number of rounds, 1 or more")
     else:
         trials = args.trials
     if trials < 1:

--- a/evals/tests/test_contribute.py
+++ b/evals/tests/test_contribute.py
@@ -174,8 +174,8 @@ def test_wizard_runs_and_stages_a_sanitized_submission(tmp_path, monkeypatch, ca
 
 def test_wizard_asks_for_rounds_and_says_why(tmp_path, monkeypatch, capsys):
     """With a terminal and no --trials, the wizard asks how many rounds and gives
-    the reason (more rounds, steadier average). Typing past the menu into 'another
-    number' runs exactly that many rounds."""
+    the reason (more rounds, steadier average). The typed number IS the round
+    count: answering 2 runs exactly two rounds."""
     root = tmp_path / "evals"
     (root / "tasks").mkdir(parents=True)
     real = contribute.EVALS
@@ -191,7 +191,7 @@ def test_wizard_asks_for_rounds_and_says_why(tmp_path, monkeypatch, capsys):
     )
     monkeypatch.setitem(harnesses.HARNESSES, "stub", Stub(GOOD))
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
-    answers = iter(["4", "2"])  # menu: another number; then the number itself
+    answers = iter(["2"])  # the answer is the round count itself
     asked = []
 
     def scripted(prompt=""):
@@ -217,7 +217,6 @@ def test_wizard_asks_for_rounds_and_says_why(tmp_path, monkeypatch, capsys):
     printed = capsys.readouterr().out
     assert any("How many rounds" in prompt for prompt in asked)
     assert "steadier average" in printed, "the wizard explains why rounds matter"
-    assert "another number" in printed, "an exact count is always available"
     sub = next((root / "submissions").glob("stub-stub-model-low-*"))
     rows = [
         json.loads(line)


### PR DESCRIPTION
The rounds question in the contribute wizard was a numbered 1-4 menu whose labels were round counts 1/3/5, so typing 5 for five rounds was rejected and 3 was the correct answer. The typed number is now the round count itself: Enter defaults to 1, any number of 1 or more runs that many rounds, and the 1/3/5 suggestions remain as plain guidance above the prompt. The separate "another number (type it)" option and its second prompt are gone. The wizard test now answers with the count directly and still verifies the run produces that many result rows.