### PR TITLE
Add the fable-5 max run to the benchmarks page

### DIFF
--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -308,6 +308,24 @@
 <details>
   <summary>
     <span class="rank">3</span>
+    <span class="who"><span class="model">claude-fable-5 <small>&middot; max</small></span>
+      <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
+    <span class="rate"><span class="rbar"><i style="width:100%"></i></span>
+      <span><b>18/18</b> &middot; 100%</span></span>
+    <span class="cells"><i class="ok" title="Follow the spec: 100%"></i><i class="ok" title="Survive the kernel: 100%"></i><i class="ok" title="Design from a problem: 100%"></i><i class="ok" title="Design a curve: 100%"></i><i class="ok" title="Make it fit: 100%"></i><i class="ok" title="Handle a missing measurement: 100%"></i></span>
+    <span class="time" title="~13 min/part">~13 min</span>
+    <span class="cost">~$5.79</span>
+  </summary>
+  <div class="body">
+  <p class="verdict">Eighteen attempts, eighteen parts worth printing, every job included, and it recorded the unmeasured dimension as a guess every time. It checks its own work hard, better than twice the measuring, cutting open and re-rendering that the same model does at medium effort. That buys nothing here, because medium sweeps the same eighteen jobs in a quarter of the time for a quarter of the money. At about thirteen minutes and five dollars eighty a part, this is the most expensive row on the board, so pay it only for a part you cannot re-run. Three attempts a job from one person, so a thinner sample than the Grok rows.</p>
+  <div class="bars">
+    <div class="name">Follow the spec</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Survive the kernel</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Design from a problem</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Design a curve</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Make it fit</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div><div class="name">Handle a missing measurement</div><div class="bar"><i style="width:100%"></i><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u><u style="left:calc(99.0% - 1px)" title="attempt: 1.000"></u></div><div class="pct">100%</div>
+  </div>
+  </div>
+</details>
+<details>
+  <summary>
+    <span class="rank">4</span>
     <span class="who"><span class="model">claude-fable-5 <small>&middot; medium</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i style="width:100%"></i></span>
@@ -325,7 +343,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">4</span>
+    <span class="rank">5</span>
     <span class="who"><span class="model">claude-opus-5 <small>&middot; high</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i style="width:100%"></i></span>
@@ -343,7 +361,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">5</span>
+    <span class="rank">6</span>
     <span class="who"><span class="model">grok-4.6 <small>&middot; xhigh</small></span>
       <span class="plan"><i style="background:#b8bec9"></i>Grok</span></span>
     <span class="rate"><span class="rbar"><i style="width:100%"></i></span>
@@ -361,7 +379,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">6</span>
+    <span class="rank">7</span>
     <span class="who"><span class="model">grok-4.6 <small>&middot; low</small></span>
       <span class="plan"><i style="background:#b8bec9"></i>Grok</span></span>
     <span class="rate"><span class="rbar"><i style="width:98%"></i></span>
@@ -379,7 +397,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">7</span>
+    <span class="rank">8</span>
     <span class="who"><span class="model">grok-4.6 <small>&middot; medium</small></span>
       <span class="plan"><i style="background:#b8bec9"></i>Grok</span></span>
     <span class="rate"><span class="rbar"><i style="width:98%"></i></span>
@@ -397,7 +415,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">8</span>
+    <span class="rank">9</span>
     <span class="who"><span class="model">claude-opus-5 <small>&middot; low</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i style="width:96%"></i></span>
@@ -415,7 +433,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">9</span>
+    <span class="rank">10</span>
     <span class="who"><span class="model">grok-4.6 <small>&middot; high</small></span>
       <span class="plan"><i style="background:#b8bec9"></i>Grok</span></span>
     <span class="rate"><span class="rbar"><i style="width:95%"></i></span>
@@ -433,7 +451,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">10</span>
+    <span class="rank">11</span>
     <span class="who"><span class="model">claude-sonnet-5 <small>&middot; xhigh</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i style="width:93%"></i></span>
@@ -451,7 +469,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">11</span>
+    <span class="rank">12</span>
     <span class="who"><span class="model">gpt-5.6-sol <small>&middot; high</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i style="width:93%"></i></span>
@@ -469,7 +487,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">12</span>
+    <span class="rank">13</span>
     <span class="who"><span class="model">gpt-5.6-sol <small>&middot; medium</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i style="width:93%"></i></span>
@@ -487,7 +505,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">13</span>
+    <span class="rank">14</span>
     <span class="who"><span class="model">claude-sonnet-5 <small>&middot; medium</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i style="width:92%"></i></span>
@@ -505,7 +523,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">14</span>
+    <span class="rank">15</span>
     <span class="who"><span class="model">claude-sonnet-5 <small>&middot; high</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i style="width:90%"></i></span>
@@ -523,7 +541,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">15</span>
+    <span class="rank">16</span>
     <span class="who"><span class="model">gpt-5.6-sol <small>&middot; xhigh</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i style="width:90%"></i></span>
@@ -541,7 +559,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">16</span>
+    <span class="rank">17</span>
     <span class="who"><span class="model">gpt-5.6-luna <small>&middot; max</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:89%"></i></span>
@@ -559,7 +577,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">17</span>
+    <span class="rank">18</span>
     <span class="who"><span class="model">claude-opus-5 <small>&middot; medium</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:89%"></i></span>
@@ -577,7 +595,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">18</span>
+    <span class="rank">19</span>
     <span class="who"><span class="model">gpt-5.6-sol <small>&middot; low</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:83%"></i></span>
@@ -595,7 +613,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">19</span>
+    <span class="rank">20</span>
     <span class="who"><span class="model">claude-sonnet-5 <small>&middot; low</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:83%"></i></span>
@@ -613,7 +631,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">20</span>
+    <span class="rank">21</span>
     <span class="who"><span class="model">gpt-5.6-terra <small>&middot; medium</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:77%"></i></span>
@@ -631,7 +649,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">21</span>
+    <span class="rank">22</span>
     <span class="who"><span class="model">gpt-5.6-luna <small>&middot; xhigh</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:77%"></i></span>
@@ -649,7 +667,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">22</span>
+    <span class="rank">23</span>
     <span class="who"><span class="model">gpt-5.6-terra <small>&middot; high</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:77%"></i></span>
@@ -667,7 +685,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">23</span>
+    <span class="rank">24</span>
     <span class="who"><span class="model">gpt-5.6-luna <small>&middot; high</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:73%"></i></span>
@@ -685,7 +703,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">24</span>
+    <span class="rank">25</span>
     <span class="who"><span class="model">gpt-5.6-luna <small>&middot; medium</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="mid" style="width:61%"></i></span>
@@ -703,7 +721,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">25</span>
+    <span class="rank">26</span>
     <span class="who"><span class="model">gpt-5.6-terra <small>&middot; low</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="low" style="width:56%"></i></span>
@@ -721,7 +739,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">26</span>
+    <span class="rank">27</span>
     <span class="who"><span class="model">gpt-5.6-luna <small>&middot; low</small></span>
       <span class="plan"><i style="background:#8f75e0"></i>ChatGPT (Codex)</span></span>
     <span class="rate"><span class="rbar"><i class="low" style="width:28%"></i></span>
@@ -739,7 +757,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">27</span>
+    <span class="rank">28</span>
     <span class="who"><span class="model">claude-haiku-4-5 <small>&middot; high</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i class="low" style="width:17%"></i></span>
@@ -757,7 +775,7 @@
 </details>
 <details>
   <summary>
-    <span class="rank">28</span>
+    <span class="rank">29</span>
     <span class="who"><span class="model">claude-haiku-4-5 <small>&middot; low</small></span>
       <span class="plan"><i style="background:#2f9fb5"></i>Claude</span></span>
     <span class="rate"><span class="rbar"><i class="low" style="width:12%"></i></span>
@@ -778,7 +796,7 @@
 <div class="sec-label"><b>// 03</b> &nbsp;the tradeoff</div>
 <h2>Quality against speed.</h2>
 <p class="chart-lead">Every dot is one model at one effort setting: how often its parts printed right, against how long it took per part. The best picks sit high and to the left, right most of the time without the wait.</p>
-<div class="chart"><svg viewBox="0 0 840 740" role="img" aria-label="First-try prints against minutes per part for every benchmarked model"><line x1="56" y1="694" x2="816" y2="694" stroke="var(--line)" stroke-width="1"/><text x="48" y="698" text-anchor="end" font-size="11" fill="var(--dimmer)">0%</text><line x1="56" y1="527" x2="816" y2="527" stroke="var(--line)" stroke-width="1"/><text x="48" y="531" text-anchor="end" font-size="11" fill="var(--dimmer)">25%</text><line x1="56" y1="360" x2="816" y2="360" stroke="var(--line)" stroke-width="1"/><text x="48" y="364" text-anchor="end" font-size="11" fill="var(--dimmer)">50%</text><line x1="56" y1="193" x2="816" y2="193" stroke="var(--line)" stroke-width="1"/><text x="48" y="197" text-anchor="end" font-size="11" fill="var(--dimmer)">75%</text><line x1="56" y1="26" x2="816" y2="26" stroke="var(--line)" stroke-width="1"/><text x="48" y="30" text-anchor="end" font-size="11" fill="var(--dimmer)">100%</text><line x1="165" y1="26" x2="165" y2="694" stroke="var(--line)" stroke-width="1"/><text x="165" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">3</text><line x1="273" y1="26" x2="273" y2="694" stroke="var(--line)" stroke-width="1"/><text x="273" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">6</text><line x1="382" y1="26" x2="382" y2="694" stroke="var(--line)" stroke-width="1"/><text x="382" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">9</text><line x1="490" y1="26" x2="490" y2="694" stroke="var(--line)" stroke-width="1"/><text x="490" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">12</text><line x1="599" y1="26" x2="599" y2="694" stroke="var(--line)" stroke-width="1"/><text x="599" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">15</text><line x1="707" y1="26" x2="707" y2="694" stroke="var(--line)" stroke-width="1"/><text x="707" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">18</text><line x1="816" y1="26" x2="816" y2="694" stroke="var(--line)" stroke-width="1"/><text x="816" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">21</text><text x="816" y="732" text-anchor="end" font-size="11" fill="var(--dim)">minutes per part &rarr;</text><text x="14" y="16" font-size="11" fill="var(--dim)">printed right first try</text><circle class="dot" cx="304" cy="26" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-fable-5" data-effort="high" data-stats="24/24 first-try &middot; ~7 min/part &middot; ~$3.20/part at API rates" aria-label="claude-fable-5 (high effort): 24/24 first-try, ~7 min/part · ~$3.20/part at API rates"/><text x="304" y="29" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="193" cy="26" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-fable-5" data-effort="low" data-stats="18/18 first-try &middot; ~4 min/part &middot; ~$1.78/part at API rates" aria-label="claude-fable-5 (low effort): 18/18 first-try, ~4 min/part · ~$1.78/part at API rates"/><text x="193" y="29" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><path d="M 169 26 L 155 54" fill="none" stroke="var(--dimmer)" stroke-width="1"/><rect x="54" y="47" width="105" height="14" fill="var(--panel)"/><text x="155" y="58" text-anchor="end" font-size="12" fill="var(--text)">claude-fable-5</text><circle class="dot" cx="169" cy="26" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-fable-5" data-effort="medium" data-stats="18/18 first-try &middot; ~3 min/part &middot; ~$1.29/part at API rates" aria-label="claude-fable-5 (medium effort): 18/18 first-try, ~3 min/part · ~$1.29/part at API rates"/><text x="169" y="29" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><path d="M 426 26 L 440 40" fill="none" stroke="var(--dimmer)" stroke-width="1"/><rect x="437" y="33" width="98" height="14" fill="var(--panel)"/><text x="440" y="44" text-anchor="start" font-size="12" fill="var(--text)">claude-opus-5</text><circle class="dot" cx="426" cy="26" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-opus-5" data-effort="high" data-stats="18/18 first-try &middot; ~10 min/part &middot; ~$2.33/part at API rates" aria-label="claude-opus-5 (high effort): 18/18 first-try, ~10 min/part · ~$2.33/part at API rates"/><text x="426" y="29" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><rect x="492" y="19" width="62" height="14" fill="var(--panel)"/><text x="495" y="30" text-anchor="start" font-size="12" fill="var(--text)">grok-4.6</text><circle class="dot" cx="481" cy="26" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="xhigh" data-stats="36/36 first-try &middot; ~12 min/part &middot; ~$0.27/part at API rates" aria-label="grok-4.6 (xhigh effort): 36/36 first-try, ~12 min/part · ~$0.27/part at API rates"/><text x="481" y="29" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">X</text><circle class="dot" cx="144" cy="38" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="low" data-stats="53/54 first-try &middot; ~2 min/part &middot; ~$0.071/part at API rates" aria-label="grok-4.6 (low effort): 53/54 first-try, ~2 min/part · ~$0.071/part at API rates"/><text x="144" y="41" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">L</text><circle class="dot" cx="326" cy="40" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="medium" data-stats="47/48 first-try &middot; ~7 min/part &middot; ~$0.18/part at API rates" aria-label="grok-4.6 (medium effort): 47/48 first-try, ~7 min/part · ~$0.18/part at API rates"/><text x="326" y="43" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">M</text><circle class="dot" cx="221" cy="54" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-opus-5" data-effort="low" data-stats="23/24 first-try &middot; ~5 min/part &middot; ~$0.92/part at API rates" aria-label="claude-opus-5 (low effort): 23/24 first-try, ~5 min/part · ~$0.92/part at API rates"/><text x="221" y="57" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="446" cy="58" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="high" data-stats="20/21 first-try &middot; ~11 min/part &middot; ~$0.24/part at API rates" aria-label="grok-4.6 (high effort): 20/21 first-try, ~11 min/part · ~$0.24/part at API rates"/><text x="446" y="61" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">H</text><rect x="636" y="64" width="112" height="14" fill="var(--panel)"/><text x="639" y="75" text-anchor="start" font-size="12" fill="var(--text)">claude-sonnet-5</text><circle class="dot" cx="625" cy="71" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="xhigh" data-stats="28/30 first-try &middot; ~16 min/part &middot; ~$2.03/part at API rates" aria-label="claude-sonnet-5 (xhigh effort): 28/30 first-try, ~16 min/part · ~$2.03/part at API rates"/><text x="625" y="74" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">X</text><circle class="dot" cx="188" cy="71" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-sol" data-effort="high" data-stats="28/30 first-try &middot; ~4 min/part &middot; ~$1.76/part at API rates" aria-label="gpt-5.6-sol (high effort): 28/30 first-try, ~4 min/part · ~$1.76/part at API rates"/><text x="188" y="74" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><rect x="74" y="64" width="84" height="14" fill="var(--panel)"/><text x="155" y="75" text-anchor="end" font-size="12" fill="var(--text)">gpt-5.6-sol</text><circle class="dot" cx="169" cy="71" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-sol" data-effort="medium" data-stats="28/30 first-try &middot; ~3 min/part &middot; ~$1.63/part at API rates" aria-label="gpt-5.6-sol (medium effort): 28/30 first-try, ~3 min/part · ~$1.63/part at API rates"/><text x="169" y="74" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="538" cy="82" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="medium" data-stats="11/12 first-try &middot; ~13 min/part &middot; ~$2.10/part at API rates" aria-label="claude-sonnet-5 (medium effort): 11/12 first-try, ~13 min/part · ~$2.10/part at API rates"/><text x="538" y="85" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="483" cy="93" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="high" data-stats="27/30 first-try &middot; ~12 min/part &middot; ~$1.58/part at API rates" aria-label="claude-sonnet-5 (high effort): 27/30 first-try, ~12 min/part · ~$1.58/part at API rates"/><text x="483" y="96" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="196" cy="93" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-sol" data-effort="xhigh" data-stats="27/30 first-try &middot; ~4 min/part &middot; ~$2.11/part at API rates" aria-label="gpt-5.6-sol (xhigh effort): 27/30 first-try, ~4 min/part · ~$2.11/part at API rates"/><text x="196" y="96" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">X</text><path d="M 234 100 L 248 86" fill="none" stroke="var(--dimmer)" stroke-width="1"/><rect x="245" y="79" width="91" height="14" fill="var(--panel)"/><text x="248" y="90" text-anchor="start" font-size="12" fill="var(--text)">gpt-5.6-luna</text><circle class="dot" cx="234" cy="100" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="max" data-stats="32/36 first-try &middot; ~5 min/part &middot; ~$0.13/part at API rates" aria-label="gpt-5.6-luna (max effort): 32/36 first-try, ~5 min/part · ~$0.13/part at API rates"/><text x="234" y="103" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">+</text><circle class="dot" cx="323" cy="100" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-opus-5" data-effort="medium" data-stats="16/18 first-try &middot; ~7 min/part &middot; ~$1.66/part at API rates" aria-label="claude-opus-5 (medium effort): 16/18 first-try, ~7 min/part · ~$1.66/part at API rates"/><text x="323" y="103" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="133" cy="137" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-sol" data-effort="low" data-stats="15/18 first-try &middot; ~2 min/part &middot; ~$1.62/part at API rates" aria-label="gpt-5.6-sol (low effort): 15/18 first-try, ~2 min/part · ~$1.62/part at API rates"/><text x="133" y="140" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="260" cy="137" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="low" data-stats="10/12 first-try &middot; ~6 min/part &middot; ~$0.84/part at API rates" aria-label="claude-sonnet-5 (low effort): 10/12 first-try, ~6 min/part · ~$0.84/part at API rates"/><text x="260" y="140" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><path d="M 150 179 L 164 165" fill="none" stroke="var(--dimmer)" stroke-width="1"/><rect x="161" y="158" width="98" height="14" fill="var(--panel)"/><text x="164" y="169" text-anchor="start" font-size="12" fill="var(--text)">gpt-5.6-terra</text><circle class="dot" cx="150" cy="179" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-terra" data-effort="medium" data-stats="37/48 first-try &middot; ~3 min/part &middot; ~$0.84/part at API rates" aria-label="gpt-5.6-terra (medium effort): 37/48 first-try, ~3 min/part · ~$0.84/part at API rates"/><text x="150" y="182" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="220" cy="182" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="xhigh" data-stats="23/30 first-try &middot; ~5 min/part &middot; ~$0.12/part at API rates" aria-label="gpt-5.6-luna (xhigh effort): 23/30 first-try, ~5 min/part · ~$0.12/part at API rates"/><text x="220" y="185" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">X</text><circle class="dot" cx="164" cy="182" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-terra" data-effort="high" data-stats="23/30 first-try &middot; ~3 min/part &middot; ~$0.79/part at API rates" aria-label="gpt-5.6-terra (high effort): 23/30 first-try, ~3 min/part · ~$0.79/part at API rates"/><text x="164" y="185" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="189" cy="204" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="high" data-stats="22/30 first-try &middot; ~4 min/part &middot; ~$0.10/part at API rates" aria-label="gpt-5.6-luna (high effort): 22/30 first-try, ~4 min/part · ~$0.10/part at API rates"/><text x="189" y="207" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="138" cy="286" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="medium" data-stats="11/18 first-try &middot; ~2 min/part &middot; ~$0.079/part at API rates" aria-label="gpt-5.6-luna (medium effort): 11/18 first-try, ~2 min/part · ~$0.079/part at API rates"/><text x="138" y="289" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="140" cy="323" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-terra" data-effort="low" data-stats="10/18 first-try &middot; ~2 min/part &middot; ~$0.74/part at API rates" aria-label="gpt-5.6-terra (low effort): 10/18 first-try, ~2 min/part · ~$0.74/part at API rates"/><text x="140" y="326" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="147" cy="508" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="low" data-stats="5/18 first-try &middot; ~3 min/part &middot; ~$0.077/part at API rates" aria-label="gpt-5.6-luna (low effort): 5/18 first-try, ~3 min/part · ~$0.077/part at API rates"/><text x="147" y="511" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><rect x="339" y="576" width="119" height="14" fill="var(--panel)"/><text x="342" y="587" text-anchor="start" font-size="12" fill="var(--text)">claude-haiku-4-5</text><circle class="dot" cx="328" cy="583" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-haiku-4-5" data-effort="high" data-stats="2/12 first-try &middot; ~8 min/part &middot; ~$0.46/part at API rates" aria-label="claude-haiku-4-5 (high effort): 2/12 first-try, ~8 min/part · ~$0.46/part at API rates"/><text x="328" y="586" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="314" cy="613" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-haiku-4-5" data-effort="low" data-stats="4/33 first-try &middot; ~7 min/part &middot; ~$0.46/part at API rates" aria-label="claude-haiku-4-5 (low effort): 4/33 first-try, ~7 min/part · ~$0.46/part at API rates"/><text x="314" y="616" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text></svg><div class="chart-legend"><span><i style="background:#2f9fb5"></i>Claude</span><span><i style="background:#8f75e0"></i>ChatGPT (Codex)</span><span><i style="background:#b8bec9"></i>Grok</span><span><b>L&thinsp;M&thinsp;H&thinsp;X&thinsp;+</b>effort, low to max; hover a dot for its numbers</span></div></div>
+<div class="chart"><svg viewBox="0 0 840 740" role="img" aria-label="First-try prints against minutes per part for every benchmarked model"><line x1="56" y1="694" x2="816" y2="694" stroke="var(--line)" stroke-width="1"/><text x="48" y="698" text-anchor="end" font-size="11" fill="var(--dimmer)">0%</text><line x1="56" y1="527" x2="816" y2="527" stroke="var(--line)" stroke-width="1"/><text x="48" y="531" text-anchor="end" font-size="11" fill="var(--dimmer)">25%</text><line x1="56" y1="360" x2="816" y2="360" stroke="var(--line)" stroke-width="1"/><text x="48" y="364" text-anchor="end" font-size="11" fill="var(--dimmer)">50%</text><line x1="56" y1="193" x2="816" y2="193" stroke="var(--line)" stroke-width="1"/><text x="48" y="197" text-anchor="end" font-size="11" fill="var(--dimmer)">75%</text><line x1="56" y1="26" x2="816" y2="26" stroke="var(--line)" stroke-width="1"/><text x="48" y="30" text-anchor="end" font-size="11" fill="var(--dimmer)">100%</text><line x1="165" y1="26" x2="165" y2="694" stroke="var(--line)" stroke-width="1"/><text x="165" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">3</text><line x1="273" y1="26" x2="273" y2="694" stroke="var(--line)" stroke-width="1"/><text x="273" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">6</text><line x1="382" y1="26" x2="382" y2="694" stroke="var(--line)" stroke-width="1"/><text x="382" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">9</text><line x1="490" y1="26" x2="490" y2="694" stroke="var(--line)" stroke-width="1"/><text x="490" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">12</text><line x1="599" y1="26" x2="599" y2="694" stroke="var(--line)" stroke-width="1"/><text x="599" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">15</text><line x1="707" y1="26" x2="707" y2="694" stroke="var(--line)" stroke-width="1"/><text x="707" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">18</text><line x1="816" y1="26" x2="816" y2="694" stroke="var(--line)" stroke-width="1"/><text x="816" y="712" text-anchor="middle" font-size="11" fill="var(--dimmer)">21</text><text x="816" y="732" text-anchor="end" font-size="11" fill="var(--dim)">minutes per part &rarr;</text><text x="14" y="16" font-size="11" fill="var(--dim)">printed right first try</text><circle class="dot" cx="304" cy="26" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-fable-5" data-effort="high" data-stats="24/24 first-try &middot; ~7 min/part &middot; ~$3.20/part at API rates" aria-label="claude-fable-5 (high effort): 24/24 first-try, ~7 min/part · ~$3.20/part at API rates"/><text x="304" y="29" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="193" cy="26" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-fable-5" data-effort="low" data-stats="18/18 first-try &middot; ~4 min/part &middot; ~$1.78/part at API rates" aria-label="claude-fable-5 (low effort): 18/18 first-try, ~4 min/part · ~$1.78/part at API rates"/><text x="193" y="29" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="513" cy="26" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-fable-5" data-effort="max" data-stats="18/18 first-try &middot; ~13 min/part &middot; ~$5.79/part at API rates" aria-label="claude-fable-5 (max effort): 18/18 first-try, ~13 min/part · ~$5.79/part at API rates"/><text x="513" y="29" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">+</text><path d="M 169 26 L 155 54" fill="none" stroke="var(--dimmer)" stroke-width="1"/><rect x="54" y="47" width="105" height="14" fill="var(--panel)"/><text x="155" y="58" text-anchor="end" font-size="12" fill="var(--text)">claude-fable-5</text><circle class="dot" cx="169" cy="26" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-fable-5" data-effort="medium" data-stats="18/18 first-try &middot; ~3 min/part &middot; ~$1.29/part at API rates" aria-label="claude-fable-5 (medium effort): 18/18 first-try, ~3 min/part · ~$1.29/part at API rates"/><text x="169" y="29" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><path d="M 426 26 L 440 40" fill="none" stroke="var(--dimmer)" stroke-width="1"/><rect x="437" y="33" width="98" height="14" fill="var(--panel)"/><text x="440" y="44" text-anchor="start" font-size="12" fill="var(--text)">claude-opus-5</text><circle class="dot" cx="426" cy="26" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-opus-5" data-effort="high" data-stats="18/18 first-try &middot; ~10 min/part &middot; ~$2.33/part at API rates" aria-label="claude-opus-5 (high effort): 18/18 first-try, ~10 min/part · ~$2.33/part at API rates"/><text x="426" y="29" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><path d="M 481 26 L 495 54" fill="none" stroke="var(--dimmer)" stroke-width="1"/><rect x="492" y="47" width="62" height="14" fill="var(--panel)"/><text x="495" y="58" text-anchor="start" font-size="12" fill="var(--text)">grok-4.6</text><circle class="dot" cx="481" cy="26" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="xhigh" data-stats="36/36 first-try &middot; ~12 min/part &middot; ~$0.27/part at API rates" aria-label="grok-4.6 (xhigh effort): 36/36 first-try, ~12 min/part · ~$0.27/part at API rates"/><text x="481" y="29" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">X</text><circle class="dot" cx="144" cy="38" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="low" data-stats="53/54 first-try &middot; ~2 min/part &middot; ~$0.071/part at API rates" aria-label="grok-4.6 (low effort): 53/54 first-try, ~2 min/part · ~$0.071/part at API rates"/><text x="144" y="41" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">L</text><circle class="dot" cx="326" cy="40" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="medium" data-stats="47/48 first-try &middot; ~7 min/part &middot; ~$0.18/part at API rates" aria-label="grok-4.6 (medium effort): 47/48 first-try, ~7 min/part · ~$0.18/part at API rates"/><text x="326" y="43" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">M</text><circle class="dot" cx="221" cy="54" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-opus-5" data-effort="low" data-stats="23/24 first-try &middot; ~5 min/part &middot; ~$0.92/part at API rates" aria-label="claude-opus-5 (low effort): 23/24 first-try, ~5 min/part · ~$0.92/part at API rates"/><text x="221" y="57" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="446" cy="58" r="8" fill="#b8bec9" stroke="var(--panel)" stroke-width="2" data-model="grok-4.6" data-effort="high" data-stats="20/21 first-try &middot; ~11 min/part &middot; ~$0.24/part at API rates" aria-label="grok-4.6 (high effort): 20/21 first-try, ~11 min/part · ~$0.24/part at API rates"/><text x="446" y="61" text-anchor="middle" font-size="9" font-weight="700" fill="#16181d" pointer-events="none">H</text><rect x="636" y="64" width="112" height="14" fill="var(--panel)"/><text x="639" y="75" text-anchor="start" font-size="12" fill="var(--text)">claude-sonnet-5</text><circle class="dot" cx="625" cy="71" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="xhigh" data-stats="28/30 first-try &middot; ~16 min/part &middot; ~$2.03/part at API rates" aria-label="claude-sonnet-5 (xhigh effort): 28/30 first-try, ~16 min/part · ~$2.03/part at API rates"/><text x="625" y="74" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">X</text><circle class="dot" cx="188" cy="71" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-sol" data-effort="high" data-stats="28/30 first-try &middot; ~4 min/part &middot; ~$1.76/part at API rates" aria-label="gpt-5.6-sol (high effort): 28/30 first-try, ~4 min/part · ~$1.76/part at API rates"/><text x="188" y="74" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><rect x="74" y="64" width="84" height="14" fill="var(--panel)"/><text x="155" y="75" text-anchor="end" font-size="12" fill="var(--text)">gpt-5.6-sol</text><circle class="dot" cx="169" cy="71" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-sol" data-effort="medium" data-stats="28/30 first-try &middot; ~3 min/part &middot; ~$1.63/part at API rates" aria-label="gpt-5.6-sol (medium effort): 28/30 first-try, ~3 min/part · ~$1.63/part at API rates"/><text x="169" y="74" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="538" cy="82" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="medium" data-stats="11/12 first-try &middot; ~13 min/part &middot; ~$2.10/part at API rates" aria-label="claude-sonnet-5 (medium effort): 11/12 first-try, ~13 min/part · ~$2.10/part at API rates"/><text x="538" y="85" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="483" cy="93" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="high" data-stats="27/30 first-try &middot; ~12 min/part &middot; ~$1.58/part at API rates" aria-label="claude-sonnet-5 (high effort): 27/30 first-try, ~12 min/part · ~$1.58/part at API rates"/><text x="483" y="96" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="196" cy="93" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-sol" data-effort="xhigh" data-stats="27/30 first-try &middot; ~4 min/part &middot; ~$2.11/part at API rates" aria-label="gpt-5.6-sol (xhigh effort): 27/30 first-try, ~4 min/part · ~$2.11/part at API rates"/><text x="196" y="96" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">X</text><path d="M 234 100 L 248 86" fill="none" stroke="var(--dimmer)" stroke-width="1"/><rect x="245" y="79" width="91" height="14" fill="var(--panel)"/><text x="248" y="90" text-anchor="start" font-size="12" fill="var(--text)">gpt-5.6-luna</text><circle class="dot" cx="234" cy="100" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="max" data-stats="32/36 first-try &middot; ~5 min/part &middot; ~$0.13/part at API rates" aria-label="gpt-5.6-luna (max effort): 32/36 first-try, ~5 min/part · ~$0.13/part at API rates"/><text x="234" y="103" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">+</text><circle class="dot" cx="323" cy="100" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-opus-5" data-effort="medium" data-stats="16/18 first-try &middot; ~7 min/part &middot; ~$1.66/part at API rates" aria-label="claude-opus-5 (medium effort): 16/18 first-try, ~7 min/part · ~$1.66/part at API rates"/><text x="323" y="103" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="133" cy="137" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-sol" data-effort="low" data-stats="15/18 first-try &middot; ~2 min/part &middot; ~$1.62/part at API rates" aria-label="gpt-5.6-sol (low effort): 15/18 first-try, ~2 min/part · ~$1.62/part at API rates"/><text x="133" y="140" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="260" cy="137" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-sonnet-5" data-effort="low" data-stats="10/12 first-try &middot; ~6 min/part &middot; ~$0.84/part at API rates" aria-label="claude-sonnet-5 (low effort): 10/12 first-try, ~6 min/part · ~$0.84/part at API rates"/><text x="260" y="140" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><path d="M 150 179 L 164 165" fill="none" stroke="var(--dimmer)" stroke-width="1"/><rect x="161" y="158" width="98" height="14" fill="var(--panel)"/><text x="164" y="169" text-anchor="start" font-size="12" fill="var(--text)">gpt-5.6-terra</text><circle class="dot" cx="150" cy="179" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-terra" data-effort="medium" data-stats="37/48 first-try &middot; ~3 min/part &middot; ~$0.84/part at API rates" aria-label="gpt-5.6-terra (medium effort): 37/48 first-try, ~3 min/part · ~$0.84/part at API rates"/><text x="150" y="182" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="220" cy="182" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="xhigh" data-stats="23/30 first-try &middot; ~5 min/part &middot; ~$0.12/part at API rates" aria-label="gpt-5.6-luna (xhigh effort): 23/30 first-try, ~5 min/part · ~$0.12/part at API rates"/><text x="220" y="185" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">X</text><circle class="dot" cx="164" cy="182" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-terra" data-effort="high" data-stats="23/30 first-try &middot; ~3 min/part &middot; ~$0.79/part at API rates" aria-label="gpt-5.6-terra (high effort): 23/30 first-try, ~3 min/part · ~$0.79/part at API rates"/><text x="164" y="185" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="189" cy="204" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="high" data-stats="22/30 first-try &middot; ~4 min/part &middot; ~$0.10/part at API rates" aria-label="gpt-5.6-luna (high effort): 22/30 first-try, ~4 min/part · ~$0.10/part at API rates"/><text x="189" y="207" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="138" cy="286" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="medium" data-stats="11/18 first-try &middot; ~2 min/part &middot; ~$0.079/part at API rates" aria-label="gpt-5.6-luna (medium effort): 11/18 first-try, ~2 min/part · ~$0.079/part at API rates"/><text x="138" y="289" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">M</text><circle class="dot" cx="140" cy="323" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-terra" data-effort="low" data-stats="10/18 first-try &middot; ~2 min/part &middot; ~$0.74/part at API rates" aria-label="gpt-5.6-terra (low effort): 10/18 first-try, ~2 min/part · ~$0.74/part at API rates"/><text x="140" y="326" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><circle class="dot" cx="147" cy="508" r="8" fill="#8f75e0" stroke="var(--panel)" stroke-width="2" data-model="gpt-5.6-luna" data-effort="low" data-stats="5/18 first-try &middot; ~3 min/part &middot; ~$0.077/part at API rates" aria-label="gpt-5.6-luna (low effort): 5/18 first-try, ~3 min/part · ~$0.077/part at API rates"/><text x="147" y="511" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text><rect x="339" y="576" width="119" height="14" fill="var(--panel)"/><text x="342" y="587" text-anchor="start" font-size="12" fill="var(--text)">claude-haiku-4-5</text><circle class="dot" cx="328" cy="583" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-haiku-4-5" data-effort="high" data-stats="2/12 first-try &middot; ~8 min/part &middot; ~$0.46/part at API rates" aria-label="claude-haiku-4-5 (high effort): 2/12 first-try, ~8 min/part · ~$0.46/part at API rates"/><text x="328" y="586" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">H</text><circle class="dot" cx="314" cy="613" r="8" fill="#2f9fb5" stroke="var(--panel)" stroke-width="2" data-model="claude-haiku-4-5" data-effort="low" data-stats="4/33 first-try &middot; ~7 min/part &middot; ~$0.46/part at API rates" aria-label="claude-haiku-4-5 (low effort): 4/33 first-try, ~7 min/part · ~$0.46/part at API rates"/><text x="314" y="616" text-anchor="middle" font-size="9" font-weight="700" fill="#fff" pointer-events="none">L</text></svg><div class="chart-legend"><span><i style="background:#2f9fb5"></i>Claude</span><span><i style="background:#8f75e0"></i>ChatGPT (Codex)</span><span><i style="background:#b8bec9"></i>Grok</span><span><b>L&thinsp;M&thinsp;H&thinsp;X&thinsp;+</b>effort, low to max; hover a dot for its numbers</span></div></div>
 
 <div class="sec-label"><b>// 04</b> &nbsp;the jobs</div>
 <h2>Six jobs, graded on geometry.</h2>
@@ -799,7 +817,7 @@
 </div>
 
 <p class="fine">$/part is what the same tokens would cost at API list prices; on a subscription it comes out of your plan.</p>
-<p class="fine">Early days: 744 graded parts across 6 jobs so far. Each bar averages every attempt on file, and the ticks are the attempts themselves.</p>
+<p class="fine">Early days: 762 graded parts across 6 jobs so far. Each bar averages every attempt on file, and the ticks are the attempts themselves.</p>
 <p class="fine">Grading is a fixed rubric measured on the part's actual geometry, so the only randomness is the model's. Raw results, full transcripts, and the grading code are <a href="https://github.com/Shpigford/nurb-benchmarks/blob/main/REPORT.md">on GitHub</a>.</p>
 </main>
 <footer>


### PR DESCRIPTION
Regenerated `site/benchmarks.html` from Shpigford/nurb-benchmarks after sanity-checking the one run that landed since this morning's publish.

## Published

**`claude-claude-fable-5-max-61829b`** — claude-fable-5 at max effort, 18 attempts across all six jobs, 18/18.

## Rejected

None.

## What moves on the page

The board gains a fourth claude-fable-5 row, at 18/18, about 13 minutes and $5.79 a part. That makes it the most expensive row on the page and the second slowest, for the same 18/18 the same model gets at medium effort for a quarter of the money, so its verdict points readers back to medium.

The three subscription cards are unchanged: the card logic tiebreaks perfect rows on speed, so fable-5 at medium (about 3 minutes) keeps the Claude card over max (about 13).

## Verification

All 18 rows re-graded and reproduce exactly; parts unique against the reference solutions and every other submission; artifacts complete and sanitized; no `nurb dev` in any transcript. Detail in Shpigford/nurb-benchmarks#19, which carries the regenerated `REPORT.md` and the verdict text.

Page opened in a browser and looked at before publishing: no label collisions on the scatter plot, no card wrapping, no empty state, and the new row's verdict wraps cleanly when expanded.