### PR TITLE
Add the Bambu P2S printer profile

### DIFF
--- a/src/nurb/printers.toml
+++ b/src/nurb/printers.toml
@@ -24,6 +24,10 @@ slicer = "Bambu Lab X2D"
 bed = [256.0, 256.0, 256.0]
 slicer = "Bambu Lab P1S"
 
+[bambu_p2s]
+bed = [256.0, 256.0, 256.0]
+slicer = "Bambu Lab P2S"
+
 [bambu_p1p]
 bed = [256.0, 256.0, 256.0]
 slicer = "Bambu Lab P1P"

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -205,6 +205,14 @@ def test_the_x2d_is_shipped_because_it_is_what_bambu_sells_now():
     }
 
 
+def test_the_p2s_profile_matches_the_vendor_and_slicer():
+    have = profiles()
+    assert have["bambu_p2s"] == {
+        "bed": [256.0, 256.0, 256.0],
+        "slicer": "Bambu Lab P2S",
+    }
+
+
 def test_anycubic_kobra_2_profile_matches_the_vendor_and_slicer():
     have = profiles()
     assert have["anycubic_kobra_2"] == {


### PR DESCRIPTION
Adds the Bambu P2S printer profile alongside the existing Bambu profiles, using its 256 x 256 x 256 mm build volume and Bambu Studio profile name. Adds regression coverage for the profile mapping.

Verification:
- npm test in desktop: 11 tests passed.
- npm run tauri build: application and DMG built successfully; updater signing was skipped because TAURI_SIGNING_PRIVATE_KEY is not configured.
- uv run pytest tests/test_printer.py tests/test_slicing.py: blocked by uv cache permissions in the local environment.