### PR TITLE
Turn a CAD kernel crash into a build error and keep the dev server alive

### DIFF
--- a/src/nurb/builder.py
+++ b/src/nurb/builder.py
@@ -8,6 +8,7 @@ import time
 import numpy as np
 import trimesh
 
+from . import crash
 from .registry import Rejected
 
 
@@ -108,6 +109,22 @@ def _safe(value):
     return repr(value)
 
 
+def describe(defn, values):
+    """One row per parameter: what the file declares, what a build uses, what control it
+    can carry. The keyword defaults are the parameters, so this is derived, never
+    declared, and it needs no build: a part the kernel crashed on still gets its sliders."""
+    return [
+        {
+            "name": name,
+            "default": _safe(default),
+            "value": _safe(values[name]),
+            "kind": _kind(default),
+            "doc": defn.docs.get(name),
+        }
+        for name, default in defn.params.items()
+    ]
+
+
 def build(path, overrides=None, draft=False):
     """Build a part. Returns (shape, params, milliseconds).
 
@@ -127,18 +144,13 @@ def build(path, overrides=None, draft=False):
     if defn.accepts_draft:
         call["draft"] = draft
 
-    params = [
-        {
-            "name": name,
-            "default": _safe(default),
-            "value": _safe(kwargs[name]),
-            "kind": _kind(default),
-            "doc": defn.docs.get(name),
-        }
-        for name, default in defn.params.items()
-    ]
+    params = describe(defn, kwargs)
 
     started = time.perf_counter()
+    # Named for the crash handler: a kernel fault inside fn() has no Python traceback,
+    # and this is how the message still says which part and which line. Restored, not
+    # cleared, because an assembly builds the parts it places from inside its own build.
+    outer, crash.part = crash.part, str(path)
     try:
         shape = fn(**call)
     except Rejected as exc:
@@ -146,6 +158,8 @@ def build(path, overrides=None, draft=False):
         # controls the viewer offers to get back into the part's valid range.
         exc.params = params
         raise
+    finally:
+        crash.part = outer
     elapsed = (time.perf_counter() - started) * 1000
     if shape is None:
         raise BuildError(f"{defn.name}() returned None")

--- a/src/nurb/cli.py
+++ b/src/nurb/cli.py
@@ -1252,8 +1252,8 @@ def cmd_dev(args):
     root = project_root()
     # Before the build, not after. Discovering the port is taken used to cost a full
     # rebuild of every part in the project first.
-    port = _pick_port(args.port, root)
-    server = Server(root, port=port, draft=args.draft, open_browser=args.open)
+    server = Server(root, port=args.port, draft=args.draft, open_browser=args.open)
+    port = server.port = _pick_port(server.port, root)
     print(f"  building {root.name}/parts")
     try:
         asyncio.run(server.run())
@@ -1288,6 +1288,11 @@ def cmd_launcher(args):
 
 
 def main(argv=None):
+    from . import crash
+
+    # Before anything touches the kernel: a fault in OCCT must end as a message and an
+    # exit code, never as a signal death with a crash dialog behind it.
+    crash.install()
     p = argparse.ArgumentParser(
         prog="nurb",
         description="agentic CAD for 3D printing",

--- a/src/nurb/crash.py
+++ b/src/nurb/crash.py
@@ -1,0 +1,111 @@
+"""What happens when the CAD kernel itself dies.
+
+OCCT can segfault on a legal-looking chamfer (issue #247: `Geom2dAdaptor_Curve::D0` on
+a polished union). A signal is not a Python exception, so nothing in a part file or in
+the server can catch it, and the default outcome is the interpreter dying with a signal:
+exit 139 from `nurb build`, and under `nurb dev` a dead server plus a macOS "Python quit
+unexpectedly" dialog for every restart that walks into the same build.
+
+OCCT's own converter (`OSD::SetSignal`) does not help here: OCP builds it in longjmp
+mode, so it only catches inside algorithms that opted in with OCC_CATCH_SIGNALS and
+exits the process from everywhere else. So the handler is ours, installed through
+ctypes because Python-level signal handlers run too late for a fault, and it does the
+two things a fault leaves possible: say what was being built, then leave without dying
+by the signal. A process that exits normally raises no crash dialog.
+
+For a one-shot command that means exit 1 with a message. The dev server instead execs
+itself with the crash described in the environment, so the same process (same pid,
+same port, same pipes for the desktop supervisor) comes back and marks that part as
+crashed until its inputs change, rather than building it again and dying again.
+"""
+
+import ctypes
+import json
+import os
+import pathlib
+import signal
+import sys
+import traceback
+
+# The part being built right now, set by builder.build. None outside a build, which
+# means a crash there is nurb's own bug and gets a plain exit rather than a restart.
+part = None
+
+# (variable, state, marker): the server's runtime settings and the active build. A restart carries both the previous faults and this one, so two broken parts cannot alternate forever.
+restart = None
+
+NAMES = {
+    signal.SIGSEGV: "segmentation fault",
+    signal.SIGBUS: "bus error",
+    signal.SIGILL: "illegal instruction",
+    signal.SIGFPE: "floating point error",
+    signal.SIGABRT: "abort",
+}
+
+HINT = (
+    "This is a fault inside the CAD kernel, not an error a part file can catch. It "
+    "usually means a chamfer or polish on a body assembled from several unions. Polish "
+    "the simple solids before uniting them, or take those edges out of the set."
+)
+
+_HANDLER = ctypes.CFUNCTYPE(None, ctypes.c_int)
+_keep = []  # the callback object must outlive the installation
+
+
+def _frame(path):
+    """`file:line  source` for the innermost frame inside the part's project."""
+    root = str(pathlib.Path(path).resolve().parent.parent)
+    for entry in reversed(traceback.extract_stack()):
+        if not entry.filename.startswith(root) or "site-packages" in entry.filename:
+            continue
+        where = pathlib.Path(entry.filename).relative_to(root).as_posix()
+        if where.startswith("."):
+            continue  # a .venv inside the project is not the user's code
+        return f"{where}:{entry.lineno}  {entry.line or ''}".rstrip()
+    return None
+
+
+def describe(signum):
+    """The message a crash gets, composed while the faulting stack is still there."""
+    what = NAMES.get(signum, f"signal {signum}")
+    if part is None:
+        return f"nurb crashed ({what}) outside a part build; please report this"
+    lines = [f"the CAD kernel crashed ({what}) building {pathlib.Path(part).stem}"]
+    where = _frame(part)
+    if where:
+        lines.append(f"  at {where}")
+    lines.append(HINT)
+    return "\n".join(lines)
+
+
+def _on_signal(signum):
+    message = describe(signum)
+    os.write(2, (message + "\n").encode("utf-8", "replace"))
+    if restart is not None and part is not None:
+        variable, state, marker = restart
+        # The first line is the status the terminal and the rail show; the whole
+        # message is the detail the viewer shows in the error's place.
+        marker = {**marker, "error": message.splitlines()[0], "traceback": message}
+        state = {**state, "crashed": {**state["crashed"], marker["path"]: marker}}
+        env = {**os.environ, variable: json.dumps(state)}
+        os.write(2, b"  restarting the server; the part stays marked until its file changes\n")
+        try:
+            # exec preserves signal masks, including the signal blocked while its handler runs. Leaving it blocked makes the next kernel fault hang.
+            signal.pthread_sigmask(signal.SIG_UNBLOCK, {signum})
+            os.execve(sys.executable, [sys.executable, *sys.orig_argv[1:]], env)
+        except OSError:
+            pass
+    os._exit(1)
+
+
+def install():
+    """Route the fatal signals through _on_signal for the rest of this process."""
+    if _keep:
+        return
+    libc = ctypes.CDLL(None)
+    libc.signal.argtypes = [ctypes.c_int, _HANDLER]
+    libc.signal.restype = ctypes.c_void_p
+    handler = _HANDLER(_on_signal)
+    _keep.append(handler)
+    for signum in NAMES:
+        libc.signal(signum, handler)

--- a/src/nurb/doctrine.md
+++ b/src/nurb/doctrine.md
@@ -278,6 +278,7 @@ Specific to OCCT, and measured on real parts rather than reasoned about.
   passes so that the first one gives those two faces a real edge to meet along, then
   reselect from the result. Found on the parts bin, where the front drop and the side
   taper land at the same height by design.
+- **The third way a chamfer dies is the kernel itself dying.** A polish on a body assembled from several unions can take OCCT down with a segmentation fault instead of an error (issue #247, inside `Geom2dAdaptor_Curve::D0`), and no Python code can catch that. nurb reports it as a build error naming the line and keeps the dev server up, with the part marked until its file changes, but the fix is in the part: polish the simple solids before uniting them, or take those edges out of the set. The tell is a `--draft` build that succeeds while the full build dies.
 - **Prefer `new_edges` over geometric selectors.** Each chamfer changes topology, so a
   selector resolved against pristine geometry drifts once an earlier chamfer runs.
   `new_edges(before, combined=after)` returns exactly the edges an operation created. It

--- a/src/nurb/server.py
+++ b/src/nurb/server.py
@@ -8,6 +8,7 @@ import asyncio
 import collections
 import hashlib
 import json
+import os
 import pathlib
 import secrets
 import threading
@@ -20,9 +21,10 @@ from websockets.asyncio.server import serve
 from websockets.http11 import Response
 from websockets.datastructures import Headers
 
-from . import __version__, builder, extract, registry
+from . import __version__, builder, crash, extract, registry
 
 VIEWER = pathlib.Path(__file__).parent / "viewer.html"
+CRASHED = "NURB_CRASHED"  # the environment variable a crash restart carries its marker in
 VENDOR = (pathlib.Path(__file__).parent / "vendor").resolve()
 
 
@@ -197,6 +199,14 @@ class Server:
         self.clients = set()
         self.loop = None
         self.queue = None
+        # A replacement process restores the whole session, including earlier faults. Opening another tab would strand the user's existing view.
+        resumed = json.loads(os.environ.pop(CRASHED, "null"))
+        self.crashed = resumed["crashed"] if resumed else {}
+        if resumed:
+            self.port = resumed["port"]
+            self.draft = resumed["draft"]
+            self.overrides = resumed["overrides"]
+            self.open_browser = False
         self.observer = None
         self.drain_task = None
         # One build at a time, shared by the rebuild loop and the export route. OCCT
@@ -222,10 +232,44 @@ class Server:
 
     # ---------- building ----------
 
-    def _build(self, path, name):
+    def _crash_key(self, path, overrides, draft, snapshot=None):
+        """What a build is made of, hashed, so a crash marker knows when to let go."""
+        if snapshot is None:
+            snapshot = self._source_snapshot(path)
+        digest = hashlib.blake2b(digest_size=8)
+        for source in sorted(snapshot or {}):
+            digest.update(str(source).encode())
+            digest.update(snapshot[source] or b"")
+        digest.update(json.dumps([overrides, draft], sort_keys=True).encode())
+        return digest.hexdigest()
+
+    def _guarded(self, path, overrides, draft, snapshot=None):
+        """Build, and should the kernel fault instead, come back as a server that knows.
+
+        The crash handler execs this process with the marker in its environment. A
+        one-off build (an export, a slice) can crash too; the marker then names the
+        polished configuration, and the dev build at its own settings goes ahead.
+        """
+        marker = {
+            "path": str(path),
+            "key": self._crash_key(path, overrides, draft, snapshot),
+        }
+        state = {
+            "port": self.port,
+            "draft": self.draft,
+            "overrides": self.overrides,
+            "crashed": self.crashed,
+        }
+        crash.restart = (CRASHED, state, marker)
+        try:
+            return builder.build(path, overrides=overrides, draft=draft)
+        finally:
+            crash.restart = None
+
+    def _build(self, path, name, snapshot=None):
         """Build with whatever the sliders are holding for this part."""
         try:
-            return builder.build(path, overrides=self.overrides.get(name), draft=self.draft)
+            return self._guarded(path, self.overrides.get(name), self.draft, snapshot)
         except builder.UnknownParams as exc:
             # An edit renamed or removed a parameter a slider was still holding. The
             # file is the authority, so those get dropped and the build goes ahead: a
@@ -235,7 +279,33 @@ class Server:
                 self.overrides.get(name, {}).pop(gone, None)
             if not self.overrides.get(name):
                 self.overrides.pop(name, None)
-            return builder.build(path, overrides=self.overrides.get(name), draft=self.draft)
+            return self._guarded(path, self.overrides.get(name), self.draft, snapshot)
+
+    def _crashed_entry(self, path, name, entry, snapshot):
+        """The entry a part gets when the last process died building exactly this.
+
+        Skipping the build is the whole point: building it again is how eight crash
+        dialogs happened (issue #247). The sliders still come from the file, so the user
+        can try another configuration, and any edit to the project clears the marker.
+        """
+        marker = self.crashed.get(str(path))
+        if marker is None:
+            return None
+        key = self._crash_key(path, self.overrides.get(name), self.draft, snapshot)
+        if marker["key"] != key:
+            self.crashed.pop(str(path))
+            return None
+        entry["glb"] = None
+        entry["shape"] = None
+        entry["error"] = marker["error"]
+        entry["traceback"] = marker["traceback"]
+        try:
+            defn = builder.load(path)._nurb
+            values = {**defn.params, **(self.overrides.get(name) or {})}
+            entry["params"] = builder.describe(defn, values)
+        except Exception:
+            entry["params"] = []
+        return entry
 
     def rebuild(self, path):
         name = pathlib.Path(path).stem
@@ -250,7 +320,10 @@ class Server:
             "stress_spots": None,
         }
         try:
-            shape, params, ms = self._build(path, name)
+            if self._crashed_entry(path, name, entry, inputs_before) is not None:
+                self.state[name] = entry
+                return entry
+            shape, params, ms = self._build(path, name, inputs_before)
             entry.update(builder.stats(shape))
             entry["params"] = params
             entry["variant"] = self._active_variant(params, entry["variants"])
@@ -770,7 +843,7 @@ class Server:
 
         def solid(path, stem):
             """(bytes, None, said) for a part, (None, scene, None) for an assembly."""
-            built, _, _ = builder.build(path, overrides=self.overrides.get(stem), draft=False)
+            built, _, _ = self._guarded(path, self.overrides.get(stem), draft=False)
             scene = getattr(built, "_nurb_scene", None)
             if scene is not None:
                 return None, scene, None
@@ -967,12 +1040,11 @@ class Server:
             raise builder.BuildError(f"{name} places no parts; nothing to print")
         return out
 
-    @staticmethod
-    def _solid(path, overrides, target):
+    def _solid(self, path, overrides, target):
         """The polished build at the exact values the estimate names, written as STL."""
         if not path.is_file():
             raise builder.BuildError(f"{path.stem} is no longer on disk")
-        built, _, _ = builder.build(path, overrides=overrides or None, draft=False)
+        built, _, _ = self._guarded(path, overrides or None, draft=False)
         builder.write_stl(built, target)
         return target
 

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -235,9 +235,7 @@ def test_the_viewer_export_route_zips_an_assemblys_placed_parts(project):
 
     write(project, "plate", PLATE)
     write(project, "carrier", USE_ASM)
-    srv = Server.__new__(Server)
-    srv.root = project
-    srv.overrides = {}
+    srv = Server(project)
 
     body, attach, mime, _ = srv._export("carrier", "stl")
     assert (attach, mime) == ("carrier-stl.zip", "application/zip")

--- a/tests/test_crash.py
+++ b/tests/test_crash.py
@@ -1,0 +1,286 @@
+"""A fault inside the CAD kernel ends as a build error, not a dead interpreter.
+
+Issue #247: a polish on a united body took OCCT down with a segfault, `nurb build` died
+with signal 11, and every `nurb dev` restart walked into the same build and raised
+another macOS crash dialog. The fault here is the same kernel call the report named,
+reached directly: an adaptor with no curve dereferences null in `D0`.
+"""
+
+import json
+import os
+import pathlib
+import queue
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.request
+
+import pytest
+from websockets.sync.client import connect
+
+from nurb import cli
+from nurb import server as server_mod
+from nurb.server import Server
+
+NURB = pathlib.Path(sys.executable).with_name("nurb")
+
+CRASHING = '''
+from nurb import *
+from OCP.Geom2dAdaptor import Geom2dAdaptor_Curve
+from OCP.gp import gp_Pnt2d
+
+
+@part
+def bracket(width=40.0, draft=False):
+    body = Box(width, 20, 5)
+    if draft:
+        return body
+    Geom2dAdaptor_Curve().D0(0.0, gp_Pnt2d())
+    return body
+'''
+
+PLATE = '''
+from nurb import *
+
+
+@part
+def plate(width=30.0):
+    return Box(width, 30, 3)
+'''
+
+
+def _project(root):
+    (root / "parts").mkdir()
+    (root / "parts" / "bracket.py").write_text(CRASHING, encoding="utf-8")
+    (root / "parts" / "plate.py").write_text(PLATE, encoding="utf-8")
+    return root
+
+
+def test_build_reports_a_kernel_fault_as_an_error(tmp_path):
+    _project(tmp_path)
+    done = subprocess.run(
+        [NURB, "build", "bracket"], cwd=tmp_path, capture_output=True, text=True, timeout=120
+    )
+    # 1, the way any failed command exits; never a signal death (-11, or 139 in a shell).
+    assert done.returncode == 1
+    assert "the CAD kernel crashed (segmentation fault) building bracket" in done.stderr
+    assert "at parts/bracket.py:12" in done.stderr
+    assert "Polish the simple solids before uniting them" in done.stderr
+
+
+def _free_port():
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+def _lines(proc):
+    out = queue.Queue()
+    threading.Thread(target=lambda: [out.put(l) for l in proc.stdout], daemon=True).start()
+    return out
+
+
+def _until(lines, needle, deadline):
+    seen = []
+    while time.monotonic() < deadline:
+        try:
+            line = lines.get(timeout=1)
+        except queue.Empty:
+            continue
+        seen.append(line)
+        if needle in line:
+            return seen
+    raise AssertionError(f"never saw {needle!r} in:\n{''.join(seen)}")
+
+
+@pytest.mark.parametrize("launcher", [[NURB], [sys.executable, "-m", "nurb.cli"]])
+def test_dev_restarts_itself_and_marks_the_part_instead_of_crashing_again(tmp_path, launcher):
+    _project(tmp_path)
+    port = _free_port()
+    proc = subprocess.Popen(
+        [*launcher, "dev", "--port", str(port)],
+        cwd=tmp_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 180
+        lines = _lines(proc)
+        _until(lines, "restarting the server", deadline)
+        # The same process comes back on the same port, says what happened to the part
+        # in one status line, and builds the rest of the project.
+        seen = _until(lines, "plate:", deadline)
+        text = "".join(seen)
+        assert "bracket: the CAD kernel crashed (segmentation fault) building bracket" in text
+        assert text.count("restarting the server") == 0, "the marked part was built again"
+        assert proc.poll() is None
+        with socket.create_connection(("127.0.0.1", port), timeout=5):
+            pass
+    finally:
+        proc.terminate()
+        proc.wait(timeout=30)
+
+
+def test_rebuild_skips_a_marked_part_until_its_inputs_change(tmp_path, monkeypatch):
+    (tmp_path / "parts").mkdir()
+    part = tmp_path / "parts" / "thing.py"
+    part.write_text(
+        "from nurb import *\nimport pathlib\n\n@part\ndef thing(width=10.0):\n"
+        "    pathlib.Path(__file__).with_name('built').touch()\n    return Box(width, 10, 10)\n",
+        encoding="utf-8",
+    )
+    key = Server(tmp_path)._crash_key(part, None, False)
+    marker = {"path": str(part), "key": key, "error": "the CAD kernel crashed", "traceback": "detail"}
+    resumed = {
+        "port": 7373, "draft": False, "overrides": {}, "crashed": {str(part): marker},
+    }
+    monkeypatch.setenv(server_mod.CRASHED, json.dumps(resumed))
+    server = Server(tmp_path)
+    assert server_mod.CRASHED not in os.environ, "the marker is consumed, not inherited again"
+
+    entry = server.rebuild(part)
+    assert entry["error"] == "the CAD kernel crashed"
+    assert entry["traceback"] == "detail"
+    assert entry["glb"] is None
+    assert not (tmp_path / "parts" / "built").exists(), "the marked part was built"
+    # The sliders still come from the file, so another configuration can be tried.
+    assert [(p["name"], p["value"]) for p in entry["params"]] == [("width", 10.0)]
+
+    server.overrides["thing"] = {"width": 12.0}
+    entry = server.rebuild(part)
+    assert entry["error"] is None
+    assert (tmp_path / "parts" / "built").exists()
+    assert server.crashed == {}
+
+
+def _parts(port):
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/api/parts", timeout=5) as response:
+        return {entry["name"]: entry for entry in json.load(response)}
+
+
+def _params(port, name, values):
+    with connect(f"ws://127.0.0.1:{port}/ws", origin=f"http://127.0.0.1:{port}") as ws:
+        ws.recv(timeout=5)
+        ws.send(json.dumps({"type": "params", "name": name, "values": values}))
+
+
+def test_second_kernel_fault_recovers_with_all_slider_values(tmp_path):
+    _project(tmp_path)
+    port = _free_port()
+    proc = subprocess.Popen(
+        [NURB, "dev", "--port", str(port)], cwd=tmp_path,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+    try:
+        lines = _lines(proc)
+        deadline = time.monotonic() + 120
+        _until(lines, "plate:", deadline)
+        _params(port, "plate", {"width": 35.0})
+        _until(lines, "plate:", deadline)
+        _params(port, "bracket", {"width": 45.0})
+        _until(lines, "restarting the server", deadline)
+        _until(lines, "plate:", deadline)
+        entries = _parts(port)
+        bracket = entries["bracket"]
+        assert "CAD kernel crashed" in bracket["error"]
+        assert bracket["params"][0]["value"] == 45.0
+        assert entries["plate"]["params"][0]["value"] == 35.0
+        assert proc.poll() is None
+    finally:
+        proc.terminate()
+        proc.wait(timeout=30)
+
+
+def test_two_crashing_parts_remain_marked_across_restarts(tmp_path):
+    _project(tmp_path)
+    (tmp_path / "parts" / "clamp.py").write_text(
+        CRASHING.replace("def bracket(", "def clamp("), encoding="utf-8"
+    )
+    port = _free_port()
+    proc = subprocess.Popen(
+        [NURB, "dev", "--port", str(port)], cwd=tmp_path,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+    try:
+        seen = _until(_lines(proc), "plate:", time.monotonic() + 120)
+        assert "".join(seen).count("restarting the server") == 2
+        entries = _parts(port)
+        assert "CAD kernel crashed" in entries["bracket"]["error"]
+        assert "CAD kernel crashed" in entries["clamp"]["error"]
+        assert entries["plate"]["error"] is None
+        assert proc.poll() is None
+    finally:
+        proc.terminate()
+        proc.wait(timeout=30)
+
+
+def test_dev_restores_resolved_port_and_draft_without_opening_another_tab(tmp_path, monkeypatch):
+    _project(tmp_path)
+    port = _free_port()
+    restored = {
+        "port": port, "draft": True, "overrides": {"plate": {"width": 35.0}},
+        "crashed": {},
+    }
+    monkeypatch.setenv(server_mod.CRASHED, json.dumps(restored))
+    monkeypatch.setattr(cli, "project_root", lambda: tmp_path)
+    asked = []
+    actual_pick = cli._pick_port
+
+    def pick(asked_port, root):
+        asked.append(asked_port)
+        return actual_pick(asked_port, root)
+
+    async def run(server):
+        assert server.port == port
+        assert server.draft is True
+        assert server.overrides == restored["overrides"]
+        assert server.open_browser is False
+
+    monkeypatch.setattr(cli, "_pick_port", pick)
+    monkeypatch.setattr(Server, "run", run)
+    cli.main(["dev", "--open"])
+    assert asked == [port]
+
+
+def test_auto_port_restart_keeps_existing_viewer_and_opens_only_once(tmp_path):
+    _project(tmp_path)
+    (tmp_path / "parts" / "bracket.py").write_text(
+        CRASHING.replace("if draft:", "if draft or width != 45:"), encoding="utf-8"
+    )
+    blocker = socket.socket()
+    blocker.bind(("127.0.0.1", 0))
+    blocker.listen()
+    first = blocker.getsockname()[1]
+    # Stub only the external browser opener; exercise real CLI port selection, server startup and crash recovery.
+    script = (
+        "import sys; from nurb import cli, server; "
+        "cli.DEFAULT_PORT = int(sys.argv[1]); "
+        "server._open_viewer = lambda url: print('BROWSER OPEN ' + url, flush=True); "
+        "cli.main(['dev', '--open'])"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script, str(first)], cwd=tmp_path,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+    try:
+        lines = _lines(proc)
+        deadline = time.monotonic() + 120
+        seen = _until(lines, "plate:", deadline)
+        opened = [line for line in seen if line.startswith("BROWSER OPEN ")]
+        assert len(opened) == 1
+        port = int(opened[0].strip().rsplit(":", 1)[1])
+        assert port != first
+        blocker.close()
+        _params(port, "bracket", {"width": 45.0})
+        seen = _until(lines, "restarting the server", deadline)
+        seen += _until(lines, "plate:", deadline)
+        assert not any(line.startswith("BROWSER OPEN ") for line in seen)
+        assert "CAD kernel crashed" in _parts(port)["bracket"]["error"]
+        assert proc.poll() is None
+    finally:
+        blocker.close()
+        proc.terminate()
+        proc.wait(timeout=30)


### PR DESCRIPTION
OCCT can segfault on a polished union (#247). A signal is not something a part file or the server can catch, so the process died by the signal, macOS raised a crash dialog, and every restart of `nurb dev` rebuilt the same part and died again.

`crash.py` installs a native handler through ctypes that names the part and the user's line, prints the polish-before-union hint, and exits normally, so `nurb build` ends with exit 1 and a message instead of 139 and a dialog. Under `nurb dev` the handler re-execs the same process with the session in its environment (port, draft, slider values, and every crash marker so far), and the server comes back on the same pid and port without opening another tab, shows the crash as that part's error with its sliders intact, builds the rest of the project, and skips each marked part until its inputs change. The doctrine gains the matching kernel rule, and tests drive the real segfault through both commands, including two crashing parts, slider values surviving a restart, and the auto-picked port case.

Closes #247