### PR TITLE
Release 0.24.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.23.0"
+version = "0.24.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,18 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.24.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.24.0">v0.24.0</a></span><time datetime="2026-08-29">August 29, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Two more Bambu printers.</b> The P2S and the X2D are in the printer list, so print time and downloads use their real build volume and settings.</span></li>
+      <li><b class="tag">improved</b><span>The printer question lets you back out. Press Escape or click the part to close the list and return to the print time button without choosing a machine.</span></li>
+      <li><b class="tag">improved</b><span>Signing in to your AI moved out of the sidebar and into Settings, and choosing which AI to talk to now happens in the chat header. The first one you pick becomes your default, and signing in partway through a conversation keeps the conversation instead of asking you to send your message again.</span></li>
+      <li><b class="tag">improved</b><span>The part list stays at one row per part. A part with saved variants shows how many it has, and clicking the part unfolds them.</span></li>
+      <li><b class="tag">improved</b><span>Grok chats now show the model and effort pickers the other agents have, so you can choose which Grok answers and how hard it thinks.</span></li>
+      <li><b class="tag">fixed</b><span>Projects created in the app came with instructions written for the command line, which could send your AI off editing files outside your project. New projects no longer carry them.</span></li>
+    </ul>
+  </article>
+
   <article class="release" id="v0.23.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.23.0">v0.23.0</a></span><time datetime="2026-08-25">August 25, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.23.0"
+  version: "0.24.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.23.0"
+  version: "0.24.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.23.0"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Cuts 0.24.0 across the engine and the desktop app. Bumps the four version strings that the tests hold in agreement (`pyproject.toml`, `src/nurb/skill.md`, `skills/nurb/SKILL.md`, `desktop/src-tauri/tauri.conf.json`) and adds the changelog entry for the release.

## What ships

- **Two more Bambu printers.** The P2S and the X2D join the shipped profiles, with their real build volumes and Bambu Studio profile names (#238, #233).
- **The printer question can be dismissed.** Print time's printer list is now the same custom list the download button uses, so Escape or a click on the part gets you back to the button without picking a machine (#233).
- **Agent sign-in moved into Settings.** The permanent AGENTS section is gone from the rail; sign-in and status live in Settings, and choosing an agent happens in the chat header, where a fresh chat also saves the pick as the default. Signing in mid-session restores the transcript instead of asking to resend (#241).
- **Variants collapse under their part.** The part list stays at one row per part, with a count badge on a part whose variants are folded away. Lands in both the desktop rail and the viewer sidebar (#239).
- **Grok gets model and effort pickers.** Grok never advertises ACP `configOptions`, so the desktop adapter now fills the pickers from its `modelState` and vendor session config (#227).
- **Desktop projects no longer seed CLI-only instructions.** The CLI-only blocks in `agents.md` are marker-wrapped and dropped by `nurb new --embed`, which the desktop seed now passes, so the app's agent stops following doctrine that assumes it owns the loop (#242).

Benchmark page regenerations and the benchmark repo move are in the range too, but they are site and tooling changes and earn no changelog line.

## Verification

`uv run pytest tests/test_cli.py -q` passes (57 tests), which is what enforces the four version strings agreeing. The changelog page was served and screenshotted: the new entry renders like its neighbours, versions still descend, no duplicate anchors, no em-dashes.

Merging this is the release. publish.yml handles PyPI, the tag, and the GitHub release; the desktop build and update feed follow from this Mac.