### PR TITLE
Seed a desktop AGENTS.md without CLI-harness instructions

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -121,7 +121,7 @@ async fn create_project(
 fn seed(launcher: &env::Launcher, dir: &std::path::Path, part: &str) -> Result<(), String> {
     let output = launcher
         .nurb()
-        .args(["new", "--root"])
+        .args(["new", "--embed", "--root"])
         .arg(dir)
         .arg(part)
         .current_dir(dir)

--- a/src/nurb/agents.md
+++ b/src/nurb/agents.md
@@ -2,10 +2,15 @@
 
 A part is a Python function and its keyword defaults are its parameters. A project is any directory with a `parts/` folder; there is no init step. You are the CAD operator: the user describes the part and you do everything else, including creating the project and modelling.
 
+<!-- cli-only -->
 **Start `nurb dev` in the background and hand the user its URL before anything else.** It prints one, and the viewer it serves is where the user watches the part take shape: every save rebuilds and repaints without moving their camera. When your shell runs on the user's own machine, `--open` puts the viewer on their screen without the URL hop. So work in saves, not in silence. `nurb new` already emits a working part; put that blocky draft on screen in the first minute and refine it while they watch. Caption it when you hand the URL over: a user who opens the viewer to an unannounced block cannot tell the placeholder from the design, and one sentence saying it is the starting shape you are now replacing turns the same block into progress. Ten correct but invisible minutes of modelling read as a hang. And repeat the URL at the end of every reply, the handoff included: chat scrolls the link away, and a part the user was never pointed at is a part they cannot judge. The URL deep-links: `?part=<name>` opens on that part and `&variant=<name>` loads one of its card variants, so link the exact thing you changed rather than making the user find it in the list. And it is one server and one tab for the whole session: the process outlives your turns and every save already reaches the open viewer, so never restart `nurb dev` to show new work, and `--open` is for the first start only, never per reply, because every extra open stacks another identical tab on the user's screen. A second start for a project already being served refuses and prints the running URL; reuse it.
+<!-- /cli-only -->
 
+<!-- cli-only -->
 **When `nurb dev` says something is out of date, fix it before modelling.** Its startup lines carry the version check: a `nurb update` line means the package is old, and a `nurb skill --sync` line means this very file is older than the installed nurb. Run the named command and tell the user, and after a sync re-read the skill file, because the stale copy is the one you are working from.
+<!-- /cli-only -->
 
+<!-- cli-only -->
 **Offer the permission allowlist before the prompts start.** A session is dozens of `nurb` invocations and part-file saves, and a harness that asks about each one turns twenty unattended minutes into twenty check-ins the user has to keep coming back for. If your harness keeps a per-project allowlist (in Claude Code it is `.claude/settings.local.json`), offer at the start of the first session in a project to add what the loop needs, merging with anything already there, and move on without it if the user declines:
 
 ```json
@@ -23,6 +28,7 @@ A part is a Python function and its keyword defaults are its parameters. A proje
 ```
 
 Other harnesses take the same grants, the `nurb` prefix and edits under `parts/` plus `system.py`, in their own file: Codex a `prefix_rule` in `.codex/rules/`, Gemini `tools.allowed` in `.gemini/settings.json`, Cursor's CLI a `Shell(nurb)` entry in `.cursor/cli.json`, OpenCode a `permission` block in `opencode.json`. Amp never prompts, so there is nothing to offer.
+<!-- /cli-only -->
 
 **Run `nurb rules` before you design.** It prints the doctrine: printability, load paths, aesthetics, the polish pass, the kernel traps, card discipline, and what to verify. This file stays thin on purpose so there is one copy of that, in the package, which cannot drift.
 
@@ -83,4 +89,6 @@ A standing preference is a file, not a flag you have to remember, and a printer 
 
 Read `parts/<name>.md` before editing `parts/<name>.py`. Its `## Don't` section is what was tried and rejected, and it is the only place that records it.
 
+<!-- cli-only -->
 If `nurb` is not on PATH: `uv tool install nurb` or `pip install nurb`.
+<!-- /cli-only -->

--- a/src/nurb/cli.py
+++ b/src/nurb/cli.py
@@ -42,7 +42,38 @@ def project_root(start=None):
     return here
 
 
-def _seed_agents(root):
+CLI_ONLY_OPEN = "<!-- cli-only -->"
+CLI_ONLY_CLOSE = "<!-- /cli-only -->"
+
+
+def agents_text(embed=False):
+    """The shim as a project should receive it, for the harness that will read it.
+
+    Parts of the file only make sense where the agent owns the loop: starting
+    `nurb dev`, keeping the package and skill current, and asking for permission
+    grants. An app that embeds the viewer already does all three, so an agent
+    told to do them there wastes turns and edits files it does not own.
+    """
+    from . import __file__ as pkg
+
+    text = (pathlib.Path(pkg).parent / "agents.md").read_text(encoding="utf-8")
+    kept, skipping = [], False
+    for line in text.splitlines():
+        if line == CLI_ONLY_OPEN:
+            skipping = True
+            continue
+        if line == CLI_ONLY_CLOSE:
+            skipping = False
+            continue
+        if not (embed and skipping):
+            kept.append(line)
+    out = "\n".join(kept)
+    while "\n\n\n" in out:
+        out = out.replace("\n\n\n", "\n\n")
+    return out.strip("\n") + "\n"
+
+
+def _seed_agents(root, embed=False):
     """Put a pointer to `nurb rules` where an agent will find it on day one.
 
     Everything an agent needs is already reachable: `nurb --help` lists the commands and
@@ -54,21 +85,30 @@ def _seed_agents(root):
     harness files of the user's own, and `nurb new` prints everything it writes either
     way.
     """
-    from . import __file__ as pkg
-
-    shim = (pathlib.Path(pkg).parent / "agents.md").read_text(encoding="utf-8")
+    full_shim = agents_text()
+    embedded_shim = agents_text(True)
+    shim = embedded_shim if embed else full_shim
     agents = root / "AGENTS.md"
     claude = root / "CLAUDE.md"
     if agents.is_file():
         # Heal projects seeded before Claude's native pointer was added, but
         # never make a second harness file alongside one the user wrote.
         existing = agents.read_text(encoding="utf-8")
-        generated = existing == shim or (
+        if existing in (full_shim, embedded_shim):
+            written = []
+            if existing != shim:
+                agents.write_text(shim, encoding="utf-8")
+                written.append(agents)
+            if not claude.is_file():
+                claude.write_text("@AGENTS.md\n", encoding="utf-8")
+                written.append(claude)
+            return written, None
+        legacy_generated = (
             existing.startswith("# nurb\n")
             and "`nurb rules`" in existing
             and "If `nurb` is not on PATH:" in existing
         )
-        if generated:
+        if legacy_generated:
             if not claude.is_file():
                 claude.write_text("@AGENTS.md\n", encoding="utf-8")
                 return [claude], None
@@ -106,7 +146,7 @@ def cmd_new(args):
     written = [py, md]
     if born:
         written.append(_write_launcher(root))
-    seeded, already = _seed_agents(root)
+    seeded, already = _seed_agents(root, getattr(args, "embed", False))
     written.extend(seeded)
     for path in written:
         print(f"  {path.relative_to(root)}")
@@ -1242,6 +1282,11 @@ def main(argv=None):
     s = sub.add_parser("new", help="create a part")
     s.add_argument("name")
     s.add_argument("--root", help=argparse.SUPPRESS)
+    s.add_argument(
+        "--embed",
+        action="store_true",
+        help="seed AGENTS.md for an embedding app that owns the server and permissions",
+    )
     s.set_defaults(fn=cmd_new)
 
     s = sub.add_parser("dev", help="watch parts and serve the viewer")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,12 +168,12 @@ def test_a_dev_for_a_different_project_is_walked_past_not_reused(tmp_path):
 # --- day one ------------------------------------------------------------------
 
 
-def _new(tmp_path, name="thing", root=None):
+def _new(tmp_path, name="thing", root=None, embed=False):
     import argparse, os
     was = os.getcwd()
     os.chdir(tmp_path)
     try:
-        cli.cmd_new(argparse.Namespace(name=name, root=root))
+        cli.cmd_new(argparse.Namespace(name=name, root=root, embed=embed))
     finally:
         os.chdir(was)
 
@@ -192,6 +192,47 @@ def test_a_fresh_project_gets_a_pointer_at_the_doctrine(tmp_path, capsys):
     output = capsys.readouterr().out
     assert "AGENTS.md" in output  # it says what it wrote
     assert "CLAUDE.md" in output
+
+
+def test_a_seeded_shim_never_carries_the_markers(tmp_path):
+    _new(tmp_path)
+    text = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert "cli-only" not in text
+    assert "Start `nurb dev`" in text
+    assert "permission allowlist" in text
+    assert "nurb skill --sync" in text
+    assert "\n\n\n" not in text
+
+
+def test_an_embedded_seed_drops_what_the_app_already_owns(tmp_path):
+    """The desktop app runs the server, the updates and the permissions itself, so an
+    agent told to do them there spends turns on work that is already done."""
+    _new(tmp_path, embed=True)
+    text = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert "cli-only" not in text
+    assert "Start `nurb dev`" not in text
+    assert "nurb skill --sync" not in text
+    assert "permission allowlist" not in text
+    assert '"Bash(nurb:*)"' not in text
+    assert "not on PATH" not in text
+    assert "Run `nurb rules` before you design" in text
+    assert "\n\n\n" not in text
+
+
+def test_a_plain_new_replaces_an_exact_embedded_shim(tmp_path):
+    _new(tmp_path, "one", embed=True)
+
+    _new(tmp_path, "two")
+
+    assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8") == cli.agents_text()
+
+
+def test_an_embedded_new_replaces_an_exact_plain_shim(tmp_path):
+    _new(tmp_path, "one")
+
+    _new(tmp_path, "two", embed=True)
+
+    assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8") == cli.agents_text(True)
 
 
 def test_a_second_part_does_not_mention_the_shim_again(tmp_path, capsys):
@@ -220,12 +261,13 @@ def test_an_old_generated_agents_shim_gets_a_claude_pointer(tmp_path):
 
 
 def test_a_custom_agents_file_does_not_grow_a_claude_pointer(tmp_path):
-    (tmp_path / "AGENTS.md").write_text("# my harness\n", encoding="utf-8")
+    custom = "# nurb\n\nOur workflow starts with `nurb rules`, then follows team policy.\n"
+    (tmp_path / "AGENTS.md").write_text(custom, encoding="utf-8")
 
     _new(tmp_path)
 
     assert not (tmp_path / "CLAUDE.md").exists()
-    assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8") == "# my harness\n"
+    assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8") == custom
 
 
 def test_an_explicit_root_never_seeds_an_ancestor_project(tmp_path):
@@ -708,7 +750,9 @@ def test_the_skill_is_the_shim_with_a_trigger_on_top():
     repo = pathlib.Path(__file__).parents[1]
     shipped = (pkg / "skill.md").read_text(encoding="utf-8")
     assert shipped == (repo / "skills" / "nurb" / "SKILL.md").read_text(encoding="utf-8")
-    assert shipped.endswith((pkg / "agents.md").read_text(encoding="utf-8"))
+    # agents.md carries the cli-only markers; the skill files carry the same body
+    # with the markers taken out, because `nurb skill` prints them to a terminal.
+    assert shipped.endswith(cli.agents_text())
     assert shipped.startswith("---\n")  # the trigger a harness keys on
     # Strict YAML reads an unquoted ": " inside a value as a nested mapping, and
     # skills.sh parses strictly: a colon in the description made `npx skills add`


### PR DESCRIPTION
Projects created by the desktop app were seeded with the same AGENTS.md as CLI projects, so the chat agent followed instructions that only make sense where the agent owns the loop: starting nurb dev, offering permission allowlists, and syncing installed skill copies. On a machine with a CLI skill install, that sync doctrine sent the app's agent off rewriting user-global files under ~/.agents mid-session.

The CLI-only blocks in agents.md are now wrapped in cli-only markers, `nurb new --embed` seeds the shim with those blocks dropped, and the desktop's project seed passes the flag. Every seed strips the marker lines themselves, so plain CLI seeds are unchanged, and the skill mirror test now compares against the stripped text so drift still fails. Verified with the full pytest suite (571 passed) plus cargo check in desktop/src-tauri.