### PR TITLE
Reprice gpt-5.6-sol to OpenAI's lowered API rates

### DIFF
--- a/evals/prices.toml
+++ b/evals/prices.toml
@@ -43,9 +43,9 @@ cache_write_5m = 1.25
 cache_write_1h = 2.00
 
 [codex."gpt-5.6-sol"]
-input = 5.00
-output = 30.00
-cache_read = 0.50
+input = 4.00
+output = 20.00
+cache_read = 0.40
 
 [codex."gpt-5.6-terra"]
 input = 2.00


### PR DESCRIPTION
OpenAI cut GPT-5.6 Sol to $4 input / $20 output / $0.40 cache read per million tokens, promotional through at least November 21, 2026. Updates the Sol row in evals/prices.toml to match; Terra and Luna already match the published page. The table is read at report time, so existing leaderboard rows reprice on the next report with no revision bump. Pricing tests pass.