### PR TITLE
Grade an undersized leg_cup instead of crashing the grader

### DIFF
--- a/evals/tasks/leg_cup/task.py
+++ b/evals/tasks/leg_cup/task.py
@@ -155,11 +155,15 @@ def _missing(shape, probe):
     samples, and the whole class of cheats this task's verification pass found lived in
     exactly the space between one probe point and the next.
     """
+    # A probe built from a boolean can come back empty when the part is smaller than
+    # the region it describes, and build123d turns a moved empty Compound into a bare
+    # list. An empty probe region has no material to miss.
+    probe_volume = getattr(probe, "volume", 0.0)
     try:
         kept = shape & probe
-        return probe.volume - (kept.volume if kept is not None else 0.0)
+        return probe_volume - (kept.volume if kept is not None else 0.0)
     except Exception:
-        return probe.volume
+        return probe_volume
 
 
 def misfits(shape, dims):

--- a/evals/tests/test_leg_cup.py
+++ b/evals/tests/test_leg_cup.py
@@ -221,6 +221,29 @@ def test_measurement_probes_preserve_project_helpers(tmp_path):
     assert changed["shape"].bounding_box().size.Z == pytest.approx(4.0)
 
 
+def test_undersized_part_grades_instead_of_crashing():
+    """A cup with 1.0mm walls makes the wall-ring probe's outer box smaller than its
+    inner cutter. The subtraction comes back empty, and build123d turns the moved
+    empty Compound into a bare list; the grader once crashed on it (a real
+    gpt-5.6-luna submission). It must grade as a misfit, not a crash."""
+    from build123d import Align, Box, Pos
+
+    task = scoring.load_task(TASK)
+    inst = task.instance(SEED)
+    dims = inst.dims
+    outer = Box(
+        dims["leg_width"] + 2.4,
+        dims["leg_depth"] + 2.4,
+        11.5,
+        align=(Align.CENTER, Align.CENTER, Align.MIN),
+    )
+    pocket = Pos(0, 0, 3.5) * Box(
+        dims["pocket_x"], dims["pocket_y"], 8.0, align=(Align.CENTER, Align.CENTER, Align.MIN)
+    )
+    problems, _ = task.misfits(outer - pocket, dims)
+    assert any("bounding box" in text for text, _ in problems)
+
+
 def test_audit_judges_the_entry():
     from build123d import Box
 


### PR DESCRIPTION
A gpt-5.6-luna benchmark run crashed the leg_cup grader: `AttributeError: 'list' object has no attribute 'volume'`. The submitted cup had 1.0mm walls, which made the wall-ring probe's outer box smaller than its inner cutter. build123d returns an empty Compound from that subtraction and turns the moved empty Compound into a bare list, so `_missing` crashed and the trial scored 0.0 with a grader error instead of its real misfits (it regrades to 0.533).

`_missing` now reads the probe volume defensively: an empty probe region has no material to miss. The fairness suite keeps the undersized case as a regression. Only leg_cup moves a boolean result with `Pos *`; the other tasks move primitives, which cannot come back empty.

Full evals suite passes (147 tests).