### PR TITLE
Run the full evals grading suite only when scorer or engine code changes

### DIFF
--- a/.claude/skills/leaderboard/SKILL.md
+++ b/.claude/skills/leaderboard/SKILL.md
@@ -42,6 +42,6 @@ uv run python -m nurb_evals.report --write
 uv run python -m nurb_evals.site
 ```
 
-Open `site/benchmarks.html` in a browser and look at it before publishing: label collisions on the chart, a card wrapping badly, an empty state showing when rows exist. Screenshot, not DOM-query. Then a PR (never straight to main): the regenerated pair, any verdict edits, and a body that lists which runs were published and which were rejected with reasons. `uv run pytest -q` from `evals/` must be green.
+Open `site/benchmarks.html` in a browser and look at it before publishing: label collisions on the chart, a card wrapping badly, an empty state showing when rows exist. Screenshot, not DOM-query. Then a PR (never straight to main): the regenerated pair, any verdict edits, and a body that lists which runs were published and which were rejected with reasons. `uv run pytest -q tests/test_report.py tests/test_pricing.py tests/test_contribute.py` from `evals/` must be green; the full grading suite only guards scorer code, which this skill never touches.
 
 The page deploys with `site/` however the site deploys; this skill's job ends at the merged PR.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The grading tests guard the scorer, and the scorer only changes when its code
+      # or the engine changes. Submission PRs, verdict edits (site.py is covered by
+      # test_report), and leaderboard regenerations are data-only and get the cheap
+      # validation tests instead of the full grading suite.
+      - uses: dorny/paths-filter@v3
+        id: changed
+        with:
+          filters: |
+            scorer:
+              - 'evals/src/**'
+              - '!evals/src/nurb_evals/site.py'
+              - 'evals/tasks/**'
+              - 'evals/tests/**'
+              - 'evals/pyproject.toml'
+              - 'evals/uv.lock'
+              - 'src/nurb/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -41,7 +60,12 @@ jobs:
       # parallelizes cleanly: 6:11 serial to 1:42 on four cores. loadscope keeps each
       # module's expensive module-scoped grades fixture on one worker instead of
       # rebuilding it per worker.
-      - run: uv run pytest -q -n auto --dist loadscope
+      - if: steps.changed.outputs.scorer == 'true'
+        run: uv run pytest -q -n auto --dist loadscope
+        working-directory: evals
+
+      - if: steps.changed.outputs.scorer != 'true'
+        run: uv run pytest -q tests/test_report.py tests/test_pricing.py tests/test_contribute.py
         working-directory: evals
 
   # The rules against the real library, on a machine that is not the one they were


### PR DESCRIPTION
Every PR paid for the evals grading tests, which build reference parts through OCCT, even when it only touched submissions, verdicts, or the regenerated leaderboard. The evals CI job now path-filters with dorny/paths-filter: the full suite runs when scorer code (evals/src minus site.py, tasks, tests) or the engine changes, and everything else runs just the report, pricing, and contribute tests. site.py is excluded because test_report covers it and it is where verdicts live, so leaderboard PRs stay on the cheap path. The /leaderboard skill's pre-PR green gate narrows to the same three tests. Verified locally: the three-test selection passes in 70s and the workflow YAML parses.