### PR TITLE
Publish four merged benchmark runs to the leaderboard

### DIFF
--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -234,12 +234,12 @@
 <div class="answers">
 <div class="answer">
   <div class="have"><i style="background:#2f9fb5"></i>Have Claude?</div>
-  <div class="pick">run claude-sonnet-5</div>
-  <div class="effort">at xhigh effort</div>
+  <div class="pick">run claude-fable-5</div>
+  <div class="effort">at low effort</div>
   <div class="facts">
-    <div><span>first-try prints</span><b>12/12</b></div>
-    <div><span>time per part</span><b>~17 min</b></div>
-    <div><span>$/part at API rates</span><b>~$2.89</b></div>
+    <div><span>first-try prints</span><b>18/18</b></div>
+    <div><span>time per part</span><b>~4 min</b></div>
+    <div><span>$/part at API rates</span><b>~$1.78</b></div>
   </div>
 </div>
 <div class="answer">
@@ -257,9 +257,9 @@
   <div class="pick">run grok-4.6</div>
   <div class="effort">at low effort</div>
   <div class="facts">
-    <div><span>first-try prints</span><b>35/36</b></div>
+    <div><span>first-try prints</span><b>53/54</b></div>
     <div><span>time per part</span><b>~2 min</b></div>
-    <div><span>$/part at API rates</span><b>~$0.078</b></div>
+    <div><span>$/part at API rates</span><b>~$0.071</b></div>
   </div>
 </div>
 </div>
@@ -272,24 +272,42 @@
 <details class="top">
   <summary>
     <span class="rank">1</span>
-    <span class="who"><span class="model">claude-sonnet-5 <small>&middot; xhigh</small></span>
+    <span class="who"><span class="model">claude-fable-5 <small>&middot; low</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i style="width:100%"></i></span>
-      <span><b>12/12</b> &middot; 100%</span></span>
+      <span><b>18/18</b> &middot; 100%</span></span>
     <span class="cells"><i class="ok" title="Follow the spec: 100%"></i><i class="ok" title="Survive the kernel: 100%"></i><i class="ok" title="Design from a problem: 100%"></i><i class="ok" title="Design a curve: 100%"></i><i class="ok" title="Make it fit: 100%"></i><i class="ok" title="Handle a missing measurement: 100%"></i></span>
-    <span class="time" title="~17 min/part">~17 min</span>
-    <span class="cost">~$2.89</span>
+    <span class="time" title="~4 min/part">~4 min</span>
+    <span class="cost">~$1.78</span>
   </summary>
   <div class="body">
-  <p class="verdict">Right on all six jobs, and the slowest route there by a wide margin. One design job ran past forty minutes. Pick it when the part matters more than the wait.</p>
+  <p class="verdict">Eighteen attempts, eighteen parts worth printing, every job included, and it recorded the unmeasured dimension as a guess every time. About four minutes and a dollar eighty a part, which is half the time and half the money of the same model at high effort, and high effort is the one that misses. This is one person&#x27;s run of three attempts a job, so it is a thinner sample than the Grok row under it.</p>
   <div class="bars">
-    <div class="name">Follow the spec</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Survive the kernel</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Design from a problem</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Design a curve</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Make it fit</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Handle a missing measurement</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div>
+    <div class="name">Follow the spec</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Survive the kernel</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Design from a problem</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Design a curve</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Make it fit</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Handle a missing measurement</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div>
   </div>
   </div>
 </details>
 <details>
   <summary>
     <span class="rank">2</span>
+    <span class="who"><span class="model">grok-4.6 <small>&middot; low</small></span>
+      <span class="plan"><i style="background:#b8bec9"></i>Grok</span></span>
+    <span class="rate"><span class="rbar"><i style="width:98%"></i></span>
+      <span><b>53/54</b> &middot; 98%</span></span>
+    <span class="cells"><i class="ok" title="Follow the spec: 100%"></i><i class="ok" title="Survive the kernel: 100%"></i><i class="ok" title="Design from a problem: 96%"></i><i class="ok" title="Design a curve: 100%"></i><i class="ok" title="Make it fit: 100%"></i><i class="ok" title="Handle a missing measurement: 100%"></i></span>
+    <span class="time" title="~2 min/part">~2 min</span>
+    <span class="cost">~$0.071</span>
+  </summary>
+  <div class="body">
+  <p class="verdict">Fifty-three of fifty-four right, pooled from two people&#x27;s runs, at about two and a half minutes and seven cents a part. The curved pole rest and the D-shaft knob, the two jobs that catch most models, came out right on all nine attempts each. Its one miss was a wall clip you could not get a screwdriver into. Nothing else here gets this much right for this little, and the same model at xhigh takes five times as long to do no better.</p>
+  <div class="bars">
+    <div class="name">Follow the spec</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Survive the kernel</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Design from a problem</div><div class="bar"><i style="width:96%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(60.0% - 1px)" title="attempt: 0.600"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">96%</div><div class="name">Design a curve</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Make it fit</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Handle a missing measurement</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div>
+  </div>
+  </div>
+</details>
+<details>
+  <summary>
+    <span class="rank">3</span>
     <span class="who"><span class="model">grok-4.6 <small>&middot; xhigh</small></span>
       <span class="plan"><i style="background:#b8bec9"></i>Grok</span></span>
     <span class="rate"><span class="rbar"><i style="width:97%"></i></span>
@@ -307,25 +325,25 @@
 </details>
 <details>
   <summary>
-    <span class="rank">3</span>
-    <span class="who"><span class="model">grok-4.6 <small>&middot; low</small></span>
-      <span class="plan"><i style="background:#b8bec9"></i>Grok</span></span>
-    <span class="rate"><span class="rbar"><i style="width:97%"></i></span>
-      <span><b>35/36</b> &middot; 97%</span></span>
-    <span class="cells"><i class="ok" title="Follow the spec: 100%"></i><i class="ok" title="Survive the kernel: 100%"></i><i class="ok" title="Design from a problem: 93%"></i><i class="ok" title="Design a curve: 100%"></i><i class="ok" title="Make it fit: 100%"></i><i class="ok" title="Handle a missing measurement: 100%"></i></span>
-    <span class="time" title="~2 min/part">~2 min</span>
-    <span class="cost">~$0.078</span>
+    <span class="rank">4</span>
+    <span class="who"><span class="model">claude-opus-5 <small>&middot; low</small></span>
+      <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
+    <span class="rate"><span class="rbar"><i style="width:96%"></i></span>
+      <span><b>23/24</b> &middot; 96%</span></span>
+    <span class="cells"><i class="ok" title="Follow the spec: 94%"></i><i class="ok" title="Survive the kernel: 100%"></i><i class="ok" title="Design from a problem: 100%"></i><i class="ok" title="Design a curve: 100%"></i><i class="ok" title="Make it fit: 100%"></i><i class="ok" title="Handle a missing measurement: 100%"></i></span>
+    <span class="time" title="~5 min/part">~5 min</span>
+    <span class="cost">~$0.92</span>
   </summary>
   <div class="body">
-  <p class="verdict">The row to run: thirty-five of thirty-six right, about two minutes and eight cents a part. Both of the hard fit jobs, the curved pole rest and the D-shaft knob, came out right on every single attempt. Its one miss was a wall clip you could not get a screwdriver into. The same model at xhigh gets the same share right and takes five times as long, so there is nothing to step up to.</p>
+  <p class="verdict">Twenty-three of twenty-four right at about five minutes and ninety cents a part, and honest about the unmeasured dimension every time. Its one miss was the easiest job on the board: a cable clip built to the stated size that stopped tracking once the size changed. Opus at medium and at high effort both take longer, cost more and get less right, so this is the Opus row to run.</p>
   <div class="bars">
-    <div class="name">Follow the spec</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Survive the kernel</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Design from a problem</div><div class="bar"><i style="width:93%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(60.0% - 1px)" title="attempt: 0.600"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">93%</div><div class="name">Design a curve</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Make it fit</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Handle a missing measurement</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div>
+    <div class="name">Follow the spec</div><div class="bar"><i style="width:94%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(74.5% - 1px)" title="attempt: 0.745"></u></div><div class="pct">94%</div><div class="name">Survive the kernel</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Design from a problem</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Design a curve</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Make it fit</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Handle a missing measurement</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div>
   </div>
   </div>
 </details>
 <details>
   <summary>
-    <span class="rank">4</span>
+    <span class="rank">5</span>
     <span class="who"><span class="model">claude-fable-5 <small>&middot; high</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i style="width:96%"></i></span>
@@ -343,7 +361,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">5</span>
+    <span class="rank">6</span>
     <span class="who"><span class="model">claude-opus-5 <small>&middot; high</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i style="width:94%"></i></span>
@@ -361,7 +379,25 @@
 </details>
 <details>
   <summary>
-    <span class="rank">6</span>
+    <span class="rank">7</span>
+    <span class="who"><span class="model">claude-sonnet-5 <small>&middot; xhigh</small></span>
+      <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
+    <span class="rate"><span class="rbar"><i style="width:93%"></i></span>
+      <span><b>28/30</b> &middot; 93%</span></span>
+    <span class="cells"><i class="ok" title="Follow the spec: 100%"></i><i class="ok" title="Survive the kernel: 100%"></i><i class="mid" title="Design from a problem: 88%"></i><i class="ok" title="Design a curve: 100%"></i><i class="ok" title="Make it fit: 100%"></i><i class="ok" title="Handle a missing measurement: 100%"></i></span>
+    <span class="time" title="~16 min/part">~16 min</span>
+    <span class="cost">~$2.03</span>
+  </summary>
+  <div class="body">
+  <p class="verdict">Twenty-eight of thirty right, and the slowest row on the board at about sixteen minutes a part. Five of the six jobs came out right on every attempt; the wall clip is the exception and it is where the time goes, one with no way in for the screw and its driver, another that held the bundle but spent more plastic than the job allowed, and a single attempt that ran past forty minutes. Sonnet at high effort is quicker and cheaper and misses five, so pay the wait when the part matters.</p>
+  <div class="bars">
+    <div class="name">Follow the spec</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Survive the kernel</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Design from a problem</div><div class="bar"><i class="mid" style="width:88%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(96.7% - 1px)" title="attempt: 0.967"></u><u style="left:calc(56.7% - 1px)" title="attempt: 0.567"></u></div><div class="pct">88%</div><div class="name">Design a curve</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Make it fit</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Handle a missing measurement</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div>
+  </div>
+  </div>
+</details>
+<details>
+  <summary>
+    <span class="rank">8</span>
     <span class="who"><span class="model">gpt-5.6-sol <small>&middot; high</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i style="width:93%"></i></span>
@@ -379,7 +415,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">7</span>
+    <span class="rank">9</span>
     <span class="who"><span class="model">gpt-5.6-sol <small>&middot; medium</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i style="width:93%"></i></span>
@@ -397,7 +433,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">8</span>
+    <span class="rank">10</span>
     <span class="who"><span class="model">claude-sonnet-5 <small>&middot; medium</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i style="width:92%"></i></span>
@@ -415,7 +451,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">9</span>
+    <span class="rank">11</span>
     <span class="who"><span class="model">grok-4.6 <small>&middot; high</small></span>
       <span class="plan"><i style="background:#b8bec9"></i>Grok</span></span>
     <span class="rate"><span class="rbar"><i style="width:90%"></i></span>
@@ -433,7 +469,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">10</span>
+    <span class="rank">12</span>
     <span class="who"><span class="model">grok-4.6 <small>&middot; medium</small></span>
       <span class="plan"><i style="background:#b8bec9"></i>Grok</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:89%"></i></span>
@@ -451,7 +487,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">11</span>
+    <span class="rank">13</span>
     <span class="who"><span class="model">claude-sonnet-5 <small>&middot; high</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:83%"></i></span>
@@ -469,25 +505,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">12</span>
-    <span class="who"><span class="model">claude-opus-5 <small>&middot; low</small></span>
-      <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
-    <span class="rate"><span class="rbar"><i class="mid" style="width:83%"></i></span>
-      <span><b>5/6</b> &middot; 83%</span></span>
-    <span class="cells"><i class="mid" title="Follow the spec: 74%"></i><i class="ok" title="Survive the kernel: 100%"></i><i class="ok" title="Design from a problem: 100%"></i><i class="ok" title="Design a curve: 100%"></i><i class="ok" title="Make it fit: 100%"></i><i class="ok" title="Handle a missing measurement: 100%"></i></span>
-    <span class="time" title="~4 min/part">~4 min</span>
-    <span class="cost">~$0.88</span>
-  </summary>
-  <div class="body">
-  <p class="verdict">One attempt per job, so read this as a sample rather than a score. Five of six right, and the miss was the easiest job on the board: a cable clip built to the stated size that stopped tracking once the size changed.</p>
-  <div class="bars">
-    <div class="name">Follow the spec</div><div class="bar"><i class="mid" style="width:74%"></i><u style="left:calc(74.5% - 1px)" title="attempt: 0.745"></u></div><div class="pct">74%</div><div class="name">Survive the kernel</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Design from a problem</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Design a curve</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Make it fit</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Handle a missing measurement</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div>
-  </div>
-  </div>
-</details>
-<details>
-  <summary>
-    <span class="rank">13</span>
+    <span class="rank">14</span>
     <span class="who"><span class="model">gpt-5.6-sol <small>&middot; low</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:83%"></i></span>
@@ -505,7 +523,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">14</span>
+    <span class="rank">15</span>
     <span class="who"><span class="model">claude-opus-5 <small>&middot; medium</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:78%"></i></span>
@@ -523,7 +541,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">15</span>
+    <span class="rank">16</span>
     <span class="who"><span class="model">gpt-5.6-luna <small>&middot; xhigh</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:77%"></i></span>
@@ -541,7 +559,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">16</span>
+    <span class="rank">17</span>
     <span class="who"><span class="model">claude-sonnet-5 <small>&middot; low</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:75%"></i></span>
@@ -559,7 +577,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">17</span>
+    <span class="rank">18</span>
     <span class="who"><span class="model">gpt-5.6-luna <small>&middot; high</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:73%"></i></span>
@@ -577,7 +595,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">18</span>
+    <span class="rank">19</span>
     <span class="who"><span class="model">gpt-5.6-terra <small>&middot; medium</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:71%"></i></span>
@@ -595,7 +613,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">19</span>
+    <span class="rank">20</span>
     <span class="who"><span class="model">gpt-5.6-terra <small>&middot; high</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:63%"></i></span>
@@ -613,7 +631,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">20</span>
+    <span class="rank">21</span>
     <span class="who"><span class="model">gpt-5.6-luna <small>&middot; medium</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:61%"></i></span>
@@ -631,7 +649,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">21</span>
+    <span class="rank">22</span>
     <span class="who"><span class="model">gpt-5.6-terra <small>&middot; low</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="low" style="width:56%"></i></span>
@@ -649,7 +667,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">22</span>
+    <span class="rank">23</span>
     <span class="who"><span class="model">gpt-5.6-luna <small>&middot; low</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="low" style="width:28%"></i></span>
@@ -667,7 +685,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">23</span>
+    <span class="rank">24</span>
     <span class="who"><span class="model">claude-haiku-4-5 <small>&middot; high</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i class="low" style="width:17%"></i></span>
@@ -685,7 +703,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">24</span>
+    <span class="rank">25</span>
     <span class="who"><span class="model">claude-haiku-4-5 <small>&middot; low</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i class="low" style="width:12%"></i></span>
@@ -706,7 +724,7 @@
 <div class="sec-label"><b>// 03</b> &nbsp;the tradeoff</div>
 <h2>Quality against speed.</h2>
 <p class="chart-lead">Every dot is one model at one effort setting: how often its parts printed right, against how long it took per part. The best picks sit high and to the left, right most of the time without the wait.</p>
-<div class="chart"><svg viewBox="0 0 840 740" role="img" aria-label="First-try prints against minutes per part for every benchmarked model"><line x1="56" y1="694" x2="816" y2="694" stroke="var(--line)" stroke-width="1"/><text x="48" y="698" text-anchor="end" font-size="11" fill="var(--dimmer)">0%</text><line x1="56" y1="527" x2="816" y2="527" stroke="var(--line)" stroke-width="1"/><text x="48" y="531" text-anchor="end" font-size="11" fill="var(--dimmer)">25%</text><line x1="56" y1="360" x2="816" y2="360" stroke="var(--line)" stroke-width="1"/><text x="48" y="364" text-anchor="end" font-size="11" fill="var(--dimmer)">50%</text><line x1="56" y1="193" x2="816" y2="193" stroke="var(--line)" stroke-width="1"/><text x="48" y="197" text-anchor="end" font-size="11" fill="var(--dimmer)">75%</text><line x1="56" y1="26" x2="816" y2="26" stroke="var(--line)" stroke-width="1"/><text x="48" y="30" text-anchor="end" font-size="11" fill="var(--dimmer)">100%</text><line x1="165" y1="26" x2="165" y2="694" stroke="var(--line)" stroke-width="1"/><text x="165" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">3</text><line x1="273" y1="26" x2="273" y2="694" stroke="var(--line)" stroke-width="1"/><text x="273" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">6</text><line x1="382" y1="26" x2="382" y2="694" stroke="var(--line)" stroke-width="1"/><text x="382" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">9</text><line x1="490" y1="26" x2="490" y2="694" stroke="var(--line)" stroke-width="1"/><text x="490" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">12</text><line x1="599" y1="26" x2="599" y2="694" stroke="var(--line)" stroke-width="1"/><text x="599" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">15</text><line x1="707" y1="26" x2="707" y2="694" stroke="var(--line)" stroke-width="1"/><text x="707" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">18</text><line x1="816" y1="26" x2="816" y2="694" stroke="var(--line)" stroke-width="1"/><text x="816" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">21</text><text x="816" y="732" text-anchor="end" font-size="11" fill="var(--dim)">minutes per part &rarr;</text><text x="14" y="16" font-size="11" fill="var(--dim)">printed right first try</text><rect x="563" y="19" width="112" height="14" fill="var(--panel)"/><text x="672" y="30" text-anchor="end" font-size="12" fill="var(--text)">claude-sonnet-5</text><circle class="dot" cx="686" cy="26" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="xhigh" data-stats="12/12 first-try &middot; ~17 min/part &middot; ~$2.89/part at API rates" aria-label="claude-sonnet-5 (xhigh effort): 12/12 first-try, ~17 min/part · ~$2.89/part at API rates"/><text x="686" y="29" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">X</text><circle class="dot" cx="481" cy="45" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="xhigh" data-stats="35/36 first-try &middot; ~12 min/part &middot; ~$0.27/part at API rates" aria-label="grok-4.6 (xhigh effort): 35/36 first-try, ~12 min/part · ~$0.27/part at API rates"/><text x="481" y="48" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">X</text><rect x="151" y="38" width="62" height="14" fill="var(--panel)"/><text x="154" y="49" text-anchor="start" font-size="12" fill="var(--text)">grok-4.6</text><circle class="dot" cx="140" cy="45" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="low" data-stats="35/36 first-try &middot; ~2 min/part &middot; ~$0.078/part at API rates" aria-label="grok-4.6 (low effort): 35/36 first-try, ~2 min/part · ~$0.078/part at API rates"/><text x="140" y="48" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">L</text><rect x="315" y="47" width="105" height="14" fill="var(--panel)"/><text x="318" y="58" text-anchor="start" font-size="12" fill="var(--text)">claude-fable-5</text><circle class="dot" cx="304" cy="54" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-fable-5" data-effort="high" data-stats="23/24 first-try &middot; ~7 min/part &middot; ~$3.20/part at API rates" aria-label="claude-fable-5 (high effort): 23/24 first-try, ~7 min/part · ~$3.20/part at API rates"/><text x="304" y="57" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><rect x="437" y="56" width="98" height="14" fill="var(--panel)"/><text x="440" y="67" text-anchor="start" font-size="12" fill="var(--text)">claude-opus-5</text><circle class="dot" cx="426" cy="63" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-opus-5" data-effort="high" data-stats="17/18 first-try &middot; ~10 min/part &middot; ~$2.33/part at API rates" aria-label="claude-opus-5 (high effort): 17/18 first-try, ~10 min/part · ~$2.33/part at API rates"/><text x="426" y="66" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="188" cy="71" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-sol" data-effort="high" data-stats="28/30 first-try &middot; ~4 min/part &middot; ~$1.76/part at API rates" aria-label="gpt-5.6-sol (high effort): 28/30 first-try, ~4 min/part · ~$1.76/part at API rates"/><text x="188" y="74" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><rect x="74" y="64" width="84" height="14" fill="var(--panel)"/><text x="155" y="75" text-anchor="end" font-size="12" fill="var(--text)">gpt-5.6-sol</text><circle class="dot" cx="169" cy="71" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-sol" data-effort="medium" data-stats="28/30 first-try &middot; ~3 min/part &middot; ~$1.63/part at API rates" aria-label="gpt-5.6-sol (medium effort): 28/30 first-try, ~3 min/part · ~$1.63/part at API rates"/><text x="169" y="74" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="538" cy="82" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="medium" data-stats="11/12 first-try &middot; ~13 min/part &middot; ~$2.10/part at API rates" aria-label="claude-sonnet-5 (medium effort): 11/12 first-try, ~13 min/part · ~$2.10/part at API rates"/><text x="538" y="85" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="446" cy="90" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="high" data-stats="19/21 first-try &middot; ~11 min/part &middot; ~$0.24/part at API rates" aria-label="grok-4.6 (high effort): 19/21 first-try, ~11 min/part · ~$0.24/part at API rates"/><text x="446" y="93" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">H</text><circle class="dot" cx="318" cy="100" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="medium" data-stats="32/36 first-try &middot; ~7 min/part &middot; ~$0.18/part at API rates" aria-label="grok-4.6 (medium effort): 32/36 first-try, ~7 min/part · ~$0.18/part at API rates"/><text x="318" y="103" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">M</text><circle class="dot" cx="483" cy="137" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="high" data-stats="25/30 first-try &middot; ~12 min/part &middot; ~$1.58/part at API rates" aria-label="claude-sonnet-5 (high effort): 25/30 first-try, ~12 min/part · ~$1.58/part at API rates"/><text x="483" y="140" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="208" cy="137" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-opus-5" data-effort="low" data-stats="5/6 first-try &middot; ~4 min/part &middot; ~$0.88/part at API rates" aria-label="claude-opus-5 (low effort): 5/6 first-try, ~4 min/part · ~$0.88/part at API rates"/><text x="208" y="140" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="133" cy="137" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-sol" data-effort="low" data-stats="15/18 first-try &middot; ~2 min/part &middot; ~$1.62/part at API rates" aria-label="gpt-5.6-sol (low effort): 15/18 first-try, ~2 min/part · ~$1.62/part at API rates"/><text x="133" y="140" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="323" cy="174" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-opus-5" data-effort="medium" data-stats="14/18 first-try &middot; ~7 min/part &middot; ~$1.66/part at API rates" aria-label="claude-opus-5 (medium effort): 14/18 first-try, ~7 min/part · ~$1.66/part at API rates"/><text x="323" y="177" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><rect x="119" y="175" width="91" height="14" fill="var(--panel)"/><text x="206" y="186" text-anchor="end" font-size="12" fill="var(--text)">gpt-5.6-luna</text><circle class="dot" cx="220" cy="182" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="xhigh" data-stats="23/30 first-try &middot; ~5 min/part &middot; ~$0.12/part at API rates" aria-label="gpt-5.6-luna (xhigh effort): 23/30 first-try, ~5 min/part · ~$0.12/part at API rates"/><text x="220" y="185" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">X</text><circle class="dot" cx="260" cy="193" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="low" data-stats="9/12 first-try &middot; ~6 min/part &middot; ~$0.84/part at API rates" aria-label="claude-sonnet-5 (low effort): 9/12 first-try, ~6 min/part · ~$0.84/part at API rates"/><text x="260" y="196" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="189" cy="204" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="high" data-stats="22/30 first-try &middot; ~4 min/part &middot; ~$0.10/part at API rates" aria-label="gpt-5.6-luna (high effort): 22/30 first-try, ~4 min/part · ~$0.10/part at API rates"/><text x="189" y="207" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><rect x="161" y="214" width="98" height="14" fill="var(--panel)"/><text x="164" y="225" text-anchor="start" font-size="12" fill="var(--text)">gpt-5.6-terra</text><circle class="dot" cx="150" cy="221" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-terra" data-effort="medium" data-stats="34/48 first-try &middot; ~3 min/part &middot; ~$0.84/part at API rates" aria-label="gpt-5.6-terra (medium effort): 34/48 first-try, ~3 min/part · ~$0.84/part at API rates"/><text x="150" y="224" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="164" cy="271" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-terra" data-effort="high" data-stats="19/30 first-try &middot; ~3 min/part &middot; ~$0.79/part at API rates" aria-label="gpt-5.6-terra (high effort): 19/30 first-try, ~3 min/part · ~$0.79/part at API rates"/><text x="164" y="274" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="138" cy="286" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="medium" data-stats="11/18 first-try &middot; ~2 min/part &middot; ~$0.079/part at API rates" aria-label="gpt-5.6-luna (medium effort): 11/18 first-try, ~2 min/part · ~$0.079/part at API rates"/><text x="138" y="289" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="140" cy="323" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-terra" data-effort="low" data-stats="10/18 first-try &middot; ~2 min/part &middot; ~$0.74/part at API rates" aria-label="gpt-5.6-terra (low effort): 10/18 first-try, ~2 min/part · ~$0.74/part at API rates"/><text x="140" y="326" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="147" cy="508" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="low" data-stats="5/18 first-try &middot; ~3 min/part &middot; ~$0.077/part at API rates" aria-label="gpt-5.6-luna (low effort): 5/18 first-try, ~3 min/part · ~$0.077/part at API rates"/><text x="147" y="511" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><rect x="339" y="576" width="119" height="14" fill="var(--panel)"/><text x="342" y="587" text-anchor="start" font-size="12" fill="var(--text)">claude-haiku-4-5</text><circle class="dot" cx="328" cy="583" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-haiku-4-5" data-effort="high" data-stats="2/12 first-try &middot; ~8 min/part &middot; ~$0.46/part at API rates" aria-label="claude-haiku-4-5 (high effort): 2/12 first-try, ~8 min/part · ~$0.46/part at API rates"/><text x="328" y="586" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="314" cy="613" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-haiku-4-5" data-effort="low" data-stats="4/33 first-try &middot; ~7 min/part &middot; ~$0.46/part at API rates" aria-label="claude-haiku-4-5 (low effort): 4/33 first-try, ~7 min/part · ~$0.46/part at API rates"/><text x="314" y="616" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text></svg><div class="chart-legend"><span><i style="background:#2f9fb5"></i>Claude</span><span><i style="background:#8f75e0"></i>ChatGPT (Codex)</span><span><i style="background:#b8bec9"></i>Grok</span><span><b>L&thinsp;M&thinsp;H&thinsp;X</b>effort, low to xhigh; hover a dot for its numbers</span></div></div>
+<div class="chart"><svg viewBox="0 0 840 740" role="img" aria-label="First-try prints against minutes per part for every benchmarked model"><line x1="56" y1="694" x2="816" y2="694" stroke="var(--line)" stroke-width="1"/><text x="48" y="698" text-anchor="end" font-size="11" fill="var(--dimmer)">0%</text><line x1="56" y1="527" x2="816" y2="527" stroke="var(--line)" stroke-width="1"/><text x="48" y="531" text-anchor="end" font-size="11" fill="var(--dimmer)">25%</text><line x1="56" y1="360" x2="816" y2="360" stroke="var(--line)" stroke-width="1"/><text x="48" y="364" text-anchor="end" font-size="11" fill="var(--dimmer)">50%</text><line x1="56" y1="193" x2="816" y2="193" stroke="var(--line)" stroke-width="1"/><text x="48" y="197" text-anchor="end" font-size="11" fill="var(--dimmer)">75%</text><line x1="56" y1="26" x2="816" y2="26" stroke="var(--line)" stroke-width="1"/><text x="48" y="30" text-anchor="end" font-size="11" fill="var(--dimmer)">100%</text><line x1="165" y1="26" x2="165" y2="694" stroke="var(--line)" stroke-width="1"/><text x="165" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">3</text><line x1="273" y1="26" x2="273" y2="694" stroke="var(--line)" stroke-width="1"/><text x="273" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">6</text><line x1="382" y1="26" x2="382" y2="694" stroke="var(--line)" stroke-width="1"/><text x="382" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">9</text><line x1="490" y1="26" x2="490" y2="694" stroke="var(--line)" stroke-width="1"/><text x="490" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">12</text><line x1="599" y1="26" x2="599" y2="694" stroke="var(--line)" stroke-width="1"/><text x="599" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">15</text><line x1="707" y1="26" x2="707" y2="694" stroke="var(--line)" stroke-width="1"/><text x="707" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">18</text><line x1="816" y1="26" x2="816" y2="694" stroke="var(--line)" stroke-width="1"/><text x="816" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">21</text><text x="816" y="732" text-anchor="end" font-size="11" fill="var(--dim)">minutes per part &rarr;</text><text x="14" y="16" font-size="11" fill="var(--dim)">printed right first try</text><rect x="204" y="19" width="105" height="14" fill="var(--panel)"/><text x="207" y="30" text-anchor="start" font-size="12" fill="var(--text)">claude-fable-5</text><circle class="dot" cx="193" cy="26" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-fable-5" data-effort="low" data-stats="18/18 first-try &middot; ~4 min/part &middot; ~$1.78/part at API rates" aria-label="claude-fable-5 (low effort): 18/18 first-try, ~4 min/part · ~$1.78/part at API rates"/><text x="193" y="29" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><rect x="70" y="31" width="62" height="14" fill="var(--panel)"/><text x="130" y="42" text-anchor="end" font-size="12" fill="var(--text)">grok-4.6</text><circle class="dot" cx="144" cy="38" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="low" data-stats="53/54 first-try &middot; ~2 min/part &middot; ~$0.071/part at API rates" aria-label="grok-4.6 (low effort): 53/54 first-try, ~2 min/part · ~$0.071/part at API rates"/><text x="144" y="41" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">L</text><circle class="dot" cx="481" cy="45" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="xhigh" data-stats="35/36 first-try &middot; ~12 min/part &middot; ~$0.27/part at API rates" aria-label="grok-4.6 (xhigh effort): 35/36 first-try, ~12 min/part · ~$0.27/part at API rates"/><text x="481" y="48" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">X</text><rect x="113" y="47" width="98" height="14" fill="var(--panel)"/><text x="207" y="58" text-anchor="end" font-size="12" fill="var(--text)">claude-opus-5</text><circle class="dot" cx="221" cy="54" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-opus-5" data-effort="low" data-stats="23/24 first-try &middot; ~5 min/part &middot; ~$0.92/part at API rates" aria-label="claude-opus-5 (low effort): 23/24 first-try, ~5 min/part · ~$0.92/part at API rates"/><text x="221" y="57" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="304" cy="54" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-fable-5" data-effort="high" data-stats="23/24 first-try &middot; ~7 min/part &middot; ~$3.20/part at API rates" aria-label="claude-fable-5 (high effort): 23/24 first-try, ~7 min/part · ~$3.20/part at API rates"/><text x="304" y="57" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="426" cy="63" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-opus-5" data-effort="high" data-stats="17/18 first-try &middot; ~10 min/part &middot; ~$2.33/part at API rates" aria-label="claude-opus-5 (high effort): 17/18 first-try, ~10 min/part · ~$2.33/part at API rates"/><text x="426" y="66" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><rect x="636" y="64" width="112" height="14" fill="var(--panel)"/><text x="639" y="75" text-anchor="start" font-size="12" fill="var(--text)">claude-sonnet-5</text><circle class="dot" cx="625" cy="71" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="xhigh" data-stats="28/30 first-try &middot; ~16 min/part &middot; ~$2.03/part at API rates" aria-label="claude-sonnet-5 (xhigh effort): 28/30 first-try, ~16 min/part · ~$2.03/part at API rates"/><text x="625" y="74" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">X</text><circle class="dot" cx="188" cy="71" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-sol" data-effort="high" data-stats="28/30 first-try &middot; ~4 min/part &middot; ~$1.76/part at API rates" aria-label="gpt-5.6-sol (high effort): 28/30 first-try, ~4 min/part · ~$1.76/part at API rates"/><text x="188" y="74" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><rect x="74" y="64" width="84" height="14" fill="var(--panel)"/><text x="155" y="75" text-anchor="end" font-size="12" fill="var(--text)">gpt-5.6-sol</text><circle class="dot" cx="169" cy="71" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-sol" data-effort="medium" data-stats="28/30 first-try &middot; ~3 min/part &middot; ~$1.63/part at API rates" aria-label="gpt-5.6-sol (medium effort): 28/30 first-try, ~3 min/part · ~$1.63/part at API rates"/><text x="169" y="74" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="538" cy="82" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="medium" data-stats="11/12 first-try &middot; ~13 min/part &middot; ~$2.10/part at API rates" aria-label="claude-sonnet-5 (medium effort): 11/12 first-try, ~13 min/part · ~$2.10/part at API rates"/><text x="538" y="85" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="446" cy="90" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="high" data-stats="19/21 first-try &middot; ~11 min/part &middot; ~$0.24/part at API rates" aria-label="grok-4.6 (high effort): 19/21 first-try, ~11 min/part · ~$0.24/part at API rates"/><text x="446" y="93" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">H</text><circle class="dot" cx="318" cy="100" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="medium" data-stats="32/36 first-try &middot; ~7 min/part &middot; ~$0.18/part at API rates" aria-label="grok-4.6 (medium effort): 32/36 first-try, ~7 min/part · ~$0.18/part at API rates"/><text x="318" y="103" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">M</text><circle class="dot" cx="483" cy="137" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="high" data-stats="25/30 first-try &middot; ~12 min/part &middot; ~$1.58/part at API rates" aria-label="claude-sonnet-5 (high effort): 25/30 first-try, ~12 min/part · ~$1.58/part at API rates"/><text x="483" y="140" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="133" cy="137" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-sol" data-effort="low" data-stats="15/18 first-try &middot; ~2 min/part &middot; ~$1.62/part at API rates" aria-label="gpt-5.6-sol (low effort): 15/18 first-try, ~2 min/part · ~$1.62/part at API rates"/><text x="133" y="140" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="323" cy="174" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-opus-5" data-effort="medium" data-stats="14/18 first-try &middot; ~7 min/part &middot; ~$1.66/part at API rates" aria-label="claude-opus-5 (medium effort): 14/18 first-try, ~7 min/part · ~$1.66/part at API rates"/><text x="323" y="177" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><rect x="119" y="175" width="91" height="14" fill="var(--panel)"/><text x="206" y="186" text-anchor="end" font-size="12" fill="var(--text)">gpt-5.6-luna</text><circle class="dot" cx="220" cy="182" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="xhigh" data-stats="23/30 first-try &middot; ~5 min/part &middot; ~$0.12/part at API rates" aria-label="gpt-5.6-luna (xhigh effort): 23/30 first-try, ~5 min/part · ~$0.12/part at API rates"/><text x="220" y="185" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">X</text><circle class="dot" cx="260" cy="193" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="low" data-stats="9/12 first-try &middot; ~6 min/part &middot; ~$0.84/part at API rates" aria-label="claude-sonnet-5 (low effort): 9/12 first-try, ~6 min/part · ~$0.84/part at API rates"/><text x="260" y="196" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="189" cy="204" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="high" data-stats="22/30 first-try &middot; ~4 min/part &middot; ~$0.10/part at API rates" aria-label="gpt-5.6-luna (high effort): 22/30 first-try, ~4 min/part · ~$0.10/part at API rates"/><text x="189" y="207" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><rect x="161" y="214" width="98" height="14" fill="var(--panel)"/><text x="164" y="225" text-anchor="start" font-size="12" fill="var(--text)">gpt-5.6-terra</text><circle class="dot" cx="150" cy="221" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-terra" data-effort="medium" data-stats="34/48 first-try &middot; ~3 min/part &middot; ~$0.84/part at API rates" aria-label="gpt-5.6-terra (medium effort): 34/48 first-try, ~3 min/part · ~$0.84/part at API rates"/><text x="150" y="224" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="164" cy="271" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-terra" data-effort="high" data-stats="19/30 first-try &middot; ~3 min/part &middot; ~$0.79/part at API rates" aria-label="gpt-5.6-terra (high effort): 19/30 first-try, ~3 min/part · ~$0.79/part at API rates"/><text x="164" y="274" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="138" cy="286" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="medium" data-stats="11/18 first-try &middot; ~2 min/part &middot; ~$0.079/part at API rates" aria-label="gpt-5.6-luna (medium effort): 11/18 first-try, ~2 min/part · ~$0.079/part at API rates"/><text x="138" y="289" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="140" cy="323" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-terra" data-effort="low" data-stats="10/18 first-try &middot; ~2 min/part &middot; ~$0.74/part at API rates" aria-label="gpt-5.6-terra (low effort): 10/18 first-try, ~2 min/part · ~$0.74/part at API rates"/><text x="140" y="326" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="147" cy="508" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="low" data-stats="5/18 first-try &middot; ~3 min/part &middot; ~$0.077/part at API rates" aria-label="gpt-5.6-luna (low effort): 5/18 first-try, ~3 min/part · ~$0.077/part at API rates"/><text x="147" y="511" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><rect x="339" y="576" width="119" height="14" fill="var(--panel)"/><text x="342" y="587" text-anchor="start" font-size="12" fill="var(--text)">claude-haiku-4-5</text><circle class="dot" cx="328" cy="583" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-haiku-4-5" data-effort="high" data-stats="2/12 first-try &middot; ~8 min/part &middot; ~$0.46/part at API rates" aria-label="claude-haiku-4-5 (high effort): 2/12 first-try, ~8 min/part · ~$0.46/part at API rates"/><text x="328" y="586" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="314" cy="613" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-haiku-4-5" data-effort="low" data-stats="4/33 first-try &middot; ~7 min/part &middot; ~$0.46/part at API rates" aria-label="claude-haiku-4-5 (low effort): 4/33 first-try, ~7 min/part · ~$0.46/part at API rates"/><text x="314" y="616" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text></svg><div class="chart-legend"><span><i style="background:#2f9fb5"></i>Claude</span><span><i style="background:#8f75e0"></i>ChatGPT (Codex)</span><span><i style="background:#b8bec9"></i>Grok</span><span><b>L&thinsp;M&thinsp;H&thinsp;X</b>effort, low to xhigh; hover a dot for its numbers</span></div></div>
 
 <div class="sec-label"><b>// 04</b> &nbsp;the jobs</div>
 <h2>Six jobs, graded on geometry.</h2>
@@ -727,7 +745,7 @@
 </div>
 
 <p class="fine">$/part is what the same tokens would cost at API list prices; on a subscription it comes out of your plan.</p>
-<p class="fine">Early days: 576 graded parts across 6 jobs so far. Each bar averages every attempt on file, and the ticks are the attempts themselves.</p>
+<p class="fine">Early days: 648 graded parts across 6 jobs so far. Each bar averages every attempt on file, and the ticks are the attempts themselves.</p>
 <p class="fine">Grading is a fixed rubric measured on the part's actual geometry, so the only randomness is the model's. Raw results, full transcripts, and the grading code are <a href="https://github.com/Shpigford/nurb-benchmarks/blob/main/REPORT.md">on GitHub</a>.</p>
 </main>
 <footer>


### PR DESCRIPTION
Regenerated `site/benchmarks.html` from Shpigford/nurb-benchmarks. The verdict text, `REPORT.md`, and the full audit ride in Shpigford/nurb-benchmarks#10.

## Published

| run | contributor | result |
|---|---|---|
| `claude-claude-sonnet-5-xhigh-51e417` | Shpigford | 16/18 first-try |
| `claude-claude-opus-5-low-9f7253` | Shpigford | 18/18 first-try |
| `claude-claude-fable-5-low-fd7b95` | Shpigford | 18/18 first-try |
| `grok-grok-4.6-low-a75086` | dimfeld (first submission) | 18/18 first-try |

## Rejected

None. All 72 rows re-graded to their committed scores exactly, no part matched a reference solution, artifacts were complete and sanitized, and the headless preamble held in all four runs.

## What changes on the page

- **The Claude card changes its recommendation.** `claude-fable-5` at low effort is new to the board and lands at rank 1 with 18/18 first-try prints, about four minutes and \$1.78 a part. It beats the same model at high effort on all three axes at once.
- **`grok-4.6` at low** goes to 53/54 pooled across two people's runs and holds rank 2 at seven cents a part.
- **`claude-opus-5` at low** goes to 23/24 and rank 4, ahead of Opus at both medium and high effort.
- **`claude-sonnet-5` at xhigh** loses its perfect record, dropping to 28/30 at rank 7. Two wall clips missed: one with no way in for the screw and its driver, one that held the bundle but spent more plastic than the job allowed.

A pattern worth noting for the marketing copy: on Claude, low effort now beats high effort for both Fable and Opus, on share right and time and cost together.

## Verification

Opened the regenerated page in a browser and looked at it rather than querying the DOM. The scatter chart's labels stagger cleanly with no collisions in the crowded upper-left cluster, the three subscription cards render correctly with the new Claude pick, the 25-row table is intact, and all four new verdicts are present with no stale text left behind. The benchmarks repo's report, pricing, contribute and site tests are green (39 passed).

https://claude.ai/code/session_01CZCgpSthtCxtzQ6AVGKfEh