### PR TITLE
Show per-effort run counts in the contribute wizard's effort menu

### DIFF
--- a/evals/src/nurb_evals/contribute.py
+++ b/evals/src/nurb_evals/contribute.py
@@ -287,10 +287,13 @@ def main():
     if model in RETIRED:
         sys.exit(f"{model} is retired from the benchmark; the leaderboard no longer accepts its rows.")
 
+    def effort_label(e):
+        return f"{e} {style(f'({runs_note(counts.get((name, model, e), 0))})', DIM)}"
+
     effort = args.effort or (
         default_effort
         if picked or not efforts
-        else ask("Thinking effort", [(e, e) for e in efforts], default=default_effort)
+        else ask("Thinking effort", [(e, effort_label(e)) for e in efforts], default=default_effort)
     )
 
     tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]


### PR DESCRIPTION
The wizard's thinking-effort menu now shows how many pooled runs each effort level already has on the board, in the same dim style the model menu uses. The counts come from the same board_counts() pool keyed by (harness, model, effort), so they sum to the model line's total and make the least-covered effort obvious at a glance.