### PR TITLE
Fix the desktop app looking frozen during the engine's cold start (#202)

### DIFF
--- a/desktop/src-tauri/src/supervisor.rs
+++ b/desktop/src-tauri/src/supervisor.rs
@@ -9,8 +9,10 @@ use std::thread;
 use std::time::Duration;
 
 const DEFAULT_PORT: u16 = 7373;
-// The first build absorbs the cold OCCT import, which alone takes ~45 seconds.
-const READY_TIMEOUT: Duration = Duration::from_secs(180);
+// The first build absorbs the cold OCCT import, which alone takes ~45 seconds on an
+// idle machine and stretched past two minutes on a loaded one (issue #202), so the
+// deadline leaves room for a busy machine rather than killing a nearly-ready server.
+const READY_TIMEOUT: Duration = Duration::from_secs(300);
 
 pub struct Supervisor {
     state: Mutex<SupervisorState>,
@@ -113,22 +115,37 @@ impl Supervisor {
     }
 
     fn start(&self, project: &Path) -> Result<Arc<ProjectServer>, String> {
-        let mut attempt = self.spawn(project)?;
-        if let Err(first) = wait_ready(&attempt) {
-            // A port grabbed between our probe and the bind is a hard exit
-            // (cli.py treats an explicitly asked-for taken port as an error),
-            // so one respawn on a fresh port covers the race.
-            kill_tree(&attempt);
-            if self.is_shutting_down() {
-                return Err("app is shutting down".into());
-            }
-            attempt = self.spawn(project)?;
-            if let Err(second) = wait_ready(&attempt) {
+        let attempt = self.spawn(project)?;
+        let first = match wait_ready(&attempt) {
+            Ok(()) => return Ok(attempt),
+            // A timed-out server is almost always a slow one, not a dead one
+            // (issue #202: a loaded machine stretched the cold OCCT import past
+            // two minutes); killing it to start over just pays the same cost
+            // again, so a timeout is a plain error, never a respawn.
+            Err(NotReady::TimedOut) => {
                 kill_tree(&attempt);
-                return Err(format!("{first}; retry: {second}"));
+                return Err(format!(
+                    "nurb dev did not become ready within {}s",
+                    READY_TIMEOUT.as_secs()
+                ));
+            }
+            Err(NotReady::Exited(reason)) => reason,
+        };
+        // A port grabbed between our probe and the bind is a hard exit
+        // (cli.py treats an explicitly asked-for taken port as an error),
+        // so one respawn on a fresh port covers the race.
+        kill_tree(&attempt);
+        if self.is_shutting_down() {
+            return Err("app is shutting down".into());
+        }
+        let attempt = self.spawn(project)?;
+        match wait_ready(&attempt) {
+            Ok(()) => Ok(attempt),
+            Err(second) => {
+                kill_tree(&attempt);
+                Err(format!("{first}; retry: {}", second.message()))
             }
         }
-        Ok(attempt)
     }
 
     /// Claim a port and publish the child while holding the shared state lock.
@@ -256,7 +273,26 @@ fn spawn_server(
     }))
 }
 
-fn wait_ready(server: &ProjectServer) -> Result<(), String> {
+enum NotReady {
+    /// The child died before printing its URL: a port race or a broken env.
+    Exited(String),
+    /// Still alive, just not ready yet.
+    TimedOut,
+}
+
+impl NotReady {
+    fn message(&self) -> String {
+        match self {
+            Self::Exited(reason) => reason.clone(),
+            Self::TimedOut => format!(
+                "nurb dev did not become ready within {}s",
+                READY_TIMEOUT.as_secs()
+            ),
+        }
+    }
+}
+
+fn wait_ready(server: &ProjectServer) -> Result<(), NotReady> {
     let stdout = server
         .child
         .lock()
@@ -264,16 +300,13 @@ fn wait_ready(server: &ProjectServer) -> Result<(), String> {
         .process
         .stdout
         .take()
-        .ok_or("child stdout missing")?;
+        .ok_or_else(|| NotReady::Exited("child stdout missing".into()))?;
     let (tx, rx) = mpsc::channel();
     drain_stdout(stdout, server.port, tx);
     match rx.recv_timeout(READY_TIMEOUT) {
         Ok(Ok(())) => Ok(()),
-        Ok(Err(e)) => Err(e),
-        Err(_) => Err(format!(
-            "nurb dev did not become ready within {}s",
-            READY_TIMEOUT.as_secs()
-        )),
+        Ok(Err(e)) => Err(NotReady::Exited(e)),
+        Err(_) => Err(NotReady::TimedOut),
     }
 }
 

--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -1388,6 +1388,13 @@ textarea {
   white-space: pre-wrap;
 }
 
+.viewer-status-detail {
+  margin-top: 8px;
+  font-size: 12px;
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+
 .setup {
   height: 100vh;
   display: flex;

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -111,6 +111,28 @@ function DeleteHints({ places }: { places: string[] }) {
   );
 }
 
+// The engine's cold start runs a heavy geometry-kernel import that can take minutes
+// on a busy machine, and a static message over an empty window reads as a frozen app
+// (issue #202: killed and reopened three times while the engine was still starting).
+// A ticking count is the proof of life; the second line sets an honest expectation.
+function EngineStarting() {
+  const [seconds, setSeconds] = useState(0);
+  useEffect(() => {
+    const timer = setInterval(() => setSeconds((s) => s + 1), 1000);
+    return () => clearInterval(timer);
+  }, []);
+  return (
+    <div className="viewer-status">
+      starting the CAD engine…
+      {seconds >= 10 && (
+        <div className="viewer-status-detail">
+          {seconds}s — a cold start can take a few minutes when the computer is busy
+        </div>
+      )}
+    </div>
+  );
+}
+
 // Which assemblies place each part. Every assembly already carries its `uses`, so
 // the other direction is a read of the list the rail has, not a second server call.
 function placedInMap(parts: Part[]) {
@@ -1401,7 +1423,7 @@ function App() {
             }
           />
         ) : active && opening[active] ? (
-          <div className="viewer-status">starting the CAD engine…</div>
+          <EngineStarting />
         ) : (
           <div className="viewer-status">
             {projectsLoaded && projects.length === 0


### PR DESCRIPTION
The desktop app looked frozen on open while the engine ran its multi-minute cold OCCT import, and the supervisor's 180s deadline could kill a nearly-ready server on a busy machine (issue #202, where the app was force-quit and reopened three times mid-startup). The viewer now shows a ticking seconds counter with an honest expectation that a cold start can take a few minutes on a busy machine. The ready deadline rises to 300s, and a timeout is now a plain error instead of a respawn that would only pay the same cold-start cost again.