### PR TITLE
Move agent sign-in from the rail into Settings and the chat

### DIFF
--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -497,95 +497,6 @@ textarea {
   background: var(--hover);
 }
 
-.agents {
-  margin-top: 12px;
-  border-top: 1px solid var(--line);
-  padding-top: 10px;
-}
-
-.agent-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 7px;
-  border-left: 2px solid transparent;
-  border-radius: 0 6px 6px 0;
-  font-size: 12px;
-  color: var(--dim);
-  cursor: pointer;
-}
-
-.agent-row:hover {
-  background: var(--hover);
-}
-
-/* The agent new conversations use. Same idiom as a selected part row, because
-   it answers the same question: which one is live right now. */
-.agent-row.selected {
-  color: var(--text);
-  background: var(--active);
-  border-left-color: var(--accent);
-}
-
-.agent-check {
-  flex: none;
-  color: var(--accent);
-}
-
-/* Faded rather than hidden, so the names stay on one column. Opacity, not
-   visibility, per this app's rule about keeping things in the AX tree. */
-.agent-check.hidden {
-  opacity: 0;
-}
-
-.agent-name {
-  flex: 1;
-  min-width: 0;
-}
-
-.agent-state {
-  color: var(--dimmer);
-  font-size: 11px;
-}
-
-.agent-more {
-  margin-top: 4px;
-  padding: 3px 7px;
-  font: inherit;
-  font-size: 11px;
-  text-align: left;
-  color: var(--dimmer);
-  background: none;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-}
-
-.agent-more:hover {
-  color: var(--text);
-  background: var(--hover);
-}
-
-.agent-signin {
-  font: inherit;
-  font-size: 11px;
-  padding: 2px 8px;
-  border-radius: 5px;
-  border: 1px solid rgba(110, 231, 168, 0.35);
-  background: none;
-  color: var(--accent);
-  cursor: pointer;
-}
-
-.agent-signin:hover:not(:disabled) {
-  background: rgba(110, 231, 168, 0.1);
-}
-
-.agent-signin:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-
 .rail-error {
   margin-top: 8px;
   padding: 6px 8px;
@@ -698,7 +609,9 @@ textarea {
 }
 
 .chat-switcher-item {
-  display: block;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
   width: 100%;
   font: inherit;
   font-size: 12px;
@@ -719,6 +632,12 @@ textarea {
 .chat-switcher-item.current {
   color: var(--text);
   background: var(--active);
+}
+
+.chat-switcher-hint {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--dimmer);
 }
 
 .chat-switcher-note {
@@ -1798,6 +1717,57 @@ textarea {
 
 .settings-toggle input {
   accent-color: var(--accent);
+}
+
+.settings-agent {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 7px 0;
+  border-top: 1px solid var(--line);
+}
+
+.settings-agent-name {
+  flex: 1;
+  min-width: 0;
+  font: 13px var(--sans);
+  color: var(--text);
+}
+
+.settings-agent-state {
+  color: var(--dimmer);
+  font: 11px var(--mono);
+}
+
+.settings-agent .settings-action {
+  padding: 4px 10px;
+  font-size: 11px;
+}
+
+.settings-agent .settings-action:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.settings-agent-error {
+  margin: 8px 0 0;
+  font: 11px/1.5 var(--mono);
+  color: var(--bad);
+  overflow-wrap: anywhere;
+}
+
+.settings-agent-more {
+  margin-top: 10px;
+  padding: 0;
+  font: 11px var(--mono);
+  color: var(--dimmer);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.settings-agent-more:hover {
+  color: var(--text);
 }
 
 /* ---- the "need another agent?" help ---- */

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -17,8 +17,9 @@ import {
   updateChatActivity,
   type ChatColumn,
 } from "./chatColumns";
-import { IconCheck, IconCube, IconCubes, IconFolder, IconFolderPlus, IconGear, IconVariant } from "./Icons";
+import { IconCube, IconCubes, IconFolder, IconFolderPlus, IconGear, IconVariant } from "./Icons";
 import { COLUMNS, fitColumns, initialColumns, resizedColumn } from "./layout";
+import { createLatestRequestGate } from "./latestRequest";
 import Logo from "./Logo";
 import type { Column } from "./layout";
 import { partMessage, type PartConfigurationRequest } from "./partMessages";
@@ -196,6 +197,8 @@ function App() {
   // nudge. Prefilled, never sent: the lift stays the user's call.
   const [projectSeed, setProjectSeed] = useState<string | null>(null);
   const [agentStatuses, setAgentStatuses] = useState<AgentStatus[]>([]);
+  const [agentStatusState, setAgentStatusState] = useState<"loading" | "ready" | "error">("loading");
+  const agentStatusRequests = useRef(createLatestRequestGate());
   const [signingIn, setSigningIn] = useState<string | null>(null);
   // A UI preference like the agent below, so it persists the same way.
   const [columnWidths, setColumnWidths] = useState(() =>
@@ -406,11 +409,30 @@ function App() {
   }, [focusProjectChat]);
 
   const refreshAgents = useCallback(async () => {
-    setAgentStatuses(await invoke<AgentStatus[]>("agent_statuses"));
+    const isLatest = agentStatusRequests.current.begin();
+    setAgentStatusState((state) => state === "ready" ? state : "loading");
+    try {
+      const statuses = await invoke<AgentStatus[]>("agent_statuses");
+      if (!isLatest()) return;
+      setAgentStatuses(statuses);
+      setAgentStatusState("ready");
+    } catch (e) {
+      if (isLatest()) setAgentStatusState((state) => state === "ready" ? state : "error");
+      throw e;
+    }
   }, []);
 
   useEffect(() => {
-    if (ready === true) refreshAgents();
+    if (ready === true) refreshAgents().catch(() => {});
+  }, [ready, refreshAgents]);
+
+  // Signing in happens in a terminal or a browser, outside this window, so
+  // coming back is the moment to notice it.
+  useEffect(() => {
+    if (ready !== true) return;
+    const onFocus = () => refreshAgents().catch(() => {});
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
   }, [ready, refreshAgents]);
 
   const chooseAgent = (id: string) => {
@@ -1178,61 +1200,6 @@ function App() {
           <IconFolderPlus />
           add existing…
         </button>
-        {agentStatuses.length > 0 && (
-          <div className="agents">
-            <div className="rail-heading">
-              <span>agents</span>
-            </div>
-            {agentStatuses
-              // Agents whose CLI is not on this Mac stay out of the rail;
-              // the "need another agent?" help is where they live.
-              .filter((status) => status.installed)
-              .map((status) => (
-              <div
-                key={status.id}
-                className={
-                  status.id === defaultAgent ? "agent-row selected" : "agent-row"
-                }
-                aria-current={status.id === defaultAgent}
-                title={
-                  status.id === defaultAgent
-                    ? `${status.note} — new conversations use ${AGENT_LABEL[status.id] ?? status.label}`
-                    : `${status.note} — click to use for new conversations`
-                }
-                onClick={() => chooseAgent(status.id)}
-              >
-                <IconCheck
-                  className={
-                    status.id === defaultAgent ? "agent-check" : "agent-check hidden"
-                  }
-                />
-                <span className="agent-name">{AGENT_LABEL[status.id] ?? status.label}</span>
-                {status.loggedIn === false ? (
-                  <button
-                    className="agent-signin"
-                    disabled={signingIn !== null}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      signInAgent(status.id).catch(() => {});
-                    }}
-                  >
-                    {signingIn === status.id ? "signing in…" : "sign in"}
-                  </button>
-                ) : (
-                  <span
-                    className="agent-state"
-                    title={status.loggedIn ? (status.detail ?? "signed in") : undefined}
-                  >
-                    {status.loggedIn ? "signed in" : "status unknown"}
-                  </span>
-                )}
-              </div>
-            ))}
-            <button className="agent-more" onClick={() => setShowAgentsHelp(true)}>
-              need another agent?
-            </button>
-          </div>
-        )}
         {error && <div className="rail-error">{error}</div>}
         <div className="rail-foot">
           {update && (
@@ -1313,6 +1280,14 @@ function App() {
           customized={projectsFolder !== null}
           onChange={changeProjectsFolder}
           onReset={() => changeProjectsFolder(null)}
+          agents={agentStatuses.filter((status) => status.installed)}
+          agentStatusState={agentStatusState}
+          signingIn={signingIn}
+          onSignIn={signInAgent}
+          onMoreAgents={() => {
+            setShowSettings(false);
+            setShowAgentsHelp(true);
+          }}
           onClose={() => setShowSettings(false)}
         />
       )}
@@ -1339,7 +1314,7 @@ function App() {
             setShowAgentsHelp(false);
             // The user may have just run an installer; notice it now, not on
             // the next launch.
-            refreshAgents();
+            refreshAgents().catch(() => {});
           }}
         />
       )}
@@ -1357,12 +1332,13 @@ function App() {
             part={col.part}
             agent={agent}
             agents={agentStatuses
-              // The rail advertises uninstalled agents with an install
-              // hint; the switcher only offers ones that can actually run.
+              // Settings lists uninstalled agents with an install hint; the
+              // switcher only offers ones that can actually run.
               .filter((status) => status.installed)
               .map((status) => ({
                 id: status.id,
                 label: AGENT_LABEL[status.id] ?? status.label,
+                loggedIn: status.loggedIn,
               }))}
             resume={col.resume}
             hidden={!columnVisible(col)}
@@ -1370,7 +1346,12 @@ function App() {
             onSeed={isProject ? () => setProjectSeed(null) : undefined}
             onSession={(id) => chatStarted(col.path, col.part, id, agent)}
             onFresh={() => startFresh(col.path, col.part)}
-            onAgent={(id) => startFresh(col.path, col.part, id)}
+            onAgent={(id, unstarted) => {
+              // Picking an agent before the first message is choosing which
+              // agent you work with, so it sticks for later chats too.
+              if (unstarted) chooseAgent(id);
+              startFresh(col.path, col.part, id);
+            }}
             onBusy={(busy) =>
               chatBusy(col.path, col.part, agent, busy, columnVisible(col))
             }

--- a/desktop/src/Chat.tsx
+++ b/desktop/src/Chat.tsx
@@ -153,7 +153,7 @@ function Chat({
   // that ran it, a fresh one takes the default from the agents pane.
   agent: string;
   // Everything the app can host, for the header's switcher.
-  agents: { id: string; label: string }[];
+  agents: { id: string; label: string; loggedIn: boolean | null }[];
   resume: string | null;
   hidden: boolean;
   // Text waiting for the composer, from a viewer nudge. Prefilled when the column
@@ -163,12 +163,15 @@ function Chat({
   onSession: (id: string) => void;
   onFresh: () => void;
   // Switching agents cannot move a conversation across two different session
-  // stores, so it starts a fresh one on the agent picked.
-  onAgent: (id: string) => void;
+  // stores, so it starts a fresh one on the agent picked. `unstarted` is true
+  // when nothing has been said yet, which makes the pick the new default.
+  onAgent: (id: string, unstarted: boolean) => void;
   onBusy: (busy: boolean) => void;
   onSignIn: (agent: string) => Promise<boolean>;
 }) {
   const label = AGENT_LABEL[agent] ?? agent;
+  // Known signed out, not merely unknown: an unknown status stays quiet.
+  const signedOut = agents.find((option) => option.id === agent)?.loggedIn === false;
   // The sentinel never reaches copy: everywhere the column says its name, the
   // project conversation speaks of the project.
   const isProject = part === PROJECT_CHAT;
@@ -177,7 +180,8 @@ function Chat({
   // A resumed transcript starts loading after the first paint, so treat it as
   // starting immediately rather than briefly exposing a live composer.
   const [starting, setStarting] = useState(Boolean(resume));
-  const [authNeeded, setAuthNeeded] = useState(false);
+  // A refused prompt needs explicit resend guidance; a proactive or resume sign-in does not.
+  const [authNeeded, setAuthNeeded] = useState<"none" | "sign-in" | "resume" | "resend">("none");
   const [signingIn, setSigningIn] = useState(false);
   const [permissions, setPermissions] = useState<Permission[]>([]);
   // Absolute paths; the Rust side reads them at send time.
@@ -473,22 +477,24 @@ function Chat({
     return start;
   }, [path, agent, applyEvent, refreshConfig]);
 
-  useEffect(() => {
-    // A history session replays its transcript the moment it opens, not on
-    // the first send.
-    if (!resume) return;
-    ensureSession().catch((e) => {
+  const restoreSession = useCallback(async () => {
+    try {
+      await ensureSession();
+    } catch (e) {
       const message = String(e);
       if (message === "Error: chat closed") return;
       if (message.includes("auth_required")) {
-        setAuthNeeded(true);
+        setAuthNeeded("resume");
       } else {
         setItems((list) => [...list, { kind: "note", text: message }]);
       }
-    });
-    // ensureSession is stable for this mount; resume never changes without a
-    // remount (the parent keys this component on it).
-  }, [resume, ensureSession]);
+    }
+  }, [ensureSession]);
+
+  useEffect(() => {
+    // A history session replays its transcript when it opens, not on the first send; reuse this path after sign-in.
+    if (resume) restoreSession();
+  }, [resume, restoreSession]);
 
   const send = useCallback(
     async (text: string, files: string[]) => {
@@ -506,7 +512,7 @@ function Chat({
       ]);
       setBusy(true);
       onBusyRef.current(true);
-      setAuthNeeded(false);
+      setAuthNeeded("none");
       let completed = false;
       try {
         const session = await ensureSession();
@@ -529,7 +535,7 @@ function Chat({
             inputRef.current.value = restoreDraftText(text, inputRef.current.value);
           }
           attachmentDraft.restore(files);
-          setAuthNeeded(true);
+          setAuthNeeded("resend");
         } else {
           setItems((list) => [...list, { kind: "note", text: message }]);
         }
@@ -616,16 +622,24 @@ function Chat({
   };
 
   const signIn = async () => {
+    const needsResend = authNeeded === "resend";
+    const needsRestore = authNeeded === "resume";
     setSigningIn(true);
     try {
       if (!(await onSignIn(agent))) return;
-      setAuthNeeded(false);
-      setItems((list) => [
-        ...list,
-        { kind: "note", text: "Signed in. Send your message again." },
-      ]);
+      setAuthNeeded("none");
+      if (needsRestore) await restoreSession();
+      // Only a refused message needs sending again; a proactive sign-in has nothing to repeat.
+      if (needsResend) {
+        setItems((list) => [
+          ...list,
+          { kind: "note", text: "Signed in. Send your message again." },
+        ]);
+      }
     } catch (e) {
       setItems((list) => [...list, { kind: "note", text: String(e) }]);
+      // Keep retry visible even though the failure adds an item to the transcript.
+      setAuthNeeded((state) => state === "none" ? "sign-in" : state);
     } finally {
       setSigningIn(false);
     }
@@ -680,10 +694,13 @@ function Chat({
                         }
                         onClick={() => {
                           setSwitching(false);
-                          if (option.id !== agent) onAgent(option.id);
+                          if (option.id !== agent) onAgent(option.id, items.length === 0);
                         }}
                       >
                         {option.label}
+                        {option.loggedIn === false && (
+                          <span className="chat-switcher-hint">sign in</span>
+                        )}
                       </button>
                     ))}
                     {items.length > 0 && (
@@ -717,6 +734,15 @@ function Chat({
             {isProject
               ? `This conversation covers the whole project. Ask ${label} for new parts, or for changes every part should share.`
               : `You're chatting with ${part}. Describe it or ask for changes, and ${label} will model it in the viewer.`}
+          </div>
+        )}
+        {/* Nothing said yet and the agent is known to be signed out: ask before the first message bounces. */}
+        {items.length === 0 && !starting && authNeeded === "none" && signedOut && (
+          <div className="chat-auth">
+            Sign in to {label} to start.{" "}
+            <button className="chat-auth-button" disabled={signingIn} onClick={signIn}>
+              {signingIn ? "signing in…" : "sign in"}
+            </button>
           </div>
         )}
         {items.map((item, index) => {
@@ -812,7 +838,7 @@ function Chat({
             {label} is working…
           </div>
         )}
-        {authNeeded && (
+        {authNeeded !== "none" && (
           <div className="chat-auth">
             {label} isn't signed in on this Mac.{" "}
             <button

--- a/desktop/src/Settings.tsx
+++ b/desktop/src/Settings.tsx
@@ -1,17 +1,45 @@
 import { useState } from "react";
 import { open as pickFolder } from "@tauri-apps/plugin-dialog";
 import { playChime, setSoundEnabled, soundEnabled } from "./chime";
+import { AGENT_LABEL } from "./Chat";
+
+type SettingsAgent = {
+  id: string;
+  label: string;
+  loggedIn: boolean | null;
+  detail: string | null;
+};
 
 type Props = {
   folder: string;
   customized: boolean;
   onChange: (folder: string) => void | Promise<void>;
   onReset: () => void | Promise<void>;
+  // The agents installed on this Mac, so signing in lives with the rest of the
+  // setup rather than beside the parts.
+  agents: SettingsAgent[];
+  agentStatusState: "loading" | "ready" | "error";
+  signingIn: string | null;
+  onSignIn: (id: string) => Promise<boolean>;
+  onMoreAgents: () => void;
   onClose: () => void;
 };
 
-export default function Settings({ folder, customized, onChange, onReset, onClose }: Props) {
+export default function Settings({
+  folder,
+  customized,
+  onChange,
+  onReset,
+  agents,
+  agentStatusState,
+  signingIn,
+  onSignIn,
+  onMoreAgents,
+  onClose,
+}: Props) {
   const [sound, setSound] = useState(soundEnabled);
+  // The rail's error line is behind this modal, so a failed sign-in reports here.
+  const [signInError, setSignInError] = useState<string | null>(null);
 
   const toggleSound = (on: boolean) => {
     setSoundEnabled(on);
@@ -70,6 +98,45 @@ export default function Settings({ folder, customized, onChange, onReset, onClos
             />
             Play a chime when the agent finishes a long task
           </label>
+          <h3>Agents</h3>
+          <p>Pick which one you chat with from the chat header.</p>
+          {agentStatusState === "loading" && (
+            <p className="settings-agent-state" role="status">checking agent status…</p>
+          )}
+          {agentStatusState === "error" && (
+            <p className="settings-agent-error" role="alert">couldn’t check agent status</p>
+          )}
+          {agentStatusState === "ready" && (
+            <>
+              {agents.map((agent) => (
+                <div className="settings-agent" key={agent.id}>
+                  <span className="settings-agent-name">
+                    {AGENT_LABEL[agent.id] ?? agent.label}
+                  </span>
+                  {agent.loggedIn === false ? (
+                    <button
+                      className="settings-action"
+                      disabled={signingIn !== null}
+                      onClick={() => {
+                        setSignInError(null);
+                        onSignIn(agent.id).catch((e) => setSignInError(String(e)));
+                      }}
+                    >
+                      {signingIn === agent.id ? "signing in…" : "sign in"}
+                    </button>
+                  ) : (
+                    <span className="settings-agent-state" title={agent.detail ?? undefined}>
+                      {agent.loggedIn ? "signed in" : "status unknown"}
+                    </span>
+                  )}
+                </div>
+              ))}
+              <button className="settings-agent-more" onClick={onMoreAgents}>
+                need another agent?
+              </button>
+            </>
+          )}
+          {signInError && <p className="settings-agent-error" role="alert">{signInError}</p>}
         </div>
       </div>
     </div>

--- a/desktop/src/latestRequest.ts
+++ b/desktop/src/latestRequest.ts
@@ -1,0 +1,10 @@
+export function createLatestRequestGate() {
+  let latest = 0;
+
+  return {
+    begin() {
+      const request = ++latest;
+      return () => request === latest;
+    },
+  };
+}

--- a/desktop/tests/latestRequest.test.ts
+++ b/desktop/tests/latestRequest.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createLatestRequestGate } from "../src/latestRequest.ts";
+
+test("only the latest request remains current", () => {
+  const gate = createLatestRequestGate();
+  const first = gate.begin();
+
+  assert.equal(first(), true);
+
+  const second = gate.begin();
+
+  assert.equal(first(), false);
+  assert.equal(second(), true);
+});


### PR DESCRIPTION
The sidebar AGENTS section was permanent chrome for set-once state, so it is gone. Sign-in and status now live in an Agents section of the Settings modal, with inline errors and a link to the install help. Choosing an agent happens in the chat header picker, which on a fresh chat also saves the pick as the default, hints at signed-out agents, and shows a sign-in prompt in the empty chat before the first message bounces. Agent statuses refresh on window focus (guarded against out-of-order responses), and signing in from a resumed session now restores the transcript instead of asking to resend.