### PR TITLE
Add the Creality K2 Plus printer profile

### DIFF
--- a/src/nurb/printers.toml
+++ b/src/nurb/printers.toml
@@ -73,6 +73,10 @@ slicer = "Prusa XL"
 bed = [220.0, 220.0, 250.0]
 slicer = "Creality Ender-3 V3"
 
+[creality_k2_plus]
+bed = [350.0, 350.0, 350.0]
+slicer = "Creality K2 Plus"
+
 [anycubic_kobra_2]
 bed = [220.0, 220.0, 250.0]
 slicer = "Anycubic Kobra 2"

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -213,6 +213,19 @@ def test_the_p2s_profile_matches_the_vendor_and_slicer():
     }
 
 
+def test_the_k2_plus_profile_matches_the_vendor_and_slicer():
+    """The only Creality on the list was the Ender-3 V3, so a K2 Plus owner had no
+    profile to name and no way to add one: profiles ship inside the package, and
+    printer.toml can name a machine but not define one, because a `slicer` key there
+    is refused as an unknown check setting. Hand-adding the entry worked until the
+    next `nurb update` rewrote the file and took it out again."""
+    have = profiles()
+    assert have["creality_k2_plus"] == {
+        "bed": [350.0, 350.0, 350.0],
+        "slicer": "Creality K2 Plus",
+    }
+
+
 def test_anycubic_kobra_2_profile_matches_the_vendor_and_slicer():
     have = profiles()
     assert have["anycubic_kobra_2"] == {


### PR DESCRIPTION
The only Creality on the list is the Ender-3 V3, so a K2 Plus owner has no profile to name.

There is also no way to add one. Profiles are read only from the packaged `printers.toml`, and `printer.toml` can *name* a machine but not *define* one: a `slicer` key there is refused as an unknown check setting, since `_apply` only accepts fields of `checks.Context`. So the workaround is to hand-add the entry to the installed package, and the next `nurb update` rewrites that file and removes it again.

That failure mode is at least loud rather than silent — every command in a project naming the machine stops with `no printer profile called 'creality_k2_plus'` — but it recurs on every upgrade until the entry is re-added by hand. Hit it twice on 0.24 and 0.25.

### The numbers

Taken from a Creality Print project file the machine's own bundle produced, rather than off a spec page:

```
printable_area:   ['0x0', '350x0', '350x350', '0x350']
printable_height: 350
printer_model:    Creality K2 Plus
printer_settings_id: Creality K2 Plus 0.4 nozzle
```

`slicer = "Creality K2 Plus"` resolves against the installed bundle, so `nurb slice` picks up `0.20mm Standard @Creality K2 Plus 0.4 nozzle` and `Creality Generic PETG @K2-all` without further mapping.

Shaped after #238. Test added alongside the P2S and Kobra 2 ones.