### PR TITLE
Release 0.26.0

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nurb",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "identifier": "dev.nurb.desktop",
   "build": {
     "beforeDevCommand": "npm run stage && npm run dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nurb"
-version = "0.25.0"
+version = "0.26.0"
 description = "Agentic CAD for 3D printing"
 readme = "README.md"
 authors = [

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -117,6 +117,16 @@
   <h1>What's new</h1>
   <p class="lede">Every nurb release, newest first. Install once, then <b>nurb update</b> keeps you current.</p>
 
+  <article class="release" id="v0.26.0">
+    <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.26.0">v0.26.0</a></span><time datetime="2026-09-05">September 5, 2026</time></div>
+    <ul>
+      <li><b class="tag new">new</b><span><b>Your printer, remembered.</b> Pick a printer once and every project on this computer uses its bed. The plate is labelled with the machine, and your AI knows the size before it designs. A new project with no printer shows the picker right on the plate.</span></li>
+      <li><b class="tag new">new</b><span><b>Creality K2 Plus.</b> It is in the printer list, so print time and downloads use its real build volume and settings.</span></li>
+      <li><b class="tag">improved</b><span>The app's Codex chat can now run GPT-6-Astra.</span></li>
+      <li><b class="tag">fixed</b><span>A part that crashed the CAD engine used to take the viewer down with it and crash again on every restart. It now shows as that part's error, with a hint about what to change, while the rest of the project keeps building.</span></li>
+      <li><b class="tag">fixed</b><span>The 3MF download failed on some parts with an invalid parameter error. Those parts download now.</span></li>
+    </ul>
+  </article>
   <article class="release" id="v0.25.0">
     <div class="meta"><span class="ver"><a href="https://github.com/Shpigford/nurb/releases/tag/v0.25.0">v0.25.0</a></span><time datetime="2026-09-04">September 4, 2026</time></div>
     <ul>

--- a/skills/nurb/SKILL.md
+++ b/skills/nurb/SKILL.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.25.0"
+  version: "0.26.0"
 ---
 # nurb
 

--- a/src/nurb/skill.md
+++ b/src/nurb/skill.md
@@ -2,7 +2,7 @@
 name: nurb
 description: Design 3D-printable parts as Python functions with nurb. Use when the user wants a part designed, changed, or checked for 3D printing (a bracket, mount, holder, enclosure, shelf, or any STL/STEP to print), and in any directory with a parts/ folder. The user describes the part and judges it in a browser; you model it.
 metadata:
-  version: "0.25.0"
+  version: "0.26.0"
 ---
 # nurb
 

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "nurb"
-version = "0.25.0"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
Bumps nurb, the skill files, and the desktop app to 0.26.0 and adds the changelog entry. Merging this is the release: publish.yml uploads to PyPI, tags v0.26.0, and creates the GitHub release; the desktop build then attaches the signed DMG and refreshes the update feed.

What ships since 0.25.0:

- Pick a printer once and every project on this computer uses its bed. The plate is labelled with the machine, your AI sees the size before designing, and a project with no printer shows the picker on the plate. (#245)
- Creality K2 Plus printer profile. (#255)
- The app's Codex chat can run GPT-6-Astra. (#256)
- A part that crashes the CAD kernel now shows as that part's error and the dev server stays up, instead of dying on every restart. (#257)
- 3MF export no longer fails on parts where tessellation emits a zero-area needle. (#251)