### PR TITLE
Show an always-visible progress bar during benchmark runs

### DIFF
--- a/evals/src/nurb_evals/contribute.py
+++ b/evals/src/nurb_evals/contribute.py
@@ -183,6 +183,15 @@ def stage_submission(out, label, task, n):
     return dst
 
 
+def progress(done, total, width=18):
+    """A bar plus a count, printed with every trial line so the last line on
+    screen always says how far along the run is, even when a single trial sits
+    silent for an hour."""
+    filled = round(width * done / total)
+    bar = style("█" * filled, GREEN) + style("░" * (width - filled), DIM)
+    return f"{bar} {style(f'{done}/{total}', BOLD)}"
+
+
 def next_trial(out, task):
     """Continue numbering after earlier local runs instead of refusing the slot."""
     n = 1
@@ -334,21 +343,24 @@ def main():
 
     h = harnesses.HARNESSES[name]
     staged = []
+    total = len(tasks) * trials
+    done = 0
     with open(out / "results.jsonl", "a", encoding="utf-8") as sink:
         for task in tasks:
             for _ in range(trials):
                 n = next_trial(out, task)
                 tag = style(f"[{task} trial {n}]", CYAN)
-                print(f"{tag} {style('running...', DIM)}", flush=True)
+                print(f"{progress(done, total)} {tag} {style('running...', DIM)}", flush=True)
                 row = completed_trial(
                     h, EVALS / "tasks" / task, args.seed, n, out,
                     model=model, effort=effort, timeout=args.timeout,
                 )
                 sink.write(json.dumps(row) + "\n")
                 sink.flush()
+                done += 1
                 note = style(f"  ({row['error']})", RED) if row["error"] else ""
                 score = style(f"{row['score']:.3f}", RED if row["error"] else GREEN, BOLD)
-                print(f"{tag} score {score}{note}", flush=True)
+                print(f"{progress(done, total)} {tag} score {score}{note}", flush=True)
                 staged.append(stage_submission(out, run_name, task, n))
 
     # The staged submission needs the matching rows; sanitize the whole file so a

--- a/evals/tests/test_contribute.py
+++ b/evals/tests/test_contribute.py
@@ -166,6 +166,10 @@ def test_wizard_runs_and_stages_a_sanitized_submission(tmp_path, monkeypatch, ca
             assert str(pathlib.Path.home()) not in staged.read_text(errors="replace")
 
     printed = capsys.readouterr().out
+    # The last line on screen always carries the run's progress, so a person
+    # glancing at a long run never has to count finished trials by hand.
+    assert "░░░░░░░░░░░░░░░░░░ 0/1" in printed
+    assert "██████████████████ 1/1" in printed
     assert "Staged in this checkout" in printed and str(root) in printed
     assert f"benchmark run: {sub.name}" in printed
     assert f"git add evals/submissions/{sub.name}" in printed


### PR DESCRIPTION
The contribute wizard now prefixes every trial line with a progress bar and a done/total count computed from tasks times rounds. Trials print nothing while they work, so the running line sits at the bottom of the terminal and always shows how far along the run is, instead of making the contributor count finished lines by hand. The wizard test asserts both the empty and the full bar appear in a run's output.