### PR TITLE
Release 0.23.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -379,7 +379,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.22.2"
+version = "0.23.0"
 source = { editable = "../" }
 dependencies = [
     { name = "build123d" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.22.2"
+version = "0.23.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,15 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.23.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.23.0">v0.23.0</a></span><time datetime="2026-08-25">August 25, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Paste an image into chat.</b> A screenshot, or a photo copied from another app, now attaches to your message the same way a dropped file does. Show your AI the thing you are trying to fit instead of describing it.</span></li>
+      <li><b class="tag">improved</b><span>You can write your next message while your AI is still working. It sends once the current work stops, and nothing you typed gets thrown away if you have to sign in again partway through.</span></li>
+      <li><b class="tag">fixed</b><span>The app looked frozen the first time you opened it, while the modeling engine warmed up in the background. The opening screen now counts the seconds and tells you a first start can take a few minutes on a busy machine, and the app waits instead of giving up on an engine that is nearly ready.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.22.2">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.22.2">v0.22.2</a></span><time datetime="2026-08-19">August 19, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.22.2"
+  version: "0.23.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.22.2"
+  version: "0.23.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.22.2"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Cuts 0.23.0 across the engine, the skill files, and the desktop app. Bumps the four version strings, relocks `evals/uv.lock` against the new version, and adds the changelog entry.

## What ships

**Paste an image into chat.** A screenshot or an image copied from another app now attaches to a message the same way a dropped file does, so you can show your AI the thing you are trying to fit instead of describing it.

**Compose while the agent works.** You can write and attach the next message while the current one is still running. Sending waits for the work to stop, and a draft survives a mid-run sign-in.

**The cold-start freeze is gone.** Opening the app for the first time no longer looks frozen while the modeling engine warms up: the opening screen counts the seconds and says a first start can take a few minutes on a busy machine. The supervisor waits 300s and reports a plain error instead of respawning an engine that would only pay the same cold-start cost again.

The rest of the work merged since 0.22.2 is benchmark and leaderboard infrastructure, which nobody using nurb sees, so it earns no changelog line.

## Verification

`uv run pytest tests/test_cli.py -q` passes, which is what enforces that all four version strings agree. The changelog entry was rendered in a browser and matches its neighbors.

https://claude.ai/code/session_01T4jt4Mww1gJ7mfBJTyGuwr