### PR TITLE
Release 0.25.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.24.0"
+version = "0.25.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,15 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.25.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.25.0">v0.25.0</a></span><time datetime="2026-09-04">September 4, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Fable 5.1.</b> The app's chat can now run Claude's newest model. Picking Fable used to fail with a version error, and the model list showed it twice.</span></li>
+      <li><b class="tag new">new</b><span><b>Geometry unchanged.</b> When your AI edits a part and the rebuilt shape is identical, the viewer says so instead of looking like it stopped updating. A cut that misses the part entirely is the usual cause.</span></li>
+      <li><b class="tag">improved</b><span>Your AI now checks that a cut actually removed material, because a subtraction that misses the part builds fine and changes nothing.</span></li>
+      <li><b class="tag">fixed</b><span>If the engine behind a project dies, the app restarts it on its own instead of needing a relaunch.</span></li>
+    </ul>
+  </article>
   <article class="release" id="v0.24.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.24.0">v0.24.0</a></span><time datetime="2026-08-29">August 29, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.24.0"
+  version: "0.25.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.24.0"
+  version: "0.25.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.24.0"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Bumps nurb, the skill files, and the desktop app to 0.25.0 and writes the changelog entry.

What ships:

- **Fable 5.1 in the app.** The Claude adapter moves to 0.74.0, so picking Fable in the chat works instead of failing with a version error, and the model list shows Fable once (#253).
- **Geometry unchanged.** When a rebuild produces the identical shape, the viewer HUD says so and `nurb build` reports it, instead of looking like the viewer stopped updating (#244).
- **Missed-cut doctrine.** Your AI now verifies that a subtraction actually removed material (#244).
- **Engine respawn.** The app restarts a dead engine on its own after three failed part polls, no relaunch needed (#244).

Merging this PR is the release: publish.yml uploads to PyPI, tags v0.25.0, and creates the GitHub release. The desktop build and update feed follow from this Mac.