### PR TITLE
Let print time offer Bambu Lab X2D and dismiss the printer question

### DIFF
--- a/src/nurb/printers.toml
+++ b/src/nurb/printers.toml
@@ -13,6 +13,13 @@
 bed = [256.0, 256.0, 256.0]
 slicer = "Bambu Lab X1 Carbon"
 
+# Dual-nozzle like the H2 series: these are the single-material figures from
+# Bambu Studio's machine profile (printable_area 256x256, printable_height 261).
+# The auxiliary nozzle loses about 21mm of X and 5mm of Z.
+[bambu_x2d]
+bed = [256.0, 256.0, 261.0]
+slicer = "Bambu Lab X2D"
+
 [bambu_p1s]
 bed = [256.0, 256.0, 256.0]
 slicer = "Bambu Lab P1S"

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -286,9 +286,21 @@
      this it inherited the question's nowrap and ran out past the pill's own border. */
   #print .line { flex-basis: 100%; white-space: normal; }
   #print .bad { color: var(--bad); }
-  #print select { flex: none; max-width: 160px; background: var(--panel); color: var(--text);
-                  border: 1px solid var(--line); border-radius: 6px; padding: 3px 6px;
-                  font: inherit; font-size: 11px; }
+  /* Native <select> in the desktop WKWebView opens an OS menu that does not dismiss.
+     Same custom menu as #dlmenu: a pick, an outside click, or Escape. */
+  #print:has(.open) { position: relative; z-index: 1; }
+  #printerpick { position: relative; }
+  #printerpick > .pick { flex: none; max-width: 160px; background: var(--panel); color: var(--text);
+                         border: 1px solid var(--line); border-radius: 6px; padding: 3px 6px;
+                         font: inherit; font-size: 11px; }
+  #printerpick .pickmenu { display: none; position: absolute; top: calc(100% + 5px); right: 0;
+                           min-width: 160px; max-height: 240px; overflow-y: auto;
+                           flex-direction: column; align-items: stretch; gap: 2px; padding: 3px;
+                           z-index: 2; background: rgba(29,32,39,.95); border: 1px solid var(--line);
+                           border-radius: 9px; box-shadow: 0 4px 16px rgba(0,0,0,.35);
+                           backdrop-filter: blur(10px); }
+  #printerpick.open .pickmenu { display: flex; }
+  #printerpick .pickmenu button { justify-content: flex-start; }
   /* The rebuild pill and the little spinner beside "parameters". Same .25s delay as
      the dimming above: a build that lands inside one round trip never shows either,
      so a light part stays silent and a crowned tray says what the wait is. */
@@ -1129,6 +1141,9 @@ const printbox = document.getElementById('print');
 let printAsk = null;
 let slicing = false;
 let requestToken = null;
+// hud() calls printRow on every rebuild. Rewriting the card while the list is open
+// destroys it mid-click, so a matching signature keeps the DOM that is already there.
+let printSig = null;
 
 function printRow() {
   const e = current ? parts.get(current) : null;
@@ -1137,20 +1152,28 @@ function printRow() {
   // same reason covers both: a print estimate needs a solid to send to the slicer.
   if (!e || e.error || (asm && !(e.uses || []).length)) {
     printbox.style.display = 'none';
+    printSig = null;
     return;
   }
   const said = printed.get(current);
   const answered = said && said.shape_id === e.shape_id;
+  const html = slicing ? '<span class="working"><span class="spin"></span>slicing</span>'
+    : printAsk && printAsk.name === current ? printAsking(printAsk)
+    : answered ? printAnswer(said)
+    : '<button class="go"><svg><use href="#i-clock"/></svg>print time</button>';
+  const sig = slicing ? 'slicing'
+    : printAsk && printAsk.name === current
+      ? `ask:${printAsk.kind}:${current}:${printAsk.error || ''}:${(printAsk.profiles || []).join(',')}`
+    : answered ? `ans:${said.shape_id}`
+    : 'btn';
   printbox.style.display = 'flex';
   // The full preset chain hangs off the row, because a reading is worth having next to
   // what produced it and is not worth the second line it would cost inline. Set here
   // and not in the answer, so no other state inherits the last one's hover.
   printbox.title = answered ? said.settings : '';
-  printbox.innerHTML =
-    slicing ? '<span class="working"><span class="spin"></span>slicing</span>'
-    : printAsk && printAsk.name === current ? printAsking(printAsk)
-    : answered ? printAnswer(said)
-    : '<button class="go"><svg><use href="#i-clock"/></svg>print time</button>';
+  if (sig === printSig) return;
+  printSig = sig;
+  printbox.innerHTML = html;
 }
 
 function printAnswer(said) {
@@ -1180,9 +1203,10 @@ function printAnswer(said) {
 // carries the picker where picking a different machine is what would fix it.
 function printAsking(ask) {
   const picker = (ask.profiles || []).length
-    ? `<select id="printerpick"><option value="">choose your printer…</option>${
-        ask.profiles.map(n => `<option value="${n}">${n.replace(/_/g, ' ')}</option>`).join('')
-      }</select>`
+    ? `<div id="printerpick"><button type="button" class="pick">choose your printer…</button>`
+      + `<div class="pickmenu">${
+        ask.profiles.map(n => `<button type="button" value="${n}">${n.replace(/_/g, ' ')}</button>`).join('')
+      }</div></div>`
     : '';
   if (ask.kind === 'choose') {
     return '<span class="ask">which printer is this for?</span>' + picker;
@@ -1223,19 +1247,41 @@ async function estimate() {
 // One listener on the card rather than one per state: the body is rewritten on every
 // paint, so a handler bound to a button inside it would not survive the next one.
 printbox.onclick = event => {
-  if (event.target.closest('.go')) estimate();
+  if (event.target.closest('.go')) { estimate(); return; }
+  const trigger = event.target.closest('#printerpick > .pick');
+  if (trigger) {
+    event.stopPropagation();
+    const pick = document.getElementById('printerpick');
+    if (pick) pick.classList.toggle('open');
+    return;
+  }
+  // Buttons never fire change, so the pick lives here. Option buttons have no
+  // children: event.target is the control that carries the profile name.
+  if (event.target.closest('#printerpick [value]') && event.target.value && sock) {
+    slicing = true;  // the card says "slicing" from here to the answer, one continuous act
+    printAsk = null;
+    printRow();
+    sock.send(JSON.stringify({ type: 'printer', profile: event.target.value }));
+  }
 };
 
-// Naming the machine is the whole of the setup, and it is also what the bed size and
-// half the printability rules have always wanted, so the choice goes to printer.toml
-// rather than into this page's memory.
-printbox.onchange = event => {
-  if (event.target.id !== 'printerpick' || !event.target.value || !sock) return;
-  slicing = true;  // the card says "slicing" from here to the answer, one continuous act
+// Same contract as #dlmenu: a pick, an outside click, or Escape. Registered once.
+// Snapshot open at the start of the event so closing the list does not also dismiss
+// the question on that same click or key.
+function printDismiss(event) {
+  if (!printAsk || slicing) return;
+  const pick = document.getElementById('printerpick');
+  const open = !!(pick && pick.classList.contains('open'));
+  if (open) {
+    pick.classList.remove('open');
+    return;
+  }
+  if (event.type === 'click' && printbox.contains(event.target)) return;
   printAsk = null;
   printRow();
-  sock.send(JSON.stringify({ type: 'printer', profile: event.target.value }));
-};
+}
+addEventListener('click', printDismiss);
+addEventListener('keydown', event => { if (event.key === 'Escape') printDismiss(event); });
 
 // On by default, matching the server: draft is a preview economy, and what the user
 // judges on screen should be the part that exports. Every rebuild while it is off is

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -195,6 +195,16 @@ def test_the_h2_series_is_shipped_because_it_is_what_bambu_sells_now(tmp_path):
     assert {"bambu_h2c", "bambu_h2d", "bambu_h2s"} <= set(have)
 
 
+def test_the_x2d_is_shipped_because_it_is_what_bambu_sells_now():
+    """Same gap as the H2 series: a current machine missing from the list makes every
+    print estimate on it dead-end at the picker."""
+    have = profiles()
+    assert have["bambu_x2d"] == {
+        "bed": [256.0, 256.0, 261.0],
+        "slicer": "Bambu Lab X2D",
+    }
+
+
 def test_anycubic_kobra_2_profile_matches_the_vendor_and_slicer():
     have = profiles()
     assert have["anycubic_kobra_2"] == {

--- a/tests/test_viewer_print.py
+++ b/tests/test_viewer_print.py
@@ -1,0 +1,58 @@
+"""The print-time printer picker: a question you can leave, not a native <select>.
+
+Source reads cannot execute JS. Substring presence of id="printerpick" and the send
+line already pass with a dead onchange, so these pin the click path, the dropped id
+guard, and dismiss that only fires when the list was already closed.
+"""
+
+from nurb import server as server_mod
+
+
+def _print_js():
+    viewer = server_mod.VIEWER.read_text(encoding="utf-8")
+    start = viewer.index("// ---- print time ----")
+    end = viewer.index("// On by default, matching the server")
+    return viewer[start:end]
+
+
+def test_the_printer_picker_is_not_a_native_select():
+    """A native <select> in the desktop WKWebView opens an OS menu that does not
+    dismiss once it has been opened."""
+    js = _print_js()
+    css = server_mod.VIEWER.read_text(encoding="utf-8")
+    assert 'id="printerpick"' in js
+    assert "<select" not in js
+    assert 'id="printerpick"' in css
+    assert "#print select" not in css
+    assert "#print:has(.open)" in css
+
+
+def test_picking_a_printer_is_a_click_not_a_change():
+    """Option buttons never fire change, and id=\"printerpick\" is the wrapper, so the
+    old onchange + target.id guard would swallow every pick."""
+    js = _print_js()
+    assert "printbox.onchange" not in js
+    assert "printbox.onclick" in js
+    assert "event.target.id" not in js
+    assert "type: 'printer', profile: event.target.value" in js
+    assert "event.target.closest('#printerpick [value]')" in js
+    assert "event.stopPropagation()" in js
+    onclick = js[js.index("printbox.onclick") : js.index("function printDismiss")]
+    assert "addEventListener" not in onclick
+
+
+def test_dismiss_reads_open_before_it_mutates_and_only_then_clears_the_question():
+    """Closing the list and dismissing the question are two events. Snapshot open
+    first, or the same Escape or canvas click does both."""
+    js = _print_js()
+    dismiss = js[js.index("function printDismiss") :]
+    open_at = dismiss.index("const open =")
+    close_at = dismiss.index("classList.remove('open')")
+    clear_at = dismiss.index("printAsk = null")
+    assert open_at < close_at < clear_at
+    assert "if (open)" in dismiss
+    assert "addEventListener('click', printDismiss)" in js
+    row = js[js.index("function printRow") : js.index("function printAnswer")]
+    assert "addEventListener" not in row
+    assert "if (sig === printSig) return" in row
+    assert "printbox.innerHTML = html" in row


### PR DESCRIPTION
Print time asked which printer this is for, but **Bambu Lab X2D** was not in the list. After you opened that menu, there was no way back to the **print time** button without picking a machine.

## What this does
- Adds Bambu Lab X2D to the shipped printers (256×256×261 mm, from Bambu Studio's machine profile).
- Replaces the native printer menu with the same custom list the download button uses. Escape or a click on the part closes it.

## How to check
1. Open a project that has not named a printer. Click **print time**.
2. Confirm `bambu x2d` is in the list.
3. Open the list, press Escape: the list closes. Press Escape again: **print time** returns.
4. Click **print time**, pick `bambu x2d`: the row shows slicing, then an estimate.

---

## Review notes

**This PR is / is not:** a catalog expansion beyond X2D, or slicer display names in the picker.

**Read first:**
- `src/nurb/viewer.html`: pick is `printbox.onclick`, not `onchange`. `printDismiss` snapshots `.open` before mutating.
- `src/nurb/printers.toml`: `bambu_x2d`

**Do not "fix":**
- Labels still `bambu x2d` (profile keys). Sending slicer names would change `_machines()` and overlap open PR #170.
- Native `<select>` on the stress row.

**Invariants:**
- `id="printerpick"` and `type: 'printer', profile: event.target.value` remain in the viewer source.
- `Server._machines()` still returns profile keys.
- First Escape or outside click only closes an open list.

**Tests that prove it:**
- `test_the_x2d_is_shipped_because_it_is_what_bambu_sells_now` — profile name, bed, slicer string
- `test_picking_a_printer_is_a_click_not_a_change` — no `onchange`, no `event.target.id` guard
- `test_dismiss_reads_open_before_it_mutates_and_only_then_clears_the_question` — two-step dismiss
