### PR TITLE
Collapse variants under their selected part in the sidebar

### DIFF
--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -432,6 +432,22 @@ textarea {
   font-weight: 600;
 }
 
+/* How many variants a folded part has. `margin-left: auto` puts it at the right
+   end, and it never shrinks, because .part-name takes the slack first. */
+.var-count {
+  margin-left: auto;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  color: var(--dimmer);
+}
+
+.var-count .row-icon {
+  color: var(--dimmer);
+}
+
 .part-refused {
   color: var(--amber);
   font-weight: 600;

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1076,36 +1076,45 @@ function App() {
                             !
                           </span>
                         )}
+                        {/* Folded-away variants still say how many there are, so the
+                            rail does not hide them without a trace. */}
+                        {part.variants.length > 0 && part.name !== selectedPart && (
+                          <span className="var-count">
+                            <IconVariant size={9} />
+                            {part.variants.length}
+                          </span>
+                        )}
                       </li>
                       {/* The card's variants nest under their part the way the
                           browser viewer draws them: the same part at other values,
-                          wearing the sliders glyph. The active mark follows the
-                          server's resolved variant, so it tracks slider drags and
-                          agent edits too, one poll behind. */}
-                      {part.variants.map((v) => {
-                        const how = Object.entries(v.params)
-                          .map(([k, val]) => `${k} = ${val}`)
-                          .join("\n");
-                        // Drifted off this variant: no longer resolved by the server,
-                        // but still where the work is, so the row stays pinned.
-                        const modified =
-                          part.name === selectedPart &&
-                          part.variant !== v.name &&
-                          variantOrigin?.drifted === true &&
-                          variantOrigin.part === part.name &&
-                          variantOrigin.variant === v.name;
-                        return (
-                          <li
-                            key={`${part.name}:${v.name}`}
-                            className={`part-var ${part.name === selectedPart && part.variant === v.name ? "selected" : ""} ${modified ? "modified" : ""}`}
-                            title={v.note ? `${v.note}\n\n${how}` : how}
-                            onClick={() => selectPart(part.name, v.name)}
-                          >
-                            <IconVariant />
-                            <span className="part-name">{v.name}</span>
-                          </li>
-                        );
-                      })}
+                          wearing the sliders glyph. They unfold under the selection
+                          only, because twenty parts' variants at once is a wall. The
+                          active mark follows the server's resolved variant, so it
+                          tracks slider drags and agent edits too, one poll behind. */}
+                      {part.name === selectedPart &&
+                        part.variants.map((v) => {
+                          const how = Object.entries(v.params)
+                            .map(([k, val]) => `${k} = ${val}`)
+                            .join("\n");
+                          // Drifted off this variant: no longer resolved by the server,
+                          // but still where the work is, so the row stays pinned.
+                          const modified =
+                            part.variant !== v.name &&
+                            variantOrigin?.drifted === true &&
+                            variantOrigin.part === part.name &&
+                            variantOrigin.variant === v.name;
+                          return (
+                            <li
+                              key={`${part.name}:${v.name}`}
+                              className={`part-var ${part.variant === v.name ? "selected" : ""} ${modified ? "modified" : ""}`}
+                              title={v.note ? `${v.note}\n\n${how}` : how}
+                              onClick={() => selectPart(part.name, v.name)}
+                            >
+                              <IconVariant />
+                              <span className="part-name">{v.name}</span>
+                            </li>
+                          );
+                        })}
                       {/* The selection expands to its counterparts: the assemblies
                           that place this part, or the parts this assembly places.
                           Only under the selection, because the relationship is what

--- a/src/nurb/viewer.html
+++ b/src/nurb/viewer.html
@@ -56,6 +56,9 @@
   .item.active { background: #2c313b; }
   .item .name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .item .ms { color: var(--dim); font-size: 11px; }
+  /* How many variants a folded part has, dim beside its build time. */
+  .item .vcount { color: var(--dim); font-size: 11px; opacity: .7; display: flex; align-items: center; gap: 3px; }
+  .item .vcount .vic { width: 9px; height: 9px; flex: none; }
   /* A variant is its part flexed, so it nests under it: indented past the dot, dim
      until it is the configuration on screen. */
   .item.var { padding: 4px 10px 4px 24px; font-size: 12px; }
@@ -2511,7 +2514,11 @@ function render() {
         ? `<svg class="dot asm ${light}"><title>assembly</title><use href="#i-cubes"/></svg>`
         : `<span class="dot ${light}"></span>`)
       + `<span class="name">${e.name}</span>`
-      + `<span class="ms">${e.error ? (e.refused ? '' : 'err') : e.ms + 'ms'}</span>`;
+      + `<span class="ms">${e.error ? (e.refused ? '' : 'err') : e.ms + 'ms'}</span>`
+      // Folded-away variants still say how many there are, so the list does not
+      // hide them without a trace.
+      + (e.name !== current && (e.variants || []).length
+          ? `<span class="vcount"><svg class="vic"><use href="#i-variant"/></svg>${e.variants.length}</span>` : '');
     row.onclick = () => {
       // A click supersedes a deep link whose part is still waiting to build.
       want = null; wantVariant = null; wantConfiguration = false;
@@ -2523,7 +2530,9 @@ function render() {
       render(); show(e.name, { keepCamera: false }); setURL();
     };
     list.appendChild(row);
-    for (const v of e.variants || []) {
+    // A part's variants unfold under the part on screen only, because every part's
+    // variants at once is a wall of rows.
+    for (const v of (e.name === current ? e.variants || [] : [])) {
       const vr = document.createElement('div');
       // Drifted off a variant: no longer active, but still where the work is, so the
       // row stays pinned and its accent says these are its values plus some drag.


### PR DESCRIPTION
Variant rows in the sidebar now render only under the selected part, the same rule the rail already used for placement links, so the list stays at one row per part at rest. A part whose variants are folded away shows a dim variant-glyph count badge (like "2") so they are discoverable, and clicking the part selects it and unfolds them. The behavior lands in both surfaces: the desktop rail (App.tsx/App.css) and the viewer's own sidebar (viewer.html), with no new state or plumbing since expanded simply means selected. Verified with tsc, desktop npm test (11/11), viewer pytest (18/18), and live browser checks of collapse, expand-on-click, and ?variant= deep links.