### PR TITLE
Attach images pasted into the desktop composer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,6 @@ jobs:
         with:
           filters: |
             scorer:
-              - 'evals/src/**'
-              - '!evals/src/nurb_evals/site.py'
               - 'evals/tasks/**'
               - 'evals/tests/**'
               - 'evals/pyproject.toml'
@@ -48,6 +46,20 @@ jobs:
               - 'src/nurb/**'
               - 'pyproject.toml'
               - 'uv.lock'
+
+      # The src-minus-site.py test needs its own step: a negation pattern only
+      # works under the `every` quantifier, and under the default `some` it
+      # matches every file in the repo, which ran the full suite on every PR.
+      # `every` in turn would break the plain list above, since no file can
+      # match two different globs at once.
+      - uses: dorny/paths-filter@v3
+        id: scorer_src
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - 'evals/src/**'
+              - '!evals/src/nurb_evals/site.py'
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -60,11 +72,11 @@ jobs:
       # parallelizes cleanly: 6:11 serial to 1:42 on four cores. loadscope keeps each
       # module's expensive module-scoped grades fixture on one worker instead of
       # rebuilding it per worker.
-      - if: steps.changed.outputs.scorer == 'true'
+      - if: steps.changed.outputs.scorer == 'true' || steps.scorer_src.outputs.code == 'true'
         run: uv run pytest -q -n auto --dist loadscope
         working-directory: evals
 
-      - if: steps.changed.outputs.scorer != 'true'
+      - if: steps.changed.outputs.scorer != 'true' && steps.scorer_src.outputs.code != 'true'
         run: uv run pytest -q tests/test_report.py tests/test_pricing.py tests/test_contribute.py
         working-directory: evals
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -279,6 +279,53 @@ async fn create_part(app: AppHandle, path: String, name: String) -> Result<Strin
     Ok(part.replace('-', "_"))
 }
 
+/// A pasted image has no path for the attachment list, so it lands in a
+/// temporary file first. Each paste gets its own directory so the friendly
+/// filename never collides across pastes.
+#[tauri::command]
+fn save_pasted_image(request: tauri::ipc::Request) -> Result<String, String> {
+    let tauri::ipc::InvokeBody::Raw(bytes) = request.body() else {
+        return Err("expected raw image bytes".into());
+    };
+    let mime = request.headers().get("mime").and_then(|m| m.to_str().ok());
+    Ok(write_pasted_image(mime, bytes)?
+        .to_string_lossy()
+        .into_owned())
+}
+
+fn write_pasted_image(mime: Option<&str>, bytes: &[u8]) -> Result<PathBuf, String> {
+    // Keep the real type: attachment_block embeds the formats agents support
+    // and links everything else. Renaming TIFF or HEIC bytes to PNG makes an
+    // invalid embedded image instead of a readable file attachment.
+    let extension = match mime {
+        Some("image/png") => "png",
+        Some("image/jpeg") => "jpg",
+        Some("image/gif") => "gif",
+        Some("image/webp") => "webp",
+        Some("image/tiff") => "tiff",
+        Some("image/bmp") => "bmp",
+        Some("image/avif") => "avif",
+        Some("image/heic") => "heic",
+        Some("image/heif") => "heif",
+        Some("image/svg+xml") => "svg",
+        Some("image/x-icon") | Some("image/vnd.microsoft.icon") => "ico",
+        Some(other) => return Err(format!("cannot paste {other} images")),
+        None => return Err("pasted image has no type".into()),
+    };
+    let dir = std::env::temp_dir().join(format!(
+        "nurb-paste-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).map_err(|e| format!("could not save pasted image: {e}"))?;
+    let path = dir.join(format!("pasted-image.{extension}"));
+    std::fs::write(&path, bytes).map_err(|e| format!("could not save pasted image: {e}"))?;
+    Ok(path)
+}
+
 #[tauri::command]
 async fn list_parts(app: AppHandle, path: String) -> Result<serde_json::Value, String> {
     let project = PathBuf::from(path);
@@ -499,6 +546,7 @@ pub fn run() {
             create_part,
             delete_part,
             list_parts,
+            save_pasted_image,
             acp::start_chat,
             acp::list_sessions,
             acp::send_prompt,
@@ -528,8 +576,37 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::registry::Registry;
-    use super::{part_views, project_base, register_projects_in_folder, seed_part_name};
+    use super::{
+        part_views, project_base, register_projects_in_folder, seed_part_name, write_pasted_image,
+    };
     use std::path::PathBuf;
+
+    #[test]
+    fn pasted_images_land_in_unique_files_with_honest_extensions() {
+        let png = write_pasted_image(Some("image/png"), b"png bytes").unwrap();
+        assert_eq!(png.file_name().unwrap(), "pasted-image.png");
+        assert_eq!(std::fs::read(&png).unwrap(), b"png bytes");
+
+        let jpg = write_pasted_image(Some("image/jpeg"), b"jpg bytes").unwrap();
+        assert_eq!(jpg.file_name().unwrap(), "pasted-image.jpg");
+        // Two pastes in one session must not overwrite each other.
+        assert_ne!(png.parent(), jpg.parent());
+
+        // Finder preserves native image bytes, so non-embeddable types must
+        // retain an honest extension and travel as file links.
+        let odd = write_pasted_image(Some("image/tiff"), b"bytes").unwrap();
+        assert_eq!(odd.file_name().unwrap(), "pasted-image.tiff");
+        assert!(write_pasted_image(Some("image/vnd.unknown"), b"bytes")
+            .unwrap_err()
+            .contains("cannot paste"));
+        assert!(write_pasted_image(None, b"bytes")
+            .unwrap_err()
+            .contains("no type"));
+
+        for path in [png, jpg, odd] {
+            std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+        }
+    }
 
     #[test]
     fn seed_part_names_survive_becoming_identifiers() {

--- a/desktop/src/Chat.tsx
+++ b/desktop/src/Chat.tsx
@@ -1,4 +1,5 @@
 import {
+  ClipboardEvent,
   FormEvent,
   KeyboardEvent,
   useCallback,
@@ -13,7 +14,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { IconChevronDown, IconMessagePlus, IconPaperclip } from "./Icons";
 import Markdown from "./Markdown";
 import { playChime, shouldPlayCompletionChime } from "./chime";
-import { restoreDraftFiles, restoreDraftText } from "./chatDraft";
+import { AttachmentDraft, restoreDraftText } from "./chatDraft";
 
 // The whole-project conversation rides the per-part plumbing under a name no part
 // file can have. Twins live in App.tsx's mount and acp.rs's context line.
@@ -181,6 +182,11 @@ function Chat({
   const [permissions, setPermissions] = useState<Permission[]>([]);
   // Absolute paths; the Rust side reads them at send time.
   const [attachments, setAttachments] = useState<string[]>([]);
+  const attachmentDraftRef = useRef<AttachmentDraft | null>(null);
+  if (!attachmentDraftRef.current) {
+    attachmentDraftRef.current = new AttachmentDraft(setAttachments);
+  }
+  const attachmentDraft = attachmentDraftRef.current;
   const [dropping, setDropping] = useState(false);
   // The model and effort this conversation runs on. Empty before the agent has
   // ever reported its lists, which is only ever the first chat on this Mac.
@@ -282,13 +288,13 @@ function Chat({
       if (event.payload.type === "drop") {
         setDropping(false);
         const paths = event.payload.paths;
-        setAttachments((list) => [...new Set([...list, ...paths])]);
+        attachmentDraft.add(paths);
       }
     });
     return () => {
       unlisten.then((stop) => stop());
     };
-  }, [hidden]);
+  }, [hidden, attachmentDraft]);
 
   const applyEvent = useCallback((event: ChatEvent) => {
     switch (event.type) {
@@ -522,7 +528,7 @@ function Chat({
           if (inputRef.current) {
             inputRef.current.value = restoreDraftText(text, inputRef.current.value);
           }
-          setAttachments((draftFiles) => restoreDraftFiles(files, draftFiles));
+          attachmentDraft.restore(files);
           setAuthNeeded(true);
         } else {
           setItems((list) => [...list, { kind: "note", text: message }]);
@@ -537,10 +543,10 @@ function Chat({
         if (shouldPlayCompletionChime(completed, Date.now() - startedAt)) playChime();
       }
     },
-    [ensureSession, part],
+    [ensureSession, part, attachmentDraft],
   );
 
-  const submit = (event: FormEvent<HTMLFormElement>) => {
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const box = inputRef.current;
     const text = box?.value.trim() ?? "";
@@ -548,22 +554,53 @@ function Chat({
     // and a double send would spawn a second adapter. A photo alone is a
     // legitimate message ("model this"), so attachments count as content.
     if (
-      (!text && attachments.length === 0) ||
+      (!text && !attachmentDraft.hasContent) ||
       sendingRef.current ||
       starting ||
       startRef.current
     )
       return;
+    // Reserve the turn before waiting: a second Enter must not queue another
+    // send while a pasted image is still crossing the IPC boundary.
+    sendingRef.current = true;
     if (box) box.value = "";
-    setAttachments([]);
-    send(text, attachments);
+    const files = await attachmentDraft.take();
+    if (!text && files.length === 0) {
+      sendingRef.current = false;
+      return;
+    }
+    send(text, files);
   };
 
   const attach = async () => {
     const picked = await open({ multiple: true, title: "Attach files" });
     if (!picked) return;
     const paths = Array.isArray(picked) ? picked : [picked];
-    setAttachments((list) => [...new Set([...list, ...paths])]);
+    attachmentDraft.add(paths);
+  };
+
+  // A pasted image (a screenshot, or an image copied from another app) has no
+  // path, so the backend writes it to a temporary file that attaches like a
+  // dropped one. Consuming the paste keeps a copied file's name out of the text.
+  const paste = (event: ClipboardEvent<HTMLTextAreaElement>) => {
+    const images = Array.from(event.clipboardData.items)
+      .filter((item) => item.type.startsWith("image/"))
+      .map((item) => item.getAsFile())
+      .filter((blob): blob is File => blob !== null);
+    if (images.length === 0) return;
+    event.preventDefault();
+    const saved = Promise.all(
+      images.map((blob) =>
+        blob.arrayBuffer().then((bytes) =>
+          invoke<string>("save_pasted_image", new Uint8Array(bytes), {
+            headers: { mime: blob.type },
+          }),
+        ),
+      ),
+    );
+    attachmentDraft.track(saved).catch((e) =>
+      setItems((list) => [...list, { kind: "note", text: String(e) }]),
+    );
   };
 
   const keydown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -828,9 +865,7 @@ function Chat({
                   type="button"
                   className="chat-attachment-remove"
                   aria-label={`remove ${basename(path)}`}
-                  onClick={() =>
-                    setAttachments((list) => list.filter((p) => p !== path))
-                  }
+                  onClick={() => attachmentDraft.remove(path)}
                 >
                   ×
                 </button>
@@ -853,6 +888,7 @@ function Chat({
           rows={2}
           disabled={starting}
           onKeyDown={keydown}
+          onPaste={paste}
         />
         <div className="chat-composer-controls">
           <button

--- a/desktop/src/chatDraft.ts
+++ b/desktop/src/chatDraft.ts
@@ -7,3 +7,64 @@ export function restoreDraftText(failed: string, draft: string): string {
 export function restoreDraftFiles(failed: string[], draft: string[]): string[] {
   return [...new Set([...failed, ...draft])];
 }
+
+export class AttachmentDraft {
+  private files: string[] = [];
+  private pending: Promise<string[]>[] = [];
+  private readonly onChange: (files: string[]) => void;
+
+  constructor(onChange: (files: string[]) => void) {
+    this.onChange = onChange;
+  }
+
+  get hasContent(): boolean {
+    return this.files.length > 0 || this.pending.length > 0;
+  }
+
+  add(paths: string[]): void {
+    this.replace(restoreDraftFiles(this.files, paths));
+  }
+
+  restore(paths: string[]): void {
+    this.replace(restoreDraftFiles(paths, this.files));
+  }
+
+  remove(path: string): void {
+    this.replace(this.files.filter((file) => file !== path));
+  }
+
+  track(task: Promise<string[]>): Promise<void> {
+    const pending = task.then((paths) => {
+      this.add(paths);
+      return paths;
+    });
+    this.pending.push(pending);
+    // The caller reports failures; this branch only keeps settled work out of
+    // the next submit boundary without creating an unhandled rejection.
+    void pending
+      .finally(() => {
+        this.pending = this.pending.filter((item) => item !== pending);
+      })
+      .catch(() => {});
+    return pending.then(() => undefined);
+  }
+
+  async take(): Promise<string[]> {
+    // Snapshot the boundary: pastes begun before submit belong to this turn;
+    // anything pasted afterward stays in the next draft.
+    const files = [...this.files];
+    const pending = [...this.pending];
+    const settled = await Promise.allSettled(pending);
+    for (const result of settled) {
+      if (result.status === "fulfilled") files.push(...result.value);
+    }
+    const taken = [...new Set(files)];
+    this.replace(this.files.filter((path) => !taken.includes(path)));
+    return taken;
+  }
+
+  private replace(files: string[]): void {
+    this.files = files;
+    this.onChange(files);
+  }
+}

--- a/desktop/tests/chatDraft.test.ts
+++ b/desktop/tests/chatDraft.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { restoreDraftFiles, restoreDraftText } from "../src/chatDraft.ts";
+import {
+  AttachmentDraft,
+  restoreDraftFiles,
+  restoreDraftText,
+} from "../src/chatDraft.ts";
 
 test("an auth failure preserves work composed during the failed turn", () => {
   assert.equal(
@@ -13,4 +17,28 @@ test("an auth failure preserves work composed during the failed turn", () => {
     restoreDraftFiles(["original.stl"], ["next.png", "original.stl"]),
     ["original.stl", "next.png"],
   );
+});
+
+test("submission waits for every paste already being saved", async () => {
+  let shown: string[] = [];
+  let finishFirst!: (paths: string[]) => void;
+  let finishSecond!: (paths: string[]) => void;
+  const first = new Promise<string[]>((resolve) => {
+    finishFirst = resolve;
+  });
+  const second = new Promise<string[]>((resolve) => {
+    finishSecond = resolve;
+  });
+  const draft = new AttachmentDraft((files) => {
+    shown = files;
+  });
+
+  draft.track(first);
+  draft.track(second);
+  const submitted = draft.take();
+  finishSecond(["second.png"]);
+  finishFirst(["first.png"]);
+
+  assert.deepEqual(await submitted, ["first.png", "second.png"]);
+  assert.deepEqual(shown, []);
 });


### PR DESCRIPTION
Pasting an image into the chat composer (a screenshot, or an image copied from another app) now attaches it like a dropped file. The webview sends the clipboard bytes to a new `save_pasted_image` command, which writes them to a per-paste temp file whose path joins the attachment list, chip and remove button included. A new `AttachmentDraft` tracks in-flight saves so submitting waits for pastes still crossing the IPC boundary, and a reserved sending flag keeps a second Enter from double-sending. Non-embeddable types (TIFF, HEIC, SVG, and friends) keep their honest extension so they travel as file links instead of broken embedded images; unknown types report a clear error as a chat note. Covered by a Rust unit test for the write path and a JS test for the submit boundary.

Closes #187