### PR TITLE
Export 3MF when tessellation emits a zero-area needle

### DIFF
--- a/src/nurb/builder.py
+++ b/src/nurb/builder.py
@@ -205,6 +205,14 @@ def _triangulate(shape, tolerance, up=(0, 0, 1)):
             a, b, c = tri.Value(1), tri.Value(2), tri.Value(3)
             if reverse:
                 b, c = c, b
+            # OCCT can emit a triangle whose nodes are distinct indices at the
+            # same xyz (a zero-area needle). Skip on the transformed points, not
+            # on a==b: the measured failures already have three different indices.
+            pa = points[offset + a - 1]
+            pb = points[offset + b - 1]
+            pc = points[offset + c - 1]
+            if pa == pb or pb == pc or pc == pa:
+                continue
             faces.append((a + offset - 1, b + offset - 1, c + offset - 1))
         if flat_ceiling:
             ceilings.append((offset, poly.NbNodes()))
@@ -340,9 +348,10 @@ def write_3mf(shape, target):
     # viewer's edges crisp. Rebuilding welds them, which is both what the format wants
     # and a third off the file size.
     welded = trimesh.Trimesh(vertices=mesh.vertices, faces=mesh.faces, process=True)
-    # Welding shared vertices can collapse a triangle onto an edge. lib3mf refuses
-    # those as "invalid parameter" and kills the whole export, so drop them; the
-    # STL has always carried the same holes and every slicer repairs them on load.
+    # lib3mf SetGeometry rejects a triangle whose three indices are not unique.
+    # Tessellation already dropped exact coincident corners; this is the weld's
+    # own rule (it bins round(v*1e8), not Euclidean equality) and the last gate
+    # before the C API.
     faces = welded.faces
     if len(faces):
         keep = (

--- a/src/nurb/builder.py
+++ b/src/nurb/builder.py
@@ -340,6 +340,19 @@ def write_3mf(shape, target):
     # viewer's edges crisp. Rebuilding welds them, which is both what the format wants
     # and a third off the file size.
     welded = trimesh.Trimesh(vertices=mesh.vertices, faces=mesh.faces, process=True)
+    # Welding shared vertices can collapse a triangle onto an edge. lib3mf refuses
+    # those as "invalid parameter" and kills the whole export, so drop them; the
+    # STL has always carried the same holes and every slicer repairs them on load.
+    faces = welded.faces
+    if len(faces):
+        keep = (
+            (faces[:, 0] != faces[:, 1])
+            & (faces[:, 1] != faces[:, 2])
+            & (faces[:, 2] != faces[:, 0])
+        )
+        if not keep.all():
+            welded.update_faces(keep)
+            welded.remove_unreferenced_vertices()
     # lib3mf will happily write an empty model, and a downloaded file that opens to an
     # empty plate is worse than a refusal: it looks like it worked. A part that
     # tessellates to nothing is what the `solids` rule is for, so say that.

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -214,6 +214,33 @@ def test_a_format_that_measures_but_cannot_convert_says_which(tmp_path):
             import_stl(target)
 
 
+def test_3mf_writes_a_mesh_whose_weld_collapses_a_triangle(tmp_path, monkeypatch):
+    """Welding shared vertices can leave a triangle with two corners the same.
+
+    lib3mf's SetGeometry rejects that as "invalid parameter" and the viewer's
+    3mf button dies with ELib3MFException. Drop the collapsed triangle and write
+    the rest; the STL has always carried the same holes.
+    """
+    import zipfile
+
+    from nurb import builder
+
+    mesh = trimesh.Trimesh(
+        vertices=[[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 0]],
+        faces=[[0, 1, 2], [0, 1, 3]],
+        process=False,
+    )
+    monkeypatch.setattr(builder, "to_mesh", lambda *a, **k: mesh)
+
+    target = tmp_path / "collapsed.3mf"
+    builder.write_3mf(Box(20, 30, 40), target)
+
+    with zipfile.ZipFile(target) as z:
+        model = z.read("3D/3dmodel.model").decode()
+    assert 'unit="millimeter"' in model
+    assert model.count("<triangle ") == 1
+
+
 def test_3mf_says_what_to_do_instead_of_naming_a_missing_module(tmp_path):
     """The other half of a model site download, and trimesh cannot read it here.
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -12,6 +12,7 @@ nothing.
 
 import shlex
 
+import numpy as np
 import pytest
 import trimesh
 from build123d import Box, Cylinder, Location, Mesher, Solid, export_stl, fillet
@@ -214,12 +215,33 @@ def test_a_format_that_measures_but_cannot_convert_says_which(tmp_path):
             import_stl(target)
 
 
-def test_3mf_writes_a_mesh_whose_weld_collapses_a_triangle(tmp_path, monkeypatch):
-    """Welding shared vertices can leave a triangle with two corners the same.
+def test_to_mesh_drops_occt_triangles_with_two_corners_at_the_same_point():
+    """OCCT tessellation of a filleted box emits needles with two corners at one xyz.
 
-    lib3mf's SetGeometry rejects that as "invalid parameter" and the viewer's
-    3mf button dies with ELib3MFException. Drop the collapsed triangle and write
-    the rest; the STL has always carried the same holes.
+    Distinct indices, same point — so an a==b skip is a no-op. `_triangulate` must
+    drop them on the transformed coordinates, or welding later hands lib3mf a
+    duplicate-index triangle and the 3mf button dies.
+    """
+    from nurb import builder
+
+    shape = fillet(Box(10, 10, 10).edges(), 1.0)
+    mesh = builder.to_mesh(shape, 0.01)
+    assert len(mesh.faces), "the fillet has to produce a mesh"
+    verts, faces = mesh.vertices, mesh.faces
+    a, b, c = verts[faces[:, 0]], verts[faces[:, 1]], verts[faces[:, 2]]
+    coincident = (
+        (np.linalg.norm(a - b, axis=1) == 0)
+        | (np.linalg.norm(b - c, axis=1) == 0)
+        | (np.linalg.norm(c - a, axis=1) == 0)
+    )
+    assert not coincident.any()
+
+
+def test_3mf_writes_a_mesh_whose_weld_collapses_a_triangle(tmp_path, monkeypatch):
+    """If a dirty mesh still reaches write_3mf, coincident corners become one index.
+
+    lib3mf's SetGeometry rejects that as "invalid parameter". Drop those faces at
+    the weld; `_triangulate` is the source fix, this is the C API's invariant.
     """
     import zipfile
 


### PR DESCRIPTION
The **3mf** button dies on some parts with `Lib3MFException 2: an invalid parameter was passed`. That is not a welding bug. OCCT tessellation can emit a triangle whose two corners sit at the same point (distinct indices, zero area). Welding then shares that point, which is what 3MF is for, and lib3mf rejects the duplicate indices. After this change, those parts download. STL was already fine.

## What this does
- Tessellation skips triangles whose transformed corners are the same point, so the viewer mesh and the 3MF never contain those needles.
- Welding still shares vertices. lib3mf still refuses a triangle with duplicate indices; that check stays as the last gate, not as a substitute for tessellation.
- Nothing else about the part or the embedded print settings changes.

## How to check
- In the Mac app, open Letter Board and click **3mf** on `letter_board`. That click used to fail.
- Click **3mf** on a simple part such as the stand. It still downloads.
- Open the file in Bambu Studio or Orca.

## Risk
The 3MF and the on-screen mesh omit a handful of zero-area needles OCCT already produced. Slicers never printed those. STL still uses a separate exporter.

---

## Review notes

**This PR is / is not:** tessellation skip on coincident XYZ plus the existing lib3mf index gate in `write_3mf`. It is not "stop welding" or a constrained weld that keeps coincident duplicates. It is not a return to `Mesher.add_shape`. No desktop shell change: the app embeds the viewer, and the viewer already calls `/export`.

**Read first:**
- `src/nurb/builder.py` `_triangulate`: skip when `pa == pb` on transformed points, not when `a == b` on indices. The measured failures already have three different indices.
- `src/nurb/builder.py` `write_3mf`: post-weld duplicate-index drop. trimesh bins `round(v * 10**8)`, which is not Euclidean `1e-8`.

**Do not "fix":**
- Skipping the weld, or refusing to merge two corners of the same triangle. That leaves zero-area faces in the file; lib3mf accepts coincident corners if the indices stay distinct.
- Index equality `a == b` in `_triangulate`. No-op on this bug.
- Changing `_triangulate` to a 2-tuple. `crown._mesh_volume` unpacks two values from the current 3-tuple; `stress.py` unpacks three. Leave the arity.

**Invariants:**
- `_triangulate` still returns `(points, faces, colors)`.
- Empty mesh still raises `BuildError` and deletes the target.
- Written 3MF still says `unit="millimeter"`.
- Cracked/non-manifold meshes still write.

**Tests that prove it:**
- `test_to_mesh_drops_occt_triangles_with_two_corners_at_the_same_point` — `to_mesh(fillet(Box(10,10,10).edges(), 1.0))` has zero coincident-xyz faces. Goes red if the skip is removed (that solid emits 8 needles today). Does not use Letter Board. Does not treat `write_3mf` success as proof.
- `test_3mf_writes_a_mesh_whose_weld_collapses_a_triangle` — dirty mesh reaching `write_3mf` still drops duplicate-index faces after weld.
- `test_3mf_writes_a_tessellation_with_a_crack_in_it` — non-manifold still writes.
