### PR TITLE
Ahrefs: link directly to canonical site routes

### DIFF
--- a/evals/src/nurb_evals/site.py
+++ b/evals/src/nurb_evals/site.py
@@ -267,16 +267,16 @@ HEAD = """\
 
 <header>
   <div class="wrap">
-    <a class="logo" href="index.html"><svg><use href="#i-cube"/></svg>nurb</a>
+    <a class="logo" href="/"><svg><use href="#i-cube"/></svg>nurb</a>
     <button class="menu-btn" aria-label="menu" aria-expanded="false">
       <svg class="bars" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="2.5" y1="5.5" x2="17.5" y2="5.5"/><line x1="2.5" y1="10" x2="17.5" y2="10"/><line x1="2.5" y1="14.5" x2="17.5" y2="14.5"/></svg>
       <svg class="x" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="4.5" y1="4.5" x2="15.5" y2="15.5"/><line x1="15.5" y1="4.5" x2="4.5" y2="15.5"/></svg>
     </button>
     <nav>
-      <a href="index.html#demo">the app</a>
-      <a href="index.html#how">how it works</a>
-      <a href="index.html#start">get started</a>
-      <a class="here" href="benchmarks.html">benchmarks</a>
+      <a href="/#demo">the app</a>
+      <a href="/#how">how it works</a>
+      <a href="/#start">get started</a>
+      <a class="here" href="/benchmarks">benchmarks</a>
       <a href="/changelog">changelog</a>
       <a class="gh" href="https://github.com/Shpigford/nurb">github &nearr;</a>
     </nav>

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -187,16 +187,16 @@
 
 <header>
   <div class="wrap">
-    <a class="logo" href="index.html"><svg><use href="#i-cube"/></svg>nurb</a>
+    <a class="logo" href="/"><svg><use href="#i-cube"/></svg>nurb</a>
     <button class="menu-btn" aria-label="menu" aria-expanded="false">
       <svg class="bars" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="2.5" y1="5.5" x2="17.5" y2="5.5"/><line x1="2.5" y1="10" x2="17.5" y2="10"/><line x1="2.5" y1="14.5" x2="17.5" y2="14.5"/></svg>
       <svg class="x" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="4.5" y1="4.5" x2="15.5" y2="15.5"/><line x1="15.5" y1="4.5" x2="4.5" y2="15.5"/></svg>
     </button>
     <nav>
-      <a href="index.html#demo">the app</a>
-      <a href="index.html#how">how it works</a>
-      <a href="index.html#start">get started</a>
-      <a class="here" href="benchmarks.html">benchmarks</a>
+      <a href="/#demo">the app</a>
+      <a href="/#how">how it works</a>
+      <a href="/#start">get started</a>
+      <a class="here" href="/benchmarks">benchmarks</a>
       <a href="/changelog">changelog</a>
       <a class="gh" href="https://github.com/Shpigford/nurb">github &nearr;</a>
     </nav>

--- a/site/index.html
+++ b/site/index.html
@@ -242,7 +242,7 @@
       <a href="#demo">the app</a>
       <a href="#how">how it works</a>
       <a href="#start">get started</a>
-      <a href="benchmarks.html">benchmarks</a>
+      <a href="/benchmarks">benchmarks</a>
       <a href="/changelog">changelog</a>
       <a class="gh" href="https://github.com/Shpigford/nurb">github &nearr;</a>
     </nav>
@@ -441,7 +441,7 @@
     <span>&copy; 2026 Ordinary Systems LLC</span>
     <a href="https://github.com/Shpigford/nurb/blob/main/LICENSE">FSL-1.1-MIT</a>
     <span class="spacer"></span>
-    <a href="benchmarks.html">benchmarks</a>
+    <a href="/benchmarks">benchmarks</a>
     <a href="/changelog">changelog</a>
     <a href="https://github.com/Shpigford/nurb">github</a>
     <a href="https://x.com/Shpigford">@shpigford</a>


### PR DESCRIPTION
## Ahrefs evidence

- Project: Nurb (`10275962`)
- Completed crawl: `2026-08-24T12:03:45Z` (Ahrefs MCP does not expose the numeric crawl ID)
- Issue: `Page has links to redirect` (`c64d3aa7-d0f4-11e7-8ed1-001e67ed4656`, Warning)
- Affected pages:
  - `https://nurb.dev/` linked to `https://nurb.dev/benchmarks.html`, which returned 308 to `/benchmarks`
  - `https://nurb.dev/benchmarks` linked to `https://nurb.dev/index.html`, which returned 308 to `/`
- Ahrefs confirmed both affected pages return HTTP 200 and both redirect targets resolve to stable same-host final destinations.

## Root cause

The static site used file-style relative links (`index.html` and `benchmarks.html`) even though the deployed host canonicalizes those documents to extensionless routes. The generated benchmark page repeated the same links.

## Fix

Link the homepage and benchmark page directly to `/` and `/benchmarks`, preserving the existing section fragments. Update both the committed benchmark output and its generator so regeneration does not restore the redirects.

## Validation

- `cd evals && uv run pytest -q tests/test_report.py tests/test_pricing.py tests/test_contribute.py` — 24 passed
- Focused generator/static-page assertion — passed; neither deployed page nor generated benchmark output contains `href="index.html..."` or `href="benchmarks.html"`, and canonical route links are present
- Browser verification — `https://nurb.dev/` and `https://nurb.dev/benchmarks` both loaded successfully
- `git diff --check` — passed

## Residual risk

Low. This changes only same-host link destinations to the already-live final 200 routes. It does not alter redirect rules, page content, canonical/indexing policy, or application behavior.

<!-- ahrefs-site-audit:08b459039ba6df682d527e6c37744d902f8a1ffd08f0b697a91e8b5886f5b853 -->
